### PR TITLE
feat(notifications): add notification router endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from app.routers.auth import router as auth_router
 from app.routers.dashboard import router as dashboard_router
 from app.routers.enrollments import router as enrollments_router
 from app.routers.grades import router as grades_router
+from app.routers.notifications import router as notifications_router
 from app.routers.timetable import availability_router, teachers_router
 from app.routers.timetable import router as timetable_router
 
@@ -45,6 +46,7 @@ app.include_router(auth_router)
 app.include_router(dashboard_router)
 app.include_router(enrollments_router)
 app.include_router(grades_router)
+app.include_router(notifications_router)
 app.include_router(timetable_router)
 app.include_router(teachers_router)
 app.include_router(availability_router)

--- a/app/repositories/notification_repository.py
+++ b/app/repositories/notification_repository.py
@@ -1,0 +1,70 @@
+"""Repository notifications — accès DB pour Notification."""
+
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.notification import Notification
+
+
+async def get_notification_by_id(db: AsyncSession, notification_id: int) -> Notification | None:
+    """Retourne une notification par ID."""
+    stmt = select(Notification).where(Notification.id == notification_id)
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_notifications(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    type: str | None = None,
+    read: bool | None = None,
+    page: int = 1,
+    size: int = 20,
+) -> tuple[list[Notification], int]:
+    """Retourne une page de notifications pour un utilisateur avec le total."""
+    base = select(Notification).where(Notification.user_id == user_id)
+    if type is not None:
+        base = base.where(Notification.type == type)
+    if read is not None:
+        base = base.where(Notification.read == read)
+
+    count_stmt = select(func.count()).select_from(base.subquery())
+    total: int = (await db.execute(count_stmt)).scalar() or 0
+
+    stmt = base.offset((page - 1) * size).limit(size).order_by(Notification.created_at.desc())
+    rows = (await db.execute(stmt)).scalars().all()
+    return list(rows), total
+
+
+async def count_unread(db: AsyncSession, user_id: int) -> int:
+    """Compte les notifications non-lues pour un utilisateur."""
+    stmt = (
+        select(func.count())
+        .select_from(Notification)
+        .where(Notification.user_id == user_id, Notification.read == False)  # noqa: E712
+    )
+    return (await db.execute(stmt)).scalar() or 0
+
+
+async def mark_as_read(db: AsyncSession, notification: Notification) -> Notification:
+    """Marque une notification comme lue."""
+    notification.read = True
+    notification.read_at = func.now()
+    await db.flush()
+    return notification
+
+
+async def mark_all_read(db: AsyncSession, user_id: int) -> int:
+    """Marque toutes les notifications non-lues d'un utilisateur comme lues.
+
+    Retourne le nombre de lignes mises à jour.
+    """
+    stmt = (
+        update(Notification)
+        .where(Notification.user_id == user_id, Notification.read == False)  # noqa: E712
+        .values(read=True, read_at=func.now())
+    )
+    result = await db.execute(stmt)
+    await db.flush()
+    return result.rowcount

