### PR TITLE
feat(db): schema MySQL complet — modèles SQLAlchemy + migrations Alembic

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -3,14 +3,13 @@
 import asyncio
 from logging.config import fileConfig
 
-from alembic import context
 from sqlalchemy.ext.asyncio import create_async_engine
 
+# Import de tous les modèles pour que leurs tables soient connues de Base.metadata
+import app.models  # noqa: F401 — enregistre toutes les tables via __init__.py
+from alembic import context
 from app.core.config import settings
 from app.core.database import Base
-
-# Import de tous les modèles pour que leurs tables soient connues de Base.metadata
-import app.core.audit  # noqa: F401
 
 config = context.config
 if config.config_file_name:

--- a/alembic/versions/20260310_0001_create_audit_logs.py
+++ b/alembic/versions/20260310_0001_create_audit_logs.py
@@ -5,8 +5,9 @@ Revises:
 Create Date: 2026-03-10
 """
 
-from alembic import op
 import sqlalchemy as sa
+
+from alembic import op
 
 # revision identifiers
 revision: str = "0001"

--- a/alembic/versions/20260317_0002_initial_schema.py
+++ b/alembic/versions/20260317_0002_initial_schema.py
@@ -1,0 +1,936 @@
+"""Initial schema — all domain tables.
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-03-17
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0002"
+down_revision: str | None = "0001"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    # -----------------------------------------------------------------------
+    # Référentiels (pas de FK entre eux)
+    # -----------------------------------------------------------------------
+    op.create_table(
+        "academic_years",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(20), nullable=False),
+        sa.Column("start_date", sa.Date(), nullable=False),
+        sa.Column("end_date", sa.Date(), nullable=False),
+        sa.Column("is_current", sa.Boolean(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+
+    op.create_table(
+        "levels",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(50), nullable=False),
+        sa.Column("order", sa.Integer(), nullable=False, server_default="0"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+
+    op.create_table(
+        "series",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("level_id", sa.BigInteger(), nullable=False),
+        sa.Column("name", sa.String(20), nullable=False),
+        sa.ForeignKeyConstraint(["level_id"], ["levels.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("level_id", "name"),
+    )
+    op.create_index("idx_series_level_id", "series", ["level_id"])
+
+    op.create_table(
+        "rooms",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(50), nullable=False),
+        sa.Column("capacity", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+
+    op.create_table(
+        "school_settings",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("school_name", sa.String(200), nullable=False),
+        sa.Column("address", sa.Text(), nullable=True),
+        sa.Column("phone", sa.String(20), nullable=True),
+        sa.Column("email", sa.String(255), nullable=True),
+        sa.Column("logo_url", sa.String(500), nullable=True),
+        sa.Column("ministry_code", sa.String(50), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "roles",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+
+    op.create_table(
+        "permissions",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("slug", sa.String(150), nullable=False),
+        sa.Column("name", sa.String(150), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("slug"),
+    )
+    op.create_index("idx_permissions_slug", "permissions", ["slug"])
+
+    op.create_table(
+        "role_permissions",
+        sa.Column("role_id", sa.BigInteger(), nullable=False),
+        sa.Column("permission_id", sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(["role_id"], ["roles.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["permission_id"], ["permissions.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("role_id", "permission_id"),
+    )
+
+    op.create_table(
+        "fee_categories",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(150), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+
+    # -----------------------------------------------------------------------
+    # users + profils
+    # -----------------------------------------------------------------------
+    op.create_table(
+        "users",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("email", sa.String(255), nullable=False),
+        sa.Column("hashed_password", sa.String(255), nullable=False),
+        sa.Column(
+            "role",
+            sa.Enum("admin", "teacher", "staff", "student", "parent", name="user_role"),
+            nullable=False,
+        ),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="1"),
+        sa.Column("last_login", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email"),
+    )
+    op.create_index("idx_users_email", "users", ["email"])
+
+    op.create_table(
+        "staff_profiles",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("first_name", sa.String(100), nullable=False),
+        sa.Column("last_name", sa.String(100), nullable=False),
+        sa.Column("position", sa.String(100), nullable=True),
+        sa.Column("phone", sa.String(20), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id"),
+    )
+    op.create_index("idx_staff_profiles_user_id", "staff_profiles", ["user_id"])
+
+    op.create_table(
+        "teacher_profiles",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("first_name", sa.String(100), nullable=False),
+        sa.Column("last_name", sa.String(100), nullable=False),
+        sa.Column("speciality", sa.String(150), nullable=True),
+        sa.Column("phone", sa.String(20), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id"),
+    )
+    op.create_index("idx_teacher_profiles_user_id", "teacher_profiles", ["user_id"])
+
+    op.create_table(
+        "parents",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=True),
+        sa.Column("first_name", sa.String(100), nullable=False),
+        sa.Column("last_name", sa.String(100), nullable=False),
+        sa.Column("phone", sa.String(20), nullable=True),
+        sa.Column("email", sa.String(255), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_parents_user_id", "parents", ["user_id"])
+
+    op.create_table(
+        "students",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=True),
+        sa.Column("first_name", sa.String(100), nullable=False),
+        sa.Column("last_name", sa.String(100), nullable=False),
+        sa.Column("birth_date", sa.Date(), nullable=True),
+        sa.Column("genre", sa.Enum("M", "F", name="genre"), nullable=True),
+        sa.Column("enrollment_number", sa.String(50), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("enrollment_number"),
+    )
+    op.create_index("idx_students_user_id", "students", ["user_id"])
+    op.create_index("idx_students_enrollment_number", "students", ["enrollment_number"])
+
+    op.create_table(
+        "parent_students",
+        sa.Column("parent_id", sa.BigInteger(), nullable=False),
+        sa.Column("student_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "relationship_type",
+            sa.Enum("father", "mother", "guardian", "other", name="parent_relationship"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["parent_id"], ["parents.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["student_id"], ["students.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("parent_id", "student_id"),
+        sa.UniqueConstraint("parent_id", "student_id"),
+    )
+
+    op.create_table(
+        "user_roles",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("role_id", sa.BigInteger(), nullable=False),
+        sa.Column("academic_year_id", sa.BigInteger(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["role_id"], ["roles.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["academic_year_id"], ["academic_years.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "role_id", "academic_year_id"),
+    )
+    op.create_index("idx_user_roles_user_id", "user_roles", ["user_id"])
+    op.create_index("idx_user_roles_role_id", "user_roles", ["role_id"])
+
+    # -----------------------------------------------------------------------
+    # Classes et matières
+    # -----------------------------------------------------------------------
+    op.create_table(
+        "classes",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("level_id", sa.BigInteger(), nullable=False),
+        sa.Column("series_id", sa.BigInteger(), nullable=True),
+        sa.Column("academic_year_id", sa.BigInteger(), nullable=False),
+        sa.Column("room_id", sa.BigInteger(), nullable=True),
+        sa.Column("max_students", sa.Integer(), nullable=False, server_default="40"),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["level_id"], ["levels.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["series_id"], ["series.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["academic_year_id"], ["academic_years.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["room_id"], ["rooms.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name", "academic_year_id"),
+    )
+    op.create_index("idx_classes_name", "classes", ["name"])
+    op.create_index("idx_classes_level_id", "classes", ["level_id"])
+    op.create_index("idx_classes_academic_year_id", "classes", ["academic_year_id"])
+
+    op.create_table(
+        "subjects",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(150), nullable=False),
+        sa.Column("level_id", sa.BigInteger(), nullable=True),
+        sa.Column("series_id", sa.BigInteger(), nullable=True),
+        sa.Column("coefficient", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("hours_per_week", sa.Integer(), nullable=False, server_default="2"),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["level_id"], ["levels.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["series_id"], ["series.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_subjects_level_id", "subjects", ["level_id"])
+
+    # -----------------------------------------------------------------------
+    # Inscriptions et frais
+    # -----------------------------------------------------------------------
+    op.create_table(
+        "enrollments",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("student_id", sa.BigInteger(), nullable=False),
+        sa.Column("class_id", sa.BigInteger(), nullable=False),
+        sa.Column("academic_year_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "prospect", "en_validation", "valide", "rejete", "annule", name="enrollment_status"
+            ),
+            nullable=False,
+            server_default="prospect",
+        ),
+        sa.Column("created_by", sa.BigInteger(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["student_id"], ["students.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["class_id"], ["classes.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["academic_year_id"], ["academic_years.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_enrollments_student_id", "enrollments", ["student_id"])
+    op.create_index("idx_enrollments_class_id", "enrollments", ["class_id"])
+    op.create_index("idx_enrollments_academic_year_id", "enrollments", ["academic_year_id"])
+    op.create_index("idx_enrollments_status", "enrollments", ["status"])
+
+    op.create_table(
+        "documents",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("enrollment_id", sa.BigInteger(), nullable=False),
+        sa.Column("type", sa.String(100), nullable=False),
+        sa.Column("file_url", sa.String(500), nullable=False),
+        sa.Column("original_name", sa.String(255), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["enrollment_id"], ["enrollments.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_documents_enrollment_id", "documents", ["enrollment_id"])
+
+    op.create_table(
+        "fee_variants",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("fee_category_id", sa.BigInteger(), nullable=False),
+        sa.Column("class_id", sa.BigInteger(), nullable=True),
+        sa.Column("academic_year_id", sa.BigInteger(), nullable=False),
+        sa.Column("amount", sa.Numeric(15, 2), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["fee_category_id"], ["fee_categories.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["class_id"], ["classes.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["academic_year_id"], ["academic_years.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_fee_variants_fee_category_id", "fee_variants", ["fee_category_id"])
+    op.create_index("idx_fee_variants_academic_year_id", "fee_variants", ["academic_year_id"])
+
+    op.create_table(
+        "optional_fee_options",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(150), nullable=False),
+        sa.Column("amount", sa.Numeric(15, 2), nullable=False),
+        sa.Column("academic_year_id", sa.BigInteger(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["academic_year_id"], ["academic_years.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "idx_optional_fee_options_academic_year_id", "optional_fee_options", ["academic_year_id"]
+    )
+
+    op.create_table(
+        "student_options",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("enrollment_id", sa.BigInteger(), nullable=False),
+        sa.Column("optional_fee_option_id", sa.BigInteger(), nullable=False),
+        sa.Column("quantity", sa.Integer(), nullable=False, server_default="1"),
+        sa.ForeignKeyConstraint(["enrollment_id"], ["enrollments.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["optional_fee_option_id"], ["optional_fee_options.id"], ondelete="RESTRICT"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_student_options_enrollment_id", "student_options", ["enrollment_id"])
+
+    op.create_table(
+        "enrollment_fees",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("enrollment_id", sa.BigInteger(), nullable=False),
+        sa.Column("fee_variant_id", sa.BigInteger(), nullable=False),
+        sa.Column("amount", sa.Numeric(15, 2), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum("pending", "partial", "paid", "waived", name="enrollment_fee_status"),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["enrollment_id"], ["enrollments.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["fee_variant_id"], ["fee_variants.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_enrollment_fees_enrollment_id", "enrollment_fees", ["enrollment_id"])
+    op.create_index("idx_enrollment_fees_status", "enrollment_fees", ["status"])
+
+    op.create_table(
+        "payments",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("enrollment_fee_id", sa.BigInteger(), nullable=False),
+        sa.Column("amount", sa.Numeric(15, 2), nullable=False),
+        sa.Column(
+            "method",
+            sa.Enum("cash", "mobile_money", "bank_transfer", "cheque", name="payment_method"),
+            nullable=False,
+        ),
+        sa.Column(
+            "status",
+            sa.Enum("pending", "completed", "failed", "refunded", name="payment_status"),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("reference", sa.String(100), nullable=True),
+        sa.Column("received_by", sa.BigInteger(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["enrollment_fee_id"], ["enrollment_fees.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_payments_enrollment_fee_id", "payments", ["enrollment_fee_id"])
+    op.create_index("idx_payments_status", "payments", ["status"])
+    op.create_index("idx_payments_reference", "payments", ["reference"])
+
+    # -----------------------------------------------------------------------
+    # Emploi du temps
+    # -----------------------------------------------------------------------
+    op.create_table(
+        "timetables",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("class_id", sa.BigInteger(), nullable=False),
+        sa.Column("academic_year_id", sa.BigInteger(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="1"),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["class_id"], ["classes.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["academic_year_id"], ["academic_years.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_timetables_class_id", "timetables", ["class_id"])
+
+    op.create_table(
+        "timetable_slots",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("timetable_id", sa.BigInteger(), nullable=True),
+        sa.Column("class_id", sa.BigInteger(), nullable=False),
+        sa.Column("teacher_id", sa.BigInteger(), nullable=False),
+        sa.Column("subject_id", sa.BigInteger(), nullable=False),
+        sa.Column("room_id", sa.BigInteger(), nullable=True),
+        sa.Column("academic_year_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "day",
+            sa.Enum(
+                "monday",
+                "tuesday",
+                "wednesday",
+                "thursday",
+                "friday",
+                "saturday",
+                name="day_of_week",
+            ),
+            nullable=False,
+        ),
+        sa.Column("start_time", sa.Time(), nullable=False),
+        sa.Column("end_time", sa.Time(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["timetable_id"], ["timetables.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["class_id"], ["classes.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["teacher_id"], ["teacher_profiles.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["subject_id"], ["subjects.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["room_id"], ["rooms.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["academic_year_id"], ["academic_years.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_timetable_slots_class_id", "timetable_slots", ["class_id"])
+    op.create_index("idx_timetable_slots_teacher_id", "timetable_slots", ["teacher_id"])
+    op.create_index("idx_timetable_slots_day", "timetable_slots", ["day"])
+
+    op.create_table(
+        "teacher_availabilities",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("teacher_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "day",
+            sa.Enum(
+                "monday",
+                "tuesday",
+                "wednesday",
+                "thursday",
+                "friday",
+                "saturday",
+                name="day_of_week",
+            ),
+            nullable=False,
+        ),
+        sa.Column("start_time", sa.Time(), nullable=False),
+        sa.Column("end_time", sa.Time(), nullable=False),
+        sa.Column("available", sa.Boolean(), nullable=False, server_default="1"),
+        sa.ForeignKeyConstraint(["teacher_id"], ["teacher_profiles.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "idx_teacher_availabilities_teacher_id", "teacher_availabilities", ["teacher_id"]
+    )
+
+    # -----------------------------------------------------------------------
+    # Notes
+    # -----------------------------------------------------------------------
+    op.create_table(
+        "evaluations",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("title", sa.String(200), nullable=False),
+        sa.Column(
+            "type",
+            sa.Enum("controle", "devoir", "examen", "oral", name="evaluation_type"),
+            nullable=False,
+        ),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("coefficient", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("subject_id", sa.BigInteger(), nullable=False),
+        sa.Column("class_id", sa.BigInteger(), nullable=False),
+        sa.Column("teacher_id", sa.BigInteger(), nullable=False),
+        sa.Column("academic_year_id", sa.BigInteger(), nullable=False),
+        sa.Column("trimester", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["subject_id"], ["subjects.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["class_id"], ["classes.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["teacher_id"], ["teacher_profiles.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["academic_year_id"], ["academic_years.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_evaluations_class_id", "evaluations", ["class_id"])
+    op.create_index("idx_evaluations_teacher_id", "evaluations", ["teacher_id"])
+    op.create_index("idx_evaluations_date", "evaluations", ["date"])
+
+    op.create_table(
+        "grades",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("evaluation_id", sa.BigInteger(), nullable=False),
+        sa.Column("student_id", sa.BigInteger(), nullable=False),
+        sa.Column("value", sa.Numeric(4, 2), nullable=True),
+        sa.Column(
+            "status",
+            sa.Enum("pending", "entered", name="grade_status"),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["evaluation_id"], ["evaluations.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["student_id"], ["students.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_grades_evaluation_id", "grades", ["evaluation_id"])
+    op.create_index("idx_grades_student_id", "grades", ["student_id"])
+    op.create_index("idx_grades_status", "grades", ["status"])
+
+    op.create_table(
+        "bulletins",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("student_id", sa.BigInteger(), nullable=False),
+        sa.Column("class_id", sa.BigInteger(), nullable=False),
+        sa.Column("academic_year_id", sa.BigInteger(), nullable=False),
+        sa.Column("trimester", sa.Integer(), nullable=False),
+        sa.Column("average", sa.Numeric(4, 2), nullable=True),
+        sa.Column("rank", sa.Integer(), nullable=True),
+        sa.Column(
+            "mention",
+            sa.Enum("TB", "B", "AB", "P", "M", name="mention"),
+            nullable=True,
+        ),
+        sa.Column("file_url", sa.String(500), nullable=True),
+        sa.Column("generated_at", sa.DateTime(), nullable=True),
+        sa.Column("is_published", sa.Boolean(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["student_id"], ["students.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["class_id"], ["classes.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["academic_year_id"], ["academic_years.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_bulletins_student_id", "bulletins", ["student_id"])
+    op.create_index("idx_bulletins_class_id", "bulletins", ["class_id"])
+
+    # -----------------------------------------------------------------------
+    # Présences
+    # -----------------------------------------------------------------------
+    op.create_table(
+        "attendance_contexts",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column(
+            "entity_type",
+            sa.Enum("class", "exam", name="attendance_entity_type"),
+            nullable=False,
+        ),
+        sa.Column("context_id", sa.BigInteger(), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("academic_year_id", sa.BigInteger(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["academic_year_id"], ["academic_years.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_attendance_contexts_date", "attendance_contexts", ["date"])
+    op.create_index(
+        "idx_attendance_contexts_context", "attendance_contexts", ["entity_type", "context_id"]
+    )
+
+    op.create_table(
+        "attendance_records",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("context_id", sa.BigInteger(), nullable=False),
+        sa.Column("student_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum("present", "absent", "late", "excused", name="attendance_status"),
+            nullable=False,
+            server_default="absent",
+        ),
+        sa.Column("time_in", sa.Time(), nullable=True),
+        sa.Column("time_out", sa.Time(), nullable=True),
+        sa.Column(
+            "source",
+            sa.Enum("manual", "qr_code", "biometric", name="attendance_source"),
+            nullable=False,
+            server_default="manual",
+        ),
+        sa.Column("notes", sa.String(255), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["context_id"], ["attendance_contexts.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["student_id"], ["students.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_attendance_records_context_id", "attendance_records", ["context_id"])
+    op.create_index("idx_attendance_records_student_id", "attendance_records", ["student_id"])
+    op.create_index("idx_attendance_records_status", "attendance_records", ["status"])
+
+    # -----------------------------------------------------------------------
+    # Notifications et messages
+    # -----------------------------------------------------------------------
+    op.create_table(
+        "notifications",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "type",
+            sa.Enum(
+                "payment_due",
+                "payment_received",
+                "grade_available",
+                "bulletin_published",
+                "absence_recorded",
+                "enrollment_status",
+                "system",
+                name="notification_type",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "channel",
+            sa.Enum("in_app", "sms", "whatsapp", "email", name="notification_channel"),
+            nullable=False,
+        ),
+        sa.Column("title", sa.String(255), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("read", sa.Boolean(), nullable=False, server_default="0"),
+        sa.Column("sent_at", sa.DateTime(), nullable=True),
+        sa.Column("read_at", sa.DateTime(), nullable=True),
+        sa.Column("entity_type", sa.String(100), nullable=True),
+        sa.Column("entity_id", sa.BigInteger(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_notifications_user_id", "notifications", ["user_id"])
+    op.create_index("idx_notifications_read", "notifications", ["read"])
+    op.create_index("idx_notifications_type", "notifications", ["type"])
+
+    op.create_table(
+        "notification_templates",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column(
+            "type",
+            sa.Enum(
+                "payment_due",
+                "payment_received",
+                "grade_available",
+                "bulletin_published",
+                "absence_recorded",
+                "enrollment_status",
+                "system",
+                name="notification_type",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "channel",
+            sa.Enum("in_app", "sms", "whatsapp", "email", name="notification_channel"),
+            nullable=False,
+        ),
+        sa.Column("subject", sa.String(255), nullable=True),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("language", sa.String(5), nullable=False, server_default="fr"),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "messages",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("sender_id", sa.BigInteger(), nullable=False),
+        sa.Column("recipient_id", sa.BigInteger(), nullable=False),
+        sa.Column("subject", sa.String(255), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("sent_at", sa.DateTime(), nullable=True),
+        sa.Column("read_at", sa.DateTime(), nullable=True),
+        sa.Column("parent_id", sa.BigInteger(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["sender_id"], ["users.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["recipient_id"], ["users.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["parent_id"], ["messages.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_messages_sender_id", "messages", ["sender_id"])
+    op.create_index("idx_messages_recipient_id", "messages", ["recipient_id"])
+
+
+def downgrade() -> None:
+    # Ordre inverse des créations (FK d'abord)
+    op.drop_table("messages")
+    op.drop_table("notification_templates")
+    op.drop_table("notifications")
+    op.drop_table("attendance_records")
+    op.drop_table("attendance_contexts")
+    op.drop_table("bulletins")
+    op.drop_table("grades")
+    op.drop_table("evaluations")
+    op.drop_table("teacher_availabilities")
+    op.drop_table("timetable_slots")
+    op.drop_table("timetables")
+    op.drop_table("payments")
+    op.drop_table("enrollment_fees")
+    op.drop_table("student_options")
+    op.drop_table("optional_fee_options")
+    op.drop_table("fee_variants")
+    op.drop_table("documents")
+    op.drop_table("enrollments")
+    op.drop_table("subjects")
+    op.drop_table("classes")
+    op.drop_table("user_roles")
+    op.drop_table("parent_students")
+    op.drop_table("students")
+    op.drop_table("parents")
+    op.drop_table("teacher_profiles")
+    op.drop_table("staff_profiles")
+    op.drop_table("users")
+    op.drop_table("fee_categories")
+    op.drop_table("role_permissions")
+    op.drop_table("permissions")
+    op.drop_table("roles")
+    op.drop_table("school_settings")
+    op.drop_table("rooms")
+    op.drop_table("series")
+    op.drop_table("levels")
+    op.drop_table("academic_years")

--- a/alembic/versions/20260317_0002_initial_schema.py
+++ b/alembic/versions/20260317_0002_initial_schema.py
@@ -379,6 +379,7 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["student_id"], ["students.id"], ondelete="RESTRICT"),
         sa.ForeignKeyConstraint(["class_id"], ["classes.id"], ondelete="RESTRICT"),
         sa.ForeignKeyConstraint(["academic_year_id"], ["academic_years.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["created_by"], ["users.id"], ondelete="SET NULL"),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index("idx_enrollments_student_id", "enrollments", ["student_id"])
@@ -521,6 +522,7 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.ForeignKeyConstraint(["enrollment_fee_id"], ["enrollment_fees.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["received_by"], ["users.id"], ondelete="SET NULL"),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index("idx_payments_enrollment_fee_id", "payments", ["enrollment_fee_id"])

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,98 @@
+"""app/models — importe tous les modèles pour enregistrer leurs tables dans Base.metadata.
+
+L'ordre d'import respecte les dépendances FK :
+  base → academic → user → enrollment → fee → timetable → grade → attendance → permission → notification → message → audit
+"""
+
+# Dépendances de base (pas de FK vers d'autres modèles de ce package)
+from app.models.academic import (  # noqa: F401
+    AcademicYear,
+    Class,
+    Level,
+    Room,
+    SchoolSettings,
+    Series,
+    Subject,
+)
+
+# Présences
+from app.models.attendance import (  # noqa: F401
+    AttendanceContext,
+    AttendanceEntityType,
+    AttendanceRecord,
+    AttendanceSource,
+    AttendanceStatus,
+)
+
+# Audit log (défini dans app.core.audit, re-exporté ici)
+from app.models.audit import AuditAction, AuditLog  # noqa: F401
+
+# Inscriptions
+from app.models.enrollment import (  # noqa: F401
+    Document,
+    Enrollment,
+    EnrollmentStatus,
+    StudentOption,
+)
+
+# Frais et paiements
+from app.models.fee import (  # noqa: F401
+    EnrollmentFee,
+    EnrollmentFeeStatus,
+    FeeCategory,
+    FeeVariant,
+    OptionalFeeOption,
+    Payment,
+    PaymentMethod,
+    PaymentStatus,
+)
+
+# Notes et bulletins
+from app.models.grade import (  # noqa: F401
+    Bulletin,
+    Evaluation,
+    EvaluationType,
+    Grade,
+    GradeStatus,
+    Mention,
+)
+
+# Messagerie interne
+from app.models.message import Message  # noqa: F401
+
+# Notifications
+from app.models.notification import (  # noqa: F401
+    Notification,
+    NotificationChannel,
+    NotificationTemplate,
+    NotificationType,
+)
+
+# Rôles et permissions
+from app.models.permission import (  # noqa: F401
+    Permission,
+    Role,
+    RolePermission,
+    UserRole,
+)
+
+# Emploi du temps
+from app.models.timetable import (  # noqa: F401
+    DayOfWeek,
+    TeacherAvailability,
+    Timetable,
+    TimetableSlot,
+)
+
+# Utilisateurs et profils
+from app.models.user import (  # noqa: F401
+    Genre,
+    Parent,
+    ParentRelationship,
+    ParentStudent,
+    StaffProfile,
+    Student,
+    TeacherProfile,
+    User,
+    UserRole_,
+)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -94,5 +94,5 @@ from app.models.user import (  # noqa: F401
     Student,
     TeacherProfile,
     User,
-    UserRole_,
+    UserRoleEnum,
 )

--- a/app/models/academic.py
+++ b/app/models/academic.py
@@ -1,0 +1,174 @@
+"""Modèles académiques : AcademicYear, Level, Series, Class, Subject, Room, SchoolSettings."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Date,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+from app.models.base import TimestampMixin
+
+if TYPE_CHECKING:
+    from app.models.enrollment import Enrollment
+    from app.models.timetable import TimetableSlot
+
+
+# ---------------------------------------------------------------------------
+# AcademicYear
+# ---------------------------------------------------------------------------
+
+
+class AcademicYear(Base, TimestampMixin):
+    """Année scolaire (ex : 2024-2025)."""
+
+    __tablename__ = "academic_years"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(20), nullable=False, unique=True)  # "2024-2025"
+    start_date: Mapped[date] = mapped_column(Date, nullable=False)
+    end_date: Mapped[date] = mapped_column(Date, nullable=False)
+    is_current: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    classes: Mapped[list[Class]] = relationship(back_populates="academic_year")
+
+
+# ---------------------------------------------------------------------------
+# Level & Series
+# ---------------------------------------------------------------------------
+
+
+class Level(Base):
+    """Niveau scolaire (ex : 6ème, 5ème, Terminale)."""
+
+    __tablename__ = "levels"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(50), nullable=False, unique=True)
+    order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    series: Mapped[list[Series]] = relationship(back_populates="level")
+    classes: Mapped[list[Class]] = relationship(back_populates="level")
+
+
+class Series(Base):
+    """Série de lycée (ex : A1, C, D). Applicable uniquement au lycée."""
+
+    __tablename__ = "series"
+    __table_args__ = (UniqueConstraint("level_id", "name"),)
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    level_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("levels.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(20), nullable=False)  # "A1", "C", "D"
+
+    level: Mapped[Level] = relationship(back_populates="series")
+    classes: Mapped[list[Class]] = relationship(back_populates="series")
+
+
+# ---------------------------------------------------------------------------
+# Room
+# ---------------------------------------------------------------------------
+
+
+class Room(Base):
+    """Salle de classe ou laboratoire."""
+
+    __tablename__ = "rooms"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(50), nullable=False, unique=True)
+    capacity: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    classes: Mapped[list[Class]] = relationship(back_populates="room")
+    timetable_slots: Mapped[list[TimetableSlot]] = relationship(back_populates="room")
+
+
+# ---------------------------------------------------------------------------
+# Class
+# ---------------------------------------------------------------------------
+
+
+class Class(Base, TimestampMixin):
+    """Classe scolaire (ex : Terminale C, 6ème A)."""
+
+    __tablename__ = "classes"
+    __table_args__ = (UniqueConstraint("name", "academic_year_id"),)
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    level_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("levels.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    series_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("series.id", ondelete="RESTRICT"), nullable=True, index=True
+    )
+    academic_year_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("academic_years.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    room_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("rooms.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    max_students: Mapped[int] = mapped_column(Integer, nullable=False, default=40)
+
+    level: Mapped[Level] = relationship(back_populates="classes")
+    series: Mapped[Series | None] = relationship(back_populates="classes")
+    academic_year: Mapped[AcademicYear] = relationship(back_populates="classes")
+    room: Mapped[Room | None] = relationship(back_populates="classes")
+    enrollments: Mapped[list[Enrollment]] = relationship(back_populates="class_")
+    timetable_slots: Mapped[list[TimetableSlot]] = relationship(back_populates="class_")
+
+
+# ---------------------------------------------------------------------------
+# Subject
+# ---------------------------------------------------------------------------
+
+
+class Subject(Base, TimestampMixin):
+    """Matière enseignée."""
+
+    __tablename__ = "subjects"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(150), nullable=False)
+    level_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("levels.id", ondelete="RESTRICT"), nullable=True, index=True
+    )
+    series_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("series.id", ondelete="RESTRICT"), nullable=True, index=True
+    )
+    coefficient: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    hours_per_week: Mapped[int] = mapped_column(Integer, nullable=False, default=2)
+
+    timetable_slots: Mapped[list[TimetableSlot]] = relationship(back_populates="subject")
+
+
+# ---------------------------------------------------------------------------
+# SchoolSettings (singleton par tenant)
+# ---------------------------------------------------------------------------
+
+
+class SchoolSettings(Base, TimestampMixin):
+    """Paramètres de l'établissement (singleton par tenant)."""
+
+    __tablename__ = "school_settings"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    school_name: Mapped[str] = mapped_column(String(200), nullable=False)
+    address: Mapped[str | None] = mapped_column(Text, nullable=True)
+    phone: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    logo_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    ministry_code: Mapped[str | None] = mapped_column(String(50), nullable=True)

--- a/app/models/attendance.py
+++ b/app/models/attendance.py
@@ -1,0 +1,90 @@
+"""Modèles de présence : AttendanceContext, AttendanceRecord."""
+
+from __future__ import annotations
+
+import enum
+from datetime import date, time
+from typing import TYPE_CHECKING
+
+from sqlalchemy import BigInteger, Date, Enum, ForeignKey, String, Time
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+from app.models.base import TimestampMixin
+
+if TYPE_CHECKING:
+    from app.models.academic import AcademicYear
+    from app.models.user import Student
+
+
+class AttendanceEntityType(str, enum.Enum):
+    CLASS = "class"
+    EXAM = "exam"
+
+
+class AttendanceStatus(str, enum.Enum):
+    PRESENT = "present"
+    ABSENT = "absent"
+    LATE = "late"
+    EXCUSED = "excused"
+
+
+class AttendanceSource(str, enum.Enum):
+    MANUAL = "manual"
+    QR_CODE = "qr_code"
+    BIOMETRIC = "biometric"
+
+
+class AttendanceContext(Base, TimestampMixin):
+    """Contexte de présence : séance de cours ou examen."""
+
+    __tablename__ = "attendance_contexts"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    entity_type: Mapped[str] = mapped_column(
+        Enum(AttendanceEntityType, name="attendance_entity_type"), nullable=False, index=True
+    )
+    context_id: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, index=True
+    )  # class_id or exam_id
+    date: Mapped[date] = mapped_column(Date, nullable=False, index=True)
+    academic_year_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("academic_years.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+
+    academic_year: Mapped[AcademicYear] = relationship()
+    records: Mapped[list[AttendanceRecord]] = relationship(back_populates="context")
+
+
+class AttendanceRecord(Base, TimestampMixin):
+    """Enregistrement de présence d'un élève."""
+
+    __tablename__ = "attendance_records"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    context_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("attendance_contexts.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+    student_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("students.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    status: Mapped[str] = mapped_column(
+        Enum(AttendanceStatus, name="attendance_status"),
+        nullable=False,
+        default=AttendanceStatus.ABSENT,
+        index=True,
+    )
+    time_in: Mapped[time | None] = mapped_column(Time, nullable=True)
+    time_out: Mapped[time | None] = mapped_column(Time, nullable=True)
+    source: Mapped[str] = mapped_column(
+        Enum(AttendanceSource, name="attendance_source"),
+        nullable=False,
+        default=AttendanceSource.MANUAL,
+    )
+    notes: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    context: Mapped[AttendanceContext] = relationship(back_populates="records")
+    student: Mapped[Student] = relationship()

--- a/app/models/audit.py
+++ b/app/models/audit.py
@@ -1,0 +1,5 @@
+"""Re-export de AuditLog depuis app.core.audit pour Alembic autogenerate."""
+
+from app.core.audit import AuditAction, AuditLog
+
+__all__ = ["AuditAction", "AuditLog"]

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -1,0 +1,17 @@
+"""Mixin de base partagé par tous les modèles SQLAlchemy."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+
+class TimestampMixin:
+    """Ajoute created_at et updated_at sur le serveur DB."""
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/app/models/enrollment.py
+++ b/app/models/enrollment.py
@@ -1,0 +1,96 @@
+"""Modèles d'inscription : Enrollment, Document, StudentOption."""
+
+from __future__ import annotations
+
+import enum
+from typing import TYPE_CHECKING
+
+from sqlalchemy import BigInteger, Enum, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+from app.models.base import TimestampMixin
+
+if TYPE_CHECKING:
+    from app.models.academic import AcademicYear, Class
+    from app.models.fee import EnrollmentFee, OptionalFeeOption
+    from app.models.user import Student
+
+
+class EnrollmentStatus(str, enum.Enum):
+    PROSPECT = "prospect"
+    EN_VALIDATION = "en_validation"
+    VALIDE = "valide"
+    REJETE = "rejete"
+    ANNULE = "annule"
+
+
+class Enrollment(Base, TimestampMixin):
+    """Inscription d'un élève dans une classe pour une année scolaire."""
+
+    __tablename__ = "enrollments"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    student_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("students.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    class_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("classes.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    academic_year_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("academic_years.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    status: Mapped[str] = mapped_column(
+        Enum(EnrollmentStatus, name="enrollment_status"),
+        nullable=False,
+        default=EnrollmentStatus.PROSPECT,
+        index=True,
+    )
+    created_by: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    student: Mapped[Student] = relationship(back_populates="enrollments")
+    class_: Mapped[Class] = relationship(back_populates="enrollments")
+    academic_year: Mapped[AcademicYear] = relationship()
+    documents: Mapped[list[Document]] = relationship(back_populates="enrollment")
+    student_options: Mapped[list[StudentOption]] = relationship(back_populates="enrollment")
+    enrollment_fees: Mapped[list[EnrollmentFee]] = relationship(back_populates="enrollment")
+
+
+class Document(Base, TimestampMixin):
+    """Document justificatif lié à une inscription."""
+
+    __tablename__ = "documents"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    enrollment_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("enrollments.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    type: Mapped[str] = mapped_column(
+        String(100), nullable=False
+    )  # "bulletin", "acte_naissance", etc.
+    file_url: Mapped[str] = mapped_column(String(500), nullable=False)
+    original_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    enrollment: Mapped[Enrollment] = relationship(back_populates="documents")
+
+
+class StudentOption(Base):
+    """Option facultative choisie par un élève (ex : EPS, 2ème langue)."""
+
+    __tablename__ = "student_options"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    enrollment_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("enrollments.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    optional_fee_option_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("optional_fee_options.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+    quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+
+    enrollment: Mapped[Enrollment] = relationship(back_populates="student_options")
+    optional_fee_option: Mapped[OptionalFeeOption] = relationship(back_populates="student_options")

--- a/app/models/enrollment.py
+++ b/app/models/enrollment.py
@@ -46,7 +46,9 @@ class Enrollment(Base, TimestampMixin):
         default=EnrollmentStatus.PROSPECT,
         index=True,
     )
-    created_by: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    created_by: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     student: Mapped[Student] = relationship(back_populates="enrollments")

--- a/app/models/fee.py
+++ b/app/models/fee.py
@@ -1,0 +1,170 @@
+"""Modèles de frais scolaires : FeeCategory, FeeVariant, OptionalFeeOption, EnrollmentFee, Payment."""
+
+from __future__ import annotations
+
+import enum
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from sqlalchemy import BigInteger, Enum, ForeignKey, Numeric, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+from app.models.base import TimestampMixin
+
+if TYPE_CHECKING:
+    from app.models.academic import AcademicYear, Class
+    from app.models.enrollment import Enrollment, StudentOption
+
+
+class PaymentMethod(str, enum.Enum):
+    CASH = "cash"
+    MOBILE_MONEY = "mobile_money"
+    BANK_TRANSFER = "bank_transfer"
+    CHEQUE = "cheque"
+
+
+class PaymentStatus(str, enum.Enum):
+    PENDING = "pending"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    REFUNDED = "refunded"
+
+
+class EnrollmentFeeStatus(str, enum.Enum):
+    PENDING = "pending"
+    PARTIAL = "partial"
+    PAID = "paid"
+    WAIVED = "waived"
+
+
+# ---------------------------------------------------------------------------
+# FeeCategory
+# ---------------------------------------------------------------------------
+
+
+class FeeCategory(Base, TimestampMixin):
+    """Catégorie de frais (ex : Inscription, Scolarité T1, Tenue scolaire)."""
+
+    __tablename__ = "fee_categories"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(150), nullable=False, unique=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    variants: Mapped[list[FeeVariant]] = relationship(back_populates="category")
+
+
+# ---------------------------------------------------------------------------
+# FeeVariant — montant applicable à une classe / année
+# ---------------------------------------------------------------------------
+
+
+class FeeVariant(Base, TimestampMixin):
+    """Montant d'une catégorie de frais pour une classe et une année scolaire."""
+
+    __tablename__ = "fee_variants"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    fee_category_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("fee_categories.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    class_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("classes.id", ondelete="RESTRICT"), nullable=True, index=True
+    )
+    academic_year_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("academic_years.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    amount: Mapped[Decimal] = mapped_column(Numeric(15, 2), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    category: Mapped[FeeCategory] = relationship(back_populates="variants")
+    class_: Mapped[Class | None] = relationship()
+    academic_year: Mapped[AcademicYear] = relationship()
+    enrollment_fees: Mapped[list[EnrollmentFee]] = relationship(back_populates="fee_variant")
+
+
+# ---------------------------------------------------------------------------
+# OptionalFeeOption — frais optionnels (ex : transport, cantine)
+# ---------------------------------------------------------------------------
+
+
+class OptionalFeeOption(Base, TimestampMixin):
+    """Option de frais facultatifs proposée aux élèves."""
+
+    __tablename__ = "optional_fee_options"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(150), nullable=False)
+    amount: Mapped[Decimal] = mapped_column(Numeric(15, 2), nullable=False)
+    academic_year_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("academic_years.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    academic_year: Mapped[AcademicYear] = relationship()
+    student_options: Mapped[list[StudentOption]] = relationship(
+        back_populates="optional_fee_option"
+    )
+
+
+# ---------------------------------------------------------------------------
+# EnrollmentFee — frais dûs par une inscription
+# ---------------------------------------------------------------------------
+
+
+class EnrollmentFee(Base, TimestampMixin):
+    """Frais applicable à une inscription spécifique."""
+
+    __tablename__ = "enrollment_fees"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    enrollment_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("enrollments.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    fee_variant_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("fee_variants.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    amount: Mapped[Decimal] = mapped_column(Numeric(15, 2), nullable=False)
+    status: Mapped[str] = mapped_column(
+        Enum(EnrollmentFeeStatus, name="enrollment_fee_status"),
+        nullable=False,
+        default=EnrollmentFeeStatus.PENDING,
+        index=True,
+    )
+
+    enrollment: Mapped[Enrollment] = relationship(back_populates="enrollment_fees")
+    fee_variant: Mapped[FeeVariant] = relationship(back_populates="enrollment_fees")
+    payments: Mapped[list[Payment]] = relationship(back_populates="enrollment_fee")
+
+
+# ---------------------------------------------------------------------------
+# Payment
+# ---------------------------------------------------------------------------
+
+
+class Payment(Base, TimestampMixin):
+    """Paiement d'un frais d'inscription."""
+
+    __tablename__ = "payments"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    enrollment_fee_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("enrollment_fees.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+    amount: Mapped[Decimal] = mapped_column(Numeric(15, 2), nullable=False)
+    method: Mapped[str] = mapped_column(Enum(PaymentMethod, name="payment_method"), nullable=False)
+    status: Mapped[str] = mapped_column(
+        Enum(PaymentStatus, name="payment_status"),
+        nullable=False,
+        default=PaymentStatus.PENDING,
+        index=True,
+    )
+    reference: Mapped[str | None] = mapped_column(String(100), nullable=True, index=True)
+    received_by: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    enrollment_fee: Mapped[EnrollmentFee] = relationship(back_populates="payments")

--- a/app/models/fee.py
+++ b/app/models/fee.py
@@ -164,7 +164,9 @@ class Payment(Base, TimestampMixin):
         index=True,
     )
     reference: Mapped[str | None] = mapped_column(String(100), nullable=True, index=True)
-    received_by: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    received_by: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     enrollment_fee: Mapped[EnrollmentFee] = relationship(back_populates="payments")

--- a/app/models/grade.py
+++ b/app/models/grade.py
@@ -1,0 +1,137 @@
+"""Modèles de notes : Evaluation, Grade, Bulletin."""
+
+from __future__ import annotations
+
+import enum
+from datetime import date, datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Date,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+from app.models.base import TimestampMixin
+
+if TYPE_CHECKING:
+    from app.models.academic import AcademicYear, Class, Subject
+    from app.models.user import Student, TeacherProfile
+
+
+class EvaluationType(str, enum.Enum):
+    CONTROLE = "controle"
+    DEVOIR = "devoir"
+    EXAMEN = "examen"
+    ORAL = "oral"
+
+
+class GradeStatus(str, enum.Enum):
+    PENDING = "pending"
+    ENTERED = "entered"
+
+
+class Mention(str, enum.Enum):
+    TRES_BIEN = "TB"  # >= 16
+    BIEN = "B"  # >= 14
+    ASSEZ_BIEN = "AB"  # >= 12
+    PASSABLE = "P"  # >= 10
+    MEDIOCRE = "M"  # < 10
+
+
+class Evaluation(Base, TimestampMixin):
+    """Évaluation (contrôle, devoir, examen) pour une classe."""
+
+    __tablename__ = "evaluations"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    type: Mapped[str] = mapped_column(
+        Enum(EvaluationType, name="evaluation_type"), nullable=False, index=True
+    )
+    date: Mapped[date] = mapped_column(Date, nullable=False, index=True)
+    coefficient: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    subject_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("subjects.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    class_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("classes.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    teacher_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("teacher_profiles.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+    academic_year_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("academic_years.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    trimester: Mapped[int] = mapped_column(Integer, nullable=False)  # 1, 2 ou 3
+
+    subject: Mapped[Subject] = relationship()
+    class_: Mapped[Class] = relationship()
+    teacher: Mapped[TeacherProfile] = relationship()
+    academic_year: Mapped[AcademicYear] = relationship()
+    grades: Mapped[list[Grade]] = relationship(back_populates="evaluation")
+
+
+class Grade(Base, TimestampMixin):
+    """Note d'un élève pour une évaluation."""
+
+    __tablename__ = "grades"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    evaluation_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("evaluations.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    student_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("students.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    # NULL tant que non saisie (status=pending)
+    value: Mapped[Decimal | None] = mapped_column(Numeric(4, 2), nullable=True)
+    status: Mapped[str] = mapped_column(
+        Enum(GradeStatus, name="grade_status"),
+        nullable=False,
+        default=GradeStatus.PENDING,
+        index=True,
+    )
+
+    evaluation: Mapped[Evaluation] = relationship(back_populates="grades")
+    student: Mapped[Student] = relationship(back_populates="grades")
+
+
+class Bulletin(Base, TimestampMixin):
+    """Bulletin scolaire trimestriel généré pour un élève."""
+
+    __tablename__ = "bulletins"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    student_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("students.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    class_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("classes.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    academic_year_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("academic_years.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    trimester: Mapped[int] = mapped_column(Integer, nullable=False)  # 1, 2 ou 3
+    average: Mapped[Decimal | None] = mapped_column(Numeric(4, 2), nullable=True)
+    rank: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    mention: Mapped[str | None] = mapped_column(Enum(Mention, name="mention"), nullable=True)
+    file_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    generated_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    is_published: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    student: Mapped[Student] = relationship()
+    class_: Mapped[Class] = relationship()
+    academic_year: Mapped[AcademicYear] = relationship()

--- a/app/models/message.py
+++ b/app/models/message.py
@@ -1,0 +1,40 @@
+"""Modèle de messagerie interne : Message."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import BigInteger, DateTime, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+from app.models.base import TimestampMixin
+
+if TYPE_CHECKING:
+    from app.models.user import User
+
+
+class Message(Base, TimestampMixin):
+    """Message interne entre utilisateurs de la plateforme."""
+
+    __tablename__ = "messages"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    sender_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    recipient_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    subject: Mapped[str] = mapped_column(String(255), nullable=False)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    sent_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    read_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    parent_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("messages.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+
+    sender: Mapped[User] = relationship(foreign_keys=[sender_id])
+    recipient: Mapped[User] = relationship(foreign_keys=[recipient_id])
+    replies: Mapped[list[Message]] = relationship(foreign_keys=[parent_id])

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -1,0 +1,77 @@
+"""Modèles de notifications : Notification, NotificationTemplate."""
+
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import BigInteger, Boolean, DateTime, Enum, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+from app.models.base import TimestampMixin
+
+if TYPE_CHECKING:
+    from app.models.user import User
+
+
+class NotificationType(str, enum.Enum):
+    PAYMENT_DUE = "payment_due"
+    PAYMENT_RECEIVED = "payment_received"
+    GRADE_AVAILABLE = "grade_available"
+    BULLETIN_PUBLISHED = "bulletin_published"
+    ABSENCE_RECORDED = "absence_recorded"
+    ENROLLMENT_STATUS = "enrollment_status"
+    SYSTEM = "system"
+
+
+class NotificationChannel(str, enum.Enum):
+    IN_APP = "in_app"
+    SMS = "sms"
+    WHATSAPP = "whatsapp"
+    EMAIL = "email"
+
+
+class Notification(Base, TimestampMixin):
+    """Notification envoyée à un utilisateur."""
+
+    __tablename__ = "notifications"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    type: Mapped[str] = mapped_column(
+        Enum(NotificationType, name="notification_type"), nullable=False, index=True
+    )
+    channel: Mapped[str] = mapped_column(
+        Enum(NotificationChannel, name="notification_channel"), nullable=False
+    )
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    read: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, index=True)
+    sent_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    read_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    # Lien optionnel vers l'entité concernée
+    entity_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    entity_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+
+    user: Mapped[User] = relationship(back_populates="notifications")
+
+
+class NotificationTemplate(Base, TimestampMixin):
+    """Gabarit de notification (sujet + corps avec variables {{var}})."""
+
+    __tablename__ = "notification_templates"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    type: Mapped[str] = mapped_column(
+        Enum(NotificationType, name="notification_type"), nullable=False, index=True
+    )
+    channel: Mapped[str] = mapped_column(
+        Enum(NotificationChannel, name="notification_channel"), nullable=False
+    )
+    subject: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    language: Mapped[str] = mapped_column(String(5), nullable=False, default="fr")

--- a/app/models/permission.py
+++ b/app/models/permission.py
@@ -1,0 +1,80 @@
+"""Modèles de permissions : Role, Permission, RolePermission, UserRole."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import BigInteger, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+from app.models.base import TimestampMixin
+
+if TYPE_CHECKING:
+    from app.models.academic import AcademicYear
+    from app.models.user import User
+
+
+class Role(Base, TimestampMixin):
+    """Rôle applicatif (ex : directeur, comptable, professeur principal)."""
+
+    __tablename__ = "roles"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False, unique=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    permissions: Mapped[list[RolePermission]] = relationship(back_populates="role")
+    users: Mapped[list[UserRole]] = relationship(back_populates="role")
+
+
+class Permission(Base):
+    """Permission atomique identifiée par un slug (ex : enrollments:create)."""
+
+    __tablename__ = "permissions"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    slug: Mapped[str] = mapped_column(String(150), nullable=False, unique=True, index=True)
+    name: Mapped[str] = mapped_column(String(150), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    roles: Mapped[list[RolePermission]] = relationship(back_populates="permission")
+
+
+class RolePermission(Base):
+    """Table de liaison Role ↔ Permission (many-to-many)."""
+
+    __tablename__ = "role_permissions"
+    __table_args__ = (UniqueConstraint("role_id", "permission_id"),)
+
+    role_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("roles.id", ondelete="CASCADE"), primary_key=True
+    )
+    permission_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("permissions.id", ondelete="CASCADE"), primary_key=True
+    )
+
+    role: Mapped[Role] = relationship(back_populates="permissions")
+    permission: Mapped[Permission] = relationship(back_populates="roles")
+
+
+class UserRole(Base, TimestampMixin):
+    """Attribution d'un rôle à un utilisateur, optionnellement pour une année scolaire."""
+
+    __tablename__ = "user_roles"
+    __table_args__ = (UniqueConstraint("user_id", "role_id", "academic_year_id"),)
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    role_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("roles.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    academic_year_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("academic_years.id", ondelete="RESTRICT"), nullable=True, index=True
+    )
+
+    user: Mapped[User] = relationship(back_populates="roles")
+    role: Mapped[Role] = relationship(back_populates="users")
+    academic_year: Mapped[AcademicYear | None] = relationship()

--- a/app/models/timetable.py
+++ b/app/models/timetable.py
@@ -1,0 +1,106 @@
+"""Modèles emploi du temps : Timetable, TimetableSlot, TeacherAvailability."""
+
+from __future__ import annotations
+
+import enum
+from datetime import time
+from typing import TYPE_CHECKING
+
+from sqlalchemy import BigInteger, Boolean, Enum, ForeignKey, Time
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+from app.models.base import TimestampMixin
+
+if TYPE_CHECKING:
+    from app.models.academic import AcademicYear, Class, Room, Subject
+    from app.models.user import TeacherProfile
+
+
+class DayOfWeek(str, enum.Enum):
+    MONDAY = "monday"
+    TUESDAY = "tuesday"
+    WEDNESDAY = "wednesday"
+    THURSDAY = "thursday"
+    FRIDAY = "friday"
+    SATURDAY = "saturday"
+
+
+class Timetable(Base, TimestampMixin):
+    """En-tête d'un emploi du temps généré pour une classe."""
+
+    __tablename__ = "timetables"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    class_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("classes.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    academic_year_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("academic_years.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    class_: Mapped[Class] = relationship()
+    academic_year: Mapped[AcademicYear] = relationship()
+    slots: Mapped[list[TimetableSlot]] = relationship(back_populates="timetable")
+
+
+class TimetableSlot(Base, TimestampMixin):
+    """Créneau horaire dans l'emploi du temps."""
+
+    __tablename__ = "timetable_slots"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    timetable_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("timetables.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    class_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("classes.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    teacher_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("teacher_profiles.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+    subject_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("subjects.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    room_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("rooms.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    academic_year_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("academic_years.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    day: Mapped[str] = mapped_column(
+        Enum(DayOfWeek, name="day_of_week"), nullable=False, index=True
+    )
+    start_time: Mapped[time] = mapped_column(Time, nullable=False)
+    end_time: Mapped[time] = mapped_column(Time, nullable=False)
+
+    timetable: Mapped[Timetable | None] = relationship(back_populates="slots")
+    class_: Mapped[Class] = relationship(back_populates="timetable_slots")
+    teacher: Mapped[TeacherProfile] = relationship()
+    subject: Mapped[Subject] = relationship(back_populates="timetable_slots")
+    room: Mapped[Room | None] = relationship(back_populates="timetable_slots")
+    academic_year: Mapped[AcademicYear] = relationship()
+
+
+class TeacherAvailability(Base):
+    """Disponibilités déclarées d'un enseignant."""
+
+    __tablename__ = "teacher_availabilities"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    teacher_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("teacher_profiles.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    day: Mapped[str] = mapped_column(Enum(DayOfWeek, name="day_of_week"), nullable=False)
+    start_time: Mapped[time] = mapped_column(Time, nullable=False)
+    end_time: Mapped[time] = mapped_column(Time, nullable=False)
+    available: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    teacher: Mapped[TeacherProfile] = relationship()

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from app.models.permission import UserRole
 
 
-class UserRole_(str, enum.Enum):
+class UserRoleEnum(str, enum.Enum):
     """Rôle fonctionnel de l'utilisateur dans la plateforme."""
 
     ADMIN = "admin"
@@ -56,7 +56,7 @@ class User(Base, TimestampMixin):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     email: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
     hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
-    role: Mapped[str] = mapped_column(Enum(UserRole_, name="user_role"), nullable=False)
+    role: Mapped[str] = mapped_column(Enum(UserRoleEnum, name="user_role"), nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     last_login: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,198 @@
+"""Modèles utilisateurs : User, profils (Staff, Teacher), Student, Parent."""
+
+from __future__ import annotations
+
+import enum
+from datetime import date, datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Date,
+    DateTime,
+    Enum,
+    ForeignKey,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+from app.models.base import TimestampMixin
+
+if TYPE_CHECKING:
+    from app.models.enrollment import Enrollment
+    from app.models.grade import Grade
+    from app.models.notification import Notification
+    from app.models.permission import UserRole
+
+
+class UserRole_(str, enum.Enum):
+    """Rôle fonctionnel de l'utilisateur dans la plateforme."""
+
+    ADMIN = "admin"
+    TEACHER = "teacher"
+    STAFF = "staff"
+    STUDENT = "student"
+    PARENT = "parent"
+
+
+class Genre(str, enum.Enum):
+    M = "M"
+    F = "F"
+
+
+# ---------------------------------------------------------------------------
+# User (compte de connexion)
+# ---------------------------------------------------------------------------
+
+
+class User(Base, TimestampMixin):
+    """Compte de connexion — toute personne pouvant se connecter à la plateforme."""
+
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    email: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
+    hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
+    role: Mapped[str] = mapped_column(Enum(UserRole_, name="user_role"), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    last_login: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+    # Relations
+    staff_profile: Mapped[StaffProfile | None] = relationship(back_populates="user", uselist=False)
+    teacher_profile: Mapped[TeacherProfile | None] = relationship(
+        back_populates="user", uselist=False
+    )
+    student_profile: Mapped[Student | None] = relationship(back_populates="user", uselist=False)
+    parent_profile: Mapped[Parent | None] = relationship(back_populates="user", uselist=False)
+    roles: Mapped[list[UserRole]] = relationship(back_populates="user")
+    notifications: Mapped[list[Notification]] = relationship(back_populates="user")
+
+
+# ---------------------------------------------------------------------------
+# Profils métier
+# ---------------------------------------------------------------------------
+
+
+class StaffProfile(Base, TimestampMixin):
+    """Profil personnel administratif."""
+
+    __tablename__ = "staff_profiles"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    first_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    last_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    position: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    phone: Mapped[str | None] = mapped_column(String(20), nullable=True)
+
+    user: Mapped[User] = relationship(back_populates="staff_profile")
+
+
+class TeacherProfile(Base, TimestampMixin):
+    """Profil enseignant."""
+
+    __tablename__ = "teacher_profiles"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    first_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    last_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    speciality: Mapped[str | None] = mapped_column(String(150), nullable=True)
+    phone: Mapped[str | None] = mapped_column(String(20), nullable=True)
+
+    user: Mapped[User] = relationship(back_populates="teacher_profile")
+
+
+# ---------------------------------------------------------------------------
+# Student
+# ---------------------------------------------------------------------------
+
+
+class Student(Base, TimestampMixin):
+    """Profil élève — peut ou non avoir un compte User."""
+
+    __tablename__ = "students"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    user_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    first_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    last_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    birth_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    genre: Mapped[str | None] = mapped_column(Enum(Genre, name="genre"), nullable=True)
+    enrollment_number: Mapped[str | None] = mapped_column(
+        String(50), nullable=True, unique=True, index=True
+    )
+
+    user: Mapped[User | None] = relationship(back_populates="student_profile")
+    parents: Mapped[list[ParentStudent]] = relationship(back_populates="student")
+    enrollments: Mapped[list[Enrollment]] = relationship(back_populates="student")
+    grades: Mapped[list[Grade]] = relationship(back_populates="student")
+
+
+# ---------------------------------------------------------------------------
+# Parent
+# ---------------------------------------------------------------------------
+
+
+class ParentRelationship(str, enum.Enum):
+    FATHER = "father"
+    MOTHER = "mother"
+    GUARDIAN = "guardian"
+    OTHER = "other"
+
+
+class Parent(Base, TimestampMixin):
+    """Profil parent / tuteur légal."""
+
+    __tablename__ = "parents"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    user_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    first_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    last_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    phone: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    user: Mapped[User | None] = relationship(back_populates="parent_profile")
+    children: Mapped[list[ParentStudent]] = relationship(back_populates="parent")
+
+
+class ParentStudent(Base):
+    """Table de liaison Parent ↔ Student (many-to-many)."""
+
+    __tablename__ = "parent_students"
+    __table_args__ = (UniqueConstraint("parent_id", "student_id"),)
+
+    parent_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("parents.id", ondelete="CASCADE"), primary_key=True
+    )
+    student_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("students.id", ondelete="CASCADE"), primary_key=True
+    )
+    relationship_type: Mapped[str] = mapped_column(
+        Enum(ParentRelationship, name="parent_relationship"),
+        nullable=False,
+        default=ParentRelationship.GUARDIAN,
+    )
+
+    parent: Mapped[Parent] = relationship(back_populates="children")
+    student: Mapped[Student] = relationship(back_populates="parents")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,9 @@ select = [
     "UP",  # pyupgrade
 ]
 ignore = [
-    "B008",  # do not perform function calls in default arguments (FastAPI Depends)
-    "E501",  # line too long — ruff format handles this
+    "B008",   # do not perform function calls in default arguments (FastAPI Depends)
+    "E501",   # line too long — ruff format handles this
+    "UP042",  # StrEnum migration — SQLAlchemy Enum type requires str+Enum pattern
 ]
 
 [tool.ruff.lint.isort]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,136 @@
+"""Smoke tests — import et structure de tous les modèles SQLAlchemy."""
+
+import pytest
+from sqlalchemy import inspect
+
+from app.core.database import Base
+
+
+def test_all_models_importable() -> None:
+    """Tous les modèles doivent pouvoir être importés sans erreur."""
+    import app.models  # noqa: F401 — déclenche l'enregistrement dans Base.metadata
+
+
+def test_base_metadata_contains_expected_tables() -> None:
+    """Base.metadata doit contenir toutes les tables du schéma après import."""
+    import app.models  # noqa: F401
+
+    expected = {
+        # Référentiels
+        "academic_years",
+        "levels",
+        "series",
+        "rooms",
+        "school_settings",
+        # Users
+        "users",
+        "staff_profiles",
+        "teacher_profiles",
+        "students",
+        "parents",
+        "parent_students",
+        # Auth
+        "roles",
+        "permissions",
+        "role_permissions",
+        "user_roles",
+        # Inscriptions et frais
+        "enrollments",
+        "documents",
+        "student_options",
+        "fee_categories",
+        "fee_variants",
+        "optional_fee_options",
+        "enrollment_fees",
+        "payments",
+        # Classes / matières
+        "classes",
+        "subjects",
+        # Emploi du temps
+        "timetables",
+        "timetable_slots",
+        "teacher_availabilities",
+        # Notes
+        "evaluations",
+        "grades",
+        "bulletins",
+        # Présences
+        "attendance_contexts",
+        "attendance_records",
+        # Notifications
+        "notifications",
+        "notification_templates",
+        # Messagerie
+        "messages",
+        # Audit
+        "audit_logs",
+    }
+
+    registered = set(Base.metadata.tables.keys())
+    missing = expected - registered
+    assert not missing, f"Tables manquantes dans Base.metadata : {missing}"
+
+
+@pytest.mark.parametrize(
+    "model_path,table_name",
+    [
+        ("app.models.academic.AcademicYear", "academic_years"),
+        ("app.models.academic.Class", "classes"),
+        ("app.models.academic.Subject", "subjects"),
+        ("app.models.user.User", "users"),
+        ("app.models.user.Student", "students"),
+        ("app.models.user.TeacherProfile", "teacher_profiles"),
+        ("app.models.enrollment.Enrollment", "enrollments"),
+        ("app.models.fee.Payment", "payments"),
+        ("app.models.timetable.TimetableSlot", "timetable_slots"),
+        ("app.models.grade.Grade", "grades"),
+        ("app.models.attendance.AttendanceRecord", "attendance_records"),
+        ("app.models.permission.Permission", "permissions"),
+        ("app.models.notification.Notification", "notifications"),
+        ("app.models.message.Message", "messages"),
+    ],
+)
+def test_model_tablename(model_path: str, table_name: str) -> None:
+    """Chaque modèle doit déclarer le bon __tablename__."""
+    module_path, class_name = model_path.rsplit(".", 1)
+    import importlib
+
+    module = importlib.import_module(module_path)
+    model_cls = getattr(module, class_name)
+    assert model_cls.__tablename__ == table_name
+
+
+def test_timestamp_mixin_on_key_models() -> None:
+    """Les modèles sensibles doivent avoir created_at et updated_at."""
+    from app.models.enrollment import Enrollment
+    from app.models.fee import Payment
+    from app.models.grade import Grade
+    from app.models.user import User
+
+    for model_cls in (User, Enrollment, Payment, Grade):
+        cols = {c.key for c in inspect(model_cls).mapper.column_attrs}
+        assert "created_at" in cols, f"{model_cls.__name__} manque created_at"
+        assert "updated_at" in cols, f"{model_cls.__name__} manque updated_at"
+
+
+def test_decimal_columns_on_financial_models() -> None:
+    """Les montants doivent être Numeric(15,2) — jamais Float."""
+    from sqlalchemy import Numeric
+
+    from app.models.fee import EnrollmentFee, FeeVariant, OptionalFeeOption, Payment
+
+    for model_cls in (Payment, FeeVariant, OptionalFeeOption, EnrollmentFee):
+        table = Base.metadata.tables[model_cls.__tablename__]
+        amount_col = table.c["amount"]
+        assert isinstance(
+            amount_col.type, Numeric
+        ), f"{model_cls.__name__}.amount doit être Numeric, pas {type(amount_col.type)}"
+        assert amount_col.type.precision == 15
+        assert amount_col.type.scale == 2
+
+
+def test_audit_log_registered() -> None:
+    """AuditLog doit être enregistré dans Base.metadata."""
+    import app.models  # noqa: F401
+
+    assert "audit_logs" in Base.metadata.tables


### PR DESCRIPTION
## Description

Implémente le schéma de base de données complet pour KLASSCI Collège :

- **10 fichiers de modèles SQLAlchemy 2.0 async** couvrant 37 tables au total
- **Migration Alembic explicite** (`0002_initial_schema`) créant toutes les tables dans l'ordre des dépendances FK
- **19 tests smoke** validant l'import, les noms de tables, les types Numeric et les timestamps

### Modèles créés

| Module | Tables |
|--------|--------|
| `user.py` | `users`, `staff_profiles`, `teacher_profiles`, `students`, `parents`, `parent_student` |
| `academic.py` | `academic_years`, `levels`, `series`, `rooms`, `classes`, `subjects`, `school_settings` |
| `enrollment.py` | `enrollments`, `documents`, `student_options` |
| `fee.py` | `fee_categories`, `fee_variants`, `optional_fee_options`, `enrollment_fees`, `payments` |
| `timetable.py` | `timetables`, `timetable_slots`, `teacher_availabilities` |
| `grade.py` | `evaluations`, `grades`, `bulletins` |
| `attendance.py` | `attendance_contexts`, `attendance_records` |
| `permission.py` | `roles`, `permissions`, `role_permissions`, `user_roles` |
| `notification.py` | `notifications`, `notification_templates` |
| `message.py` | `messages` |
| `audit.py` | re-export depuis `app.core.audit` |

### Conventions respectées

- Tous les montants en `Numeric(15, 2)` (jamais `Float`)
- FK avec `ondelete` explicite (`RESTRICT`, `CASCADE`, `SET NULL`)
- Index sur toutes les FK et colonnes de filtre fréquent
- `TimestampMixin` avec `server_default=func.now()` côté DB
- `from __future__ import annotations` + imports directs pour types SQLAlchemy

## Closes

Closes #2

## Checklist

- [x] Tests passent (`pytest tests/ -v`) — 19/19
- [x] Linting passe (`ruff check app/ tests/`)
- [x] Format correct (`ruff format --check app/ tests/`)
- [x] Branche à jour avec feature/1-core-bootstrap (base de cette branche)