--- a/app/routers/notifications.py
+++ b/app/routers/notifications.py
@@ -1,0 +1,60 @@
+"""Router notifications — endpoints utilisateur pour les notifications in-app."""
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db
+from app.schemas.notification import (
+    MarkAllReadResponse,
+    NotificationListResponse,
+    NotificationResponse,
+    UnreadCountResponse,
+)
+from app.services import notification_service
+
+router = APIRouter(prefix="/notifications", tags=["notifications"])
+
+
+@router.get("", response_model=NotificationListResponse)
+async def list_notifications(
+    type: str | None = Query(None),
+    read: bool | None = Query(None),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> NotificationListResponse:
+    """Liste paginée des notifications de l'utilisateur courant."""
+    return await notification_service.list_notifications(
+        db, user_id=current_user.user_id, type=type, read=read, page=page, size=size
+    )
+
+
+@router.get("/count", response_model=UnreadCountResponse)
+async def get_unread_count(
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> UnreadCountResponse:
+    """Nombre de notifications non-lues (pour le badge navbar)."""
+    return await notification_service.get_unread_count(db, user_id=current_user.user_id)
+
+
+@router.patch("/{notification_id}/read", response_model=NotificationResponse)
+async def mark_as_read(
+    notification_id: int,
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> NotificationResponse:
+    """Marque une notification comme lue."""
+    return await notification_service.mark_as_read(
+        db, notification_id=notification_id, user_id=current_user.user_id
+    )
+
+
+@router.post("/read-all", response_model=MarkAllReadResponse)
+async def mark_all_read(
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> MarkAllReadResponse:
+    """Marque toutes les notifications non-lues comme lues."""
+    return await notification_service.mark_all_read(db, user_id=current_user.user_id)

--- a/app/schemas/notification.py
+++ b/app/schemas/notification.py
@@ -1,0 +1,37 @@
+"""Schémas Pydantic pour les notifications."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class NotificationResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    user_id: int
+    type: str
+    channel: str
+    title: str
+    body: str
+    read: bool
+    sent_at: datetime | None
+    read_at: datetime | None
+    entity_type: str | None
+    entity_id: int | None
+    created_at: datetime
+
+
+class NotificationListResponse(BaseModel):
+    items: list[NotificationResponse]
+    total: int
+    page: int
+    size: int
+
+
+class UnreadCountResponse(BaseModel):
+    count: int
+
+
+class MarkAllReadResponse(BaseModel):
+    updated: int

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -1,0 +1,70 @@
+"""Service notifications — logique métier lecture/marquage."""
+
+import logging
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import NotFoundError, PermissionDeniedError
+from app.repositories import notification_repository as repo
+from app.schemas.notification import (
+    MarkAllReadResponse,
+    NotificationListResponse,
+    NotificationResponse,
+    UnreadCountResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _to_response(notification: object) -> NotificationResponse:
+    """Convertit un Notification ORM en NotificationResponse."""
+    return NotificationResponse.model_validate(notification)
+
+
+async def list_notifications(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    type: str | None = None,
+    read: bool | None = None,
+    page: int = 1,
+    size: int = 20,
+) -> NotificationListResponse:
+    """Retourne une page de notifications pour l'utilisateur courant."""
+    notifications, total = await repo.list_notifications(
+        db, user_id=user_id, type=type, read=read, page=page, size=size
+    )
+    return NotificationListResponse(
+        items=[_to_response(n) for n in notifications],
+        total=total,
+        page=page,
+        size=size,
+    )
+
+
+async def get_unread_count(db: AsyncSession, *, user_id: int) -> UnreadCountResponse:
+    """Retourne le nombre de notifications non-lues."""
+    count = await repo.count_unread(db, user_id)
+    return UnreadCountResponse(count=count)
+
+
+async def mark_as_read(
+    db: AsyncSession, *, notification_id: int, user_id: int
+) -> NotificationResponse:
+    """Marque une notification comme lue après vérification de propriété."""
+    notification = await repo.get_notification_by_id(db, notification_id)
+    if notification is None:
+        raise NotFoundError("Notification", notification_id)
+    if notification.user_id != user_id:
+        raise PermissionDeniedError("Cannot mark another user's notification as read")
+
+    updated = await repo.mark_as_read(db, notification)
+    await db.commit()
+    return _to_response(updated)
+
+
+async def mark_all_read(db: AsyncSession, *, user_id: int) -> MarkAllReadResponse:
+    """Marque toutes les notifications non-lues comme lues."""
+    count = await repo.mark_all_read(db, user_id)
+    await db.commit()
+    return MarkAllReadResponse(updated=count)

--- a/tests/routers/test_notifications.py
+++ b/tests/routers/test_notifications.py
@@ -1,0 +1,245 @@
+"""Tests des endpoints /notifications."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db
+from app.core.redis import get_redis
+from app.main import app
+from app.schemas.notification import (
+    MarkAllReadResponse,
+    NotificationListResponse,
+    NotificationResponse,
+    UnreadCountResponse,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NOW = datetime.now(UTC)
+
+SAMPLE_NOTIFICATION = NotificationResponse(
+    id=1,
+    user_id=1,
+    type="system",
+    channel="in_app",
+    title="Bienvenue",
+    body="Bienvenue sur KLASSCI Collège",
+    read=False,
+    sent_at=NOW,
+    read_at=None,
+    entity_type=None,
+    entity_id=None,
+    created_at=NOW,
+)
+
+SAMPLE_READ_NOTIFICATION = SAMPLE_NOTIFICATION.model_copy(
+    update={"read": True, "read_at": NOW}
+)
+
+SAMPLE_LIST = NotificationListResponse(
+    items=[SAMPLE_NOTIFICATION],
+    total=1,
+    page=1,
+    size=20,
+)
+
+MOCK_USER = TokenData(user_id=1, tenant_id="local", email="user@college.ci")
+
+
+def _override_deps() -> None:
+    """Surcharge les dépendances d'auth et DB pour les tests."""
+    app.dependency_overrides[get_current_user] = lambda: MOCK_USER
+    app.dependency_overrides[get_tenant_db] = lambda: AsyncMock()
+    app.dependency_overrides[get_redis] = lambda: AsyncMock()
+
+
+def _clear_deps() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# GET /notifications
+# ---------------------------------------------------------------------------
+
+
+def test_list_notifications_success() -> None:
+    """GET /notifications → 200 + liste paginée."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.notifications.notification_service.list_notifications",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_LIST,
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/notifications")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["page"] == 1
+    assert body["size"] == 20
+    assert len(body["items"]) == 1
+    assert body["items"][0]["id"] == 1
+    assert body["items"][0]["read"] is False
+
+
+def test_list_notifications_with_filters() -> None:
+    """GET /notifications?type=system&read=false → filtres transmis au service."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.notifications.notification_service.list_notifications",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_LIST,
+        ) as mock_list:
+            with TestClient(app) as client:
+                resp = client.get("/notifications?type=system&read=false&page=2&size=10")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    mock_list.assert_called_once()
+    call_kwargs = mock_list.call_args.kwargs
+    assert call_kwargs["user_id"] == 1
+    assert call_kwargs["type"] == "system"
+    assert call_kwargs["read"] is False
+    assert call_kwargs["page"] == 2
+    assert call_kwargs["size"] == 10
+
+
+def test_list_notifications_unauthenticated() -> None:
+    """GET /notifications sans token → 401."""
+    with TestClient(app) as client:
+        resp = client.get("/notifications")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /notifications/count
+# ---------------------------------------------------------------------------
+
+
+def test_get_unread_count_success() -> None:
+    """GET /notifications/count → 200 + count."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.notifications.notification_service.get_unread_count",
+            new_callable=AsyncMock,
+            return_value=UnreadCountResponse(count=5),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/notifications/count")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 5
+
+
+def test_get_unread_count_unauthenticated() -> None:
+    """GET /notifications/count sans token → 401."""
+    with TestClient(app) as client:
+        resp = client.get("/notifications/count")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# PATCH /notifications/{id}/read
+# ---------------------------------------------------------------------------
+
+
+def test_mark_as_read_success() -> None:
+    """PATCH /notifications/1/read → 200 + notification lue."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.notifications.notification_service.mark_as_read",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_READ_NOTIFICATION,
+        ):
+            with TestClient(app) as client:
+                resp = client.patch("/notifications/1/read")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    assert resp.json()["read"] is True
+    assert resp.json()["read_at"] is not None
+
+
+def test_mark_as_read_not_found() -> None:
+    """PATCH /notifications/999/read → 404."""
+    from app.core.exceptions import NotFoundError
+
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.notifications.notification_service.mark_as_read",
+            new_callable=AsyncMock,
+            side_effect=NotFoundError("Notification", 999),
+        ):
+            with TestClient(app) as client:
+                resp = client.patch("/notifications/999/read")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 404
+
+
+def test_mark_as_read_forbidden() -> None:
+    """PATCH /notifications/2/read d'un autre user → 403."""
+    from app.core.exceptions import PermissionDeniedError
+
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.notifications.notification_service.mark_as_read",
+            new_callable=AsyncMock,
+            side_effect=PermissionDeniedError(
+                "Cannot mark another user's notification as read"
+            ),
+        ):
+            with TestClient(app) as client:
+                resp = client.patch("/notifications/2/read")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# POST /notifications/read-all
+# ---------------------------------------------------------------------------
+
+
+def test_mark_all_read_success() -> None:
+    """POST /notifications/read-all → 200 + updated count."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.notifications.notification_service.mark_all_read",
+            new_callable=AsyncMock,
+            return_value=MarkAllReadResponse(updated=3),
+        ):
+            with TestClient(app) as client:
+                resp = client.post("/notifications/read-all")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    assert resp.json()["updated"] == 3
+
+
+def test_mark_all_read_unauthenticated() -> None:
+    """POST /notifications/read-all sans token → 401."""
+    with TestClient(app) as client:
+        resp = client.post("/notifications/read-all")
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
Closes #25

- `GET /notifications` — paginated list with type/read filters (user-scoped)
- `GET /notifications/count` — unread count for navbar badge
- `PATCH /notifications/{id}/read` — mark single as read (ownership check)
- `POST /notifications/read-all` — bulk mark all as read

## Architecture
- `app/schemas/notification.py` — Pydantic v2 schemas (Response, ListResponse, UnreadCount, MarkAllRead)
- `app/repositories/notification_repository.py` — SQLAlchemy 2.0 async DB access
- `app/services/notification_service.py` — business logic with ownership verification
- `app/routers/notifications.py` — FastAPI router (4 endpoints, all user-scoped)
- `tests/routers/test_notifications.py` — 10 test cases (success + error paths)

## Key decisions
- All endpoints user-scoped via JWT — no `require_permission()` needed
- Ownership check on `mark_as_read` prevents cross-user access
- `func.now()` for `read_at` timestamps (DB server time)
- No audit log (user actions on own data)

## Test plan
- [ ] `pytest tests/routers/test_notifications.py -v`
- [ ] Verify 401 on unauthenticated requests
- [ ] Verify 403 when marking another user's notification
- [ ] Verify unread count decreases after mark_as_read