### PR TITLE
feat(admin): CRUD élèves, enseignants, classes, matières, personnel

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from app.routers.auth import router as auth_router
 from app.routers.dashboard import router as dashboard_router
 from app.routers.enrollments import router as enrollments_router
 from app.routers.grades import router as grades_router
+from app.routers.admin import router as admin_router
 from app.routers.timetable import availability_router, teachers_router
 from app.routers.timetable import router as timetable_router
 
@@ -41,6 +42,7 @@ app.add_middleware(
 register_exception_handlers(app)
 
 # --- Routers ---
+app.include_router(admin_router)
 app.include_router(auth_router)
 app.include_router(dashboard_router)
 app.include_router(enrollments_router)

--- a/app/repositories/admin_repository.py
+++ b/app/repositories/admin_repository.py
@@ -1,0 +1,356 @@
+"""Repository admin — accès DB pour les entités de base (CRUD)."""
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.academic import AcademicYear, Class, Level, Subject
+from app.models.user import StaffProfile, Student, TeacherProfile
+
+
+# ---------------------------------------------------------------------------
+# Student
+# ---------------------------------------------------------------------------
+
+
+async def get_student_by_id(db: AsyncSession, student_id: int) -> Student | None:
+    stmt = select(Student).where(Student.id == student_id)
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def list_students(
+    db: AsyncSession,
+    *,
+    page: int = 1,
+    size: int = 20,
+    search: str | None = None,
+) -> tuple[list[Student], int]:
+    base = select(Student)
+    if search:
+        pattern = f"%{search}%"
+        base = base.where(
+            Student.first_name.ilike(pattern) | Student.last_name.ilike(pattern)
+        )
+    count_stmt = select(func.count()).select_from(base.subquery())
+    total: int = (await db.execute(count_stmt)).scalar() or 0
+    stmt = base.offset((page - 1) * size).limit(size).order_by(Student.id.desc())
+    rows = (await db.execute(stmt)).scalars().all()
+    return list(rows), total
+
+
+async def create_student(db: AsyncSession, **kwargs: object) -> Student:
+    student = Student(**kwargs)
+    db.add(student)
+    await db.flush()
+    return student
+
+
+async def update_student(
+    db: AsyncSession, student: Student, **kwargs: object
+) -> Student:
+    for key, value in kwargs.items():
+        if value is not None:
+            setattr(student, key, value)
+    await db.flush()
+    return student
+
+
+async def delete_student(db: AsyncSession, student: Student) -> None:
+    await db.delete(student)
+    await db.flush()
+
+
+# ---------------------------------------------------------------------------
+# TeacherProfile
+# ---------------------------------------------------------------------------
+
+
+async def get_teacher_by_id(db: AsyncSession, teacher_id: int) -> TeacherProfile | None:
+    stmt = select(TeacherProfile).where(TeacherProfile.id == teacher_id)
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def list_teachers(
+    db: AsyncSession,
+    *,
+    page: int = 1,
+    size: int = 20,
+    search: str | None = None,
+) -> tuple[list[TeacherProfile], int]:
+    base = select(TeacherProfile)
+    if search:
+        pattern = f"%{search}%"
+        base = base.where(
+            TeacherProfile.first_name.ilike(pattern)
+            | TeacherProfile.last_name.ilike(pattern)
+        )
+    count_stmt = select(func.count()).select_from(base.subquery())
+    total: int = (await db.execute(count_stmt)).scalar() or 0
+    stmt = base.offset((page - 1) * size).limit(size).order_by(TeacherProfile.id.desc())
+    rows = (await db.execute(stmt)).scalars().all()
+    return list(rows), total
+
+
+async def create_teacher(db: AsyncSession, **kwargs: object) -> TeacherProfile:
+    teacher = TeacherProfile(**kwargs)
+    db.add(teacher)
+    await db.flush()
+    return teacher
+
+
+async def update_teacher(
+    db: AsyncSession, teacher: TeacherProfile, **kwargs: object
+) -> TeacherProfile:
+    for key, value in kwargs.items():
+        if value is not None:
+            setattr(teacher, key, value)
+    await db.flush()
+    return teacher
+
+
+async def delete_teacher(db: AsyncSession, teacher: TeacherProfile) -> None:
+    await db.delete(teacher)
+    await db.flush()
+
+
+# ---------------------------------------------------------------------------
+# StaffProfile
+# ---------------------------------------------------------------------------
+
+
+async def get_staff_by_id(db: AsyncSession, staff_id: int) -> StaffProfile | None:
+    stmt = select(StaffProfile).where(StaffProfile.id == staff_id)
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def list_staff(
+    db: AsyncSession,
+    *,
+    page: int = 1,
+    size: int = 20,
+    search: str | None = None,
+) -> tuple[list[StaffProfile], int]:
+    base = select(StaffProfile)
+    if search:
+        pattern = f"%{search}%"
+        base = base.where(
+            StaffProfile.first_name.ilike(pattern)
+            | StaffProfile.last_name.ilike(pattern)
+        )
+    count_stmt = select(func.count()).select_from(base.subquery())
+    total: int = (await db.execute(count_stmt)).scalar() or 0
+    stmt = base.offset((page - 1) * size).limit(size).order_by(StaffProfile.id.desc())
+    rows = (await db.execute(stmt)).scalars().all()
+    return list(rows), total
+
+
+async def create_staff(db: AsyncSession, **kwargs: object) -> StaffProfile:
+    staff = StaffProfile(**kwargs)
+    db.add(staff)
+    await db.flush()
+    return staff
+
+
+async def update_staff(
+    db: AsyncSession, staff: StaffProfile, **kwargs: object
+) -> StaffProfile:
+    for key, value in kwargs.items():
+        if value is not None:
+            setattr(staff, key, value)
+    await db.flush()
+    return staff
+
+
+async def delete_staff(db: AsyncSession, staff: StaffProfile) -> None:
+    await db.delete(staff)
+    await db.flush()
+
+
+# ---------------------------------------------------------------------------
+# Class
+# ---------------------------------------------------------------------------
+
+
+async def get_class_by_id(db: AsyncSession, class_id: int) -> Class | None:
+    stmt = select(Class).where(Class.id == class_id)
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def list_classes(
+    db: AsyncSession,
+    *,
+    page: int = 1,
+    size: int = 20,
+    level_id: int | None = None,
+    academic_year_id: int | None = None,
+) -> tuple[list[Class], int]:
+    base = select(Class)
+    if level_id is not None:
+        base = base.where(Class.level_id == level_id)
+    if academic_year_id is not None:
+        base = base.where(Class.academic_year_id == academic_year_id)
+    count_stmt = select(func.count()).select_from(base.subquery())
+    total: int = (await db.execute(count_stmt)).scalar() or 0
+    stmt = base.offset((page - 1) * size).limit(size).order_by(Class.id.desc())
+    rows = (await db.execute(stmt)).scalars().all()
+    return list(rows), total
+
+
+async def create_class(db: AsyncSession, **kwargs: object) -> Class:
+    cls = Class(**kwargs)
+    db.add(cls)
+    await db.flush()
+    return cls
+
+
+async def update_class(db: AsyncSession, cls: Class, **kwargs: object) -> Class:
+    for key, value in kwargs.items():
+        if value is not None:
+            setattr(cls, key, value)
+    await db.flush()
+    return cls
+
+
+async def delete_class(db: AsyncSession, cls: Class) -> None:
+    await db.delete(cls)
+    await db.flush()
+
+
+# ---------------------------------------------------------------------------
+# Subject
+# ---------------------------------------------------------------------------
+
+
+async def get_subject_by_id(db: AsyncSession, subject_id: int) -> Subject | None:
+    stmt = select(Subject).where(Subject.id == subject_id)
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def list_subjects(
+    db: AsyncSession,
+    *,
+    page: int = 1,
+    size: int = 20,
+    level_id: int | None = None,
+) -> tuple[list[Subject], int]:
+    base = select(Subject)
+    if level_id is not None:
+        base = base.where(Subject.level_id == level_id)
+    count_stmt = select(func.count()).select_from(base.subquery())
+    total: int = (await db.execute(count_stmt)).scalar() or 0
+    stmt = base.offset((page - 1) * size).limit(size).order_by(Subject.id.desc())
+    rows = (await db.execute(stmt)).scalars().all()
+    return list(rows), total
+
+
+async def create_subject(db: AsyncSession, **kwargs: object) -> Subject:
+    subject = Subject(**kwargs)
+    db.add(subject)
+    await db.flush()
+    return subject
+
+
+async def update_subject(
+    db: AsyncSession, subject: Subject, **kwargs: object
+) -> Subject:
+    for key, value in kwargs.items():
+        if value is not None:
+            setattr(subject, key, value)
+    await db.flush()
+    return subject
+
+
+async def delete_subject(db: AsyncSession, subject: Subject) -> None:
+    await db.delete(subject)
+    await db.flush()
+
+
+# ---------------------------------------------------------------------------
+# AcademicYear
+# ---------------------------------------------------------------------------
+
+
+async def get_academic_year_by_id(
+    db: AsyncSession, year_id: int
+) -> AcademicYear | None:
+    stmt = select(AcademicYear).where(AcademicYear.id == year_id)
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def list_academic_years(
+    db: AsyncSession,
+    *,
+    page: int = 1,
+    size: int = 20,
+) -> tuple[list[AcademicYear], int]:
+    base = select(AcademicYear)
+    count_stmt = select(func.count()).select_from(base.subquery())
+    total: int = (await db.execute(count_stmt)).scalar() or 0
+    stmt = base.offset((page - 1) * size).limit(size).order_by(AcademicYear.id.desc())
+    rows = (await db.execute(stmt)).scalars().all()
+    return list(rows), total
+
+
+async def create_academic_year(db: AsyncSession, **kwargs: object) -> AcademicYear:
+    year = AcademicYear(**kwargs)
+    db.add(year)
+    await db.flush()
+    return year
+
+
+async def update_academic_year(
+    db: AsyncSession, year: AcademicYear, **kwargs: object
+) -> AcademicYear:
+    for key, value in kwargs.items():
+        if value is not None:
+            setattr(year, key, value)
+    await db.flush()
+    return year
+
+
+async def delete_academic_year(db: AsyncSession, year: AcademicYear) -> None:
+    await db.delete(year)
+    await db.flush()
+
+
+# ---------------------------------------------------------------------------
+# Level
+# ---------------------------------------------------------------------------
+
+
+async def get_level_by_id(db: AsyncSession, level_id: int) -> Level | None:
+    stmt = select(Level).where(Level.id == level_id)
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def list_levels(
+    db: AsyncSession,
+    *,
+    page: int = 1,
+    size: int = 20,
+) -> tuple[list[Level], int]:
+    base = select(Level)
+    count_stmt = select(func.count()).select_from(base.subquery())
+    total: int = (await db.execute(count_stmt)).scalar() or 0
+    stmt = base.offset((page - 1) * size).limit(size).order_by(Level.order.asc())
+    rows = (await db.execute(stmt)).scalars().all()
+    return list(rows), total
+
+
+async def create_level(db: AsyncSession, **kwargs: object) -> Level:
+    level = Level(**kwargs)
+    db.add(level)
+    await db.flush()
+    return level
+
+
+async def update_level(db: AsyncSession, level: Level, **kwargs: object) -> Level:
+    for key, value in kwargs.items():
+        if value is not None:
+            setattr(level, key, value)
+    await db.flush()
+    return level
+
+
+async def delete_level(db: AsyncSession, level: Level) -> None:
+    await db.delete(level)
+    await db.flush()

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1,0 +1,485 @@
+"""Router admin — CRUD endpoints pour les entités de base."""
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db, require_permission
+from app.schemas.admin import (
+    AcademicYearCreate,
+    AcademicYearListResponse,
+    AcademicYearResponse,
+    AcademicYearUpdate,
+    ClassCreate,
+    ClassListResponse,
+    ClassResponse,
+    ClassUpdate,
+    LevelCreate,
+    LevelListResponse,
+    LevelResponse,
+    LevelUpdate,
+    StaffCreate,
+    StaffListResponse,
+    StaffResponse,
+    StaffUpdate,
+    StudentCreate,
+    StudentListResponse,
+    StudentResponse,
+    StudentUpdate,
+    SubjectCreate,
+    SubjectListResponse,
+    SubjectResponse,
+    SubjectUpdate,
+    TeacherCreate,
+    TeacherListResponse,
+    TeacherResponse,
+    TeacherUpdate,
+)
+from app.services import admin_service
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+# ---------------------------------------------------------------------------
+# Students
+# ---------------------------------------------------------------------------
+
+
+@router.get("/students", response_model=StudentListResponse)
+async def list_students(
+    search: str | None = Query(None),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    _: None = require_permission("admin:students:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> StudentListResponse:
+    """Liste paginee des eleves avec recherche optionnelle."""
+    return await admin_service.list_students(db, page=page, size=size, search=search)
+
+
+@router.post("/students", response_model=StudentResponse, status_code=status.HTTP_201_CREATED)
+async def create_student(
+    data: StudentCreate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:students:create"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> StudentResponse:
+    """Cree un nouvel eleve."""
+    return await admin_service.create_student(db, data, created_by=current_user.user_id)
+
+
+@router.get("/students/{student_id}", response_model=StudentResponse)
+async def get_student(
+    student_id: int,
+    _: None = require_permission("admin:students:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> StudentResponse:
+    """Retourne un eleve par ID."""
+    return await admin_service.get_student(db, student_id)
+
+
+@router.patch("/students/{student_id}", response_model=StudentResponse)
+async def update_student(
+    student_id: int,
+    data: StudentUpdate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:students:update"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> StudentResponse:
+    """Met a jour un eleve (patch partiel)."""
+    return await admin_service.update_student(
+        db, student_id, data, updated_by=current_user.user_id
+    )
+
+
+@router.delete("/students/{student_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_student(
+    student_id: int,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:students:delete"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> None:
+    """Supprime un eleve."""
+    await admin_service.delete_student(db, student_id, deleted_by=current_user.user_id)
+
+
+# ---------------------------------------------------------------------------
+# Teachers
+# ---------------------------------------------------------------------------
+
+
+@router.get("/teachers", response_model=TeacherListResponse)
+async def list_teachers(
+    search: str | None = Query(None),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    _: None = require_permission("admin:teachers:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> TeacherListResponse:
+    """Liste paginee des enseignants."""
+    return await admin_service.list_teachers(db, page=page, size=size, search=search)
+
+
+@router.post("/teachers", response_model=TeacherResponse, status_code=status.HTTP_201_CREATED)
+async def create_teacher(
+    data: TeacherCreate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:teachers:create"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> TeacherResponse:
+    """Cree un nouvel enseignant."""
+    return await admin_service.create_teacher(db, data, created_by=current_user.user_id)
+
+
+@router.get("/teachers/{teacher_id}", response_model=TeacherResponse)
+async def get_teacher(
+    teacher_id: int,
+    _: None = require_permission("admin:teachers:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> TeacherResponse:
+    """Retourne un enseignant par ID."""
+    return await admin_service.get_teacher(db, teacher_id)
+
+
+@router.patch("/teachers/{teacher_id}", response_model=TeacherResponse)
+async def update_teacher(
+    teacher_id: int,
+    data: TeacherUpdate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:teachers:update"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> TeacherResponse:
+    """Met a jour un enseignant (patch partiel)."""
+    return await admin_service.update_teacher(
+        db, teacher_id, data, updated_by=current_user.user_id
+    )
+
+
+@router.delete("/teachers/{teacher_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_teacher(
+    teacher_id: int,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:teachers:delete"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> None:
+    """Supprime un enseignant."""
+    await admin_service.delete_teacher(db, teacher_id, deleted_by=current_user.user_id)
+
+
+# ---------------------------------------------------------------------------
+# Staff
+# ---------------------------------------------------------------------------
+
+
+@router.get("/staff", response_model=StaffListResponse)
+async def list_staff(
+    search: str | None = Query(None),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    _: None = require_permission("admin:staff:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> StaffListResponse:
+    """Liste paginee du personnel."""
+    return await admin_service.list_staff(db, page=page, size=size, search=search)
+
+
+@router.post("/staff", response_model=StaffResponse, status_code=status.HTTP_201_CREATED)
+async def create_staff(
+    data: StaffCreate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:staff:create"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> StaffResponse:
+    """Cree un nouveau membre du personnel."""
+    return await admin_service.create_staff(db, data, created_by=current_user.user_id)
+
+
+@router.get("/staff/{staff_id}", response_model=StaffResponse)
+async def get_staff(
+    staff_id: int,
+    _: None = require_permission("admin:staff:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> StaffResponse:
+    """Retourne un membre du personnel par ID."""
+    return await admin_service.get_staff(db, staff_id)
+
+
+@router.patch("/staff/{staff_id}", response_model=StaffResponse)
+async def update_staff(
+    staff_id: int,
+    data: StaffUpdate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:staff:update"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> StaffResponse:
+    """Met a jour un membre du personnel (patch partiel)."""
+    return await admin_service.update_staff(
+        db, staff_id, data, updated_by=current_user.user_id
+    )
+
+
+@router.delete("/staff/{staff_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_staff(
+    staff_id: int,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:staff:delete"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> None:
+    """Supprime un membre du personnel."""
+    await admin_service.delete_staff(db, staff_id, deleted_by=current_user.user_id)
+
+
+# ---------------------------------------------------------------------------
+# Classes
+# ---------------------------------------------------------------------------
+
+
+@router.get("/classes", response_model=ClassListResponse)
+async def list_classes(
+    level_id: int | None = Query(None),
+    academic_year_id: int | None = Query(None),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    _: None = require_permission("admin:classes:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> ClassListResponse:
+    """Liste paginee des classes avec filtres."""
+    return await admin_service.list_classes(
+        db, page=page, size=size, level_id=level_id, academic_year_id=academic_year_id
+    )
+
+
+@router.post("/classes", response_model=ClassResponse, status_code=status.HTTP_201_CREATED)
+async def create_class(
+    data: ClassCreate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:classes:create"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> ClassResponse:
+    """Cree une nouvelle classe."""
+    return await admin_service.create_class(db, data, created_by=current_user.user_id)
+
+
+@router.get("/classes/{class_id}", response_model=ClassResponse)
+async def get_class(
+    class_id: int,
+    _: None = require_permission("admin:classes:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> ClassResponse:
+    """Retourne une classe par ID."""
+    return await admin_service.get_class(db, class_id)
+
+
+@router.patch("/classes/{class_id}", response_model=ClassResponse)
+async def update_class(
+    class_id: int,
+    data: ClassUpdate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:classes:update"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> ClassResponse:
+    """Met a jour une classe (patch partiel)."""
+    return await admin_service.update_class(
+        db, class_id, data, updated_by=current_user.user_id
+    )
+
+
+@router.delete("/classes/{class_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_class(
+    class_id: int,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:classes:delete"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> None:
+    """Supprime une classe."""
+    await admin_service.delete_class(db, class_id, deleted_by=current_user.user_id)
+
+
+# ---------------------------------------------------------------------------
+# Subjects
+# ---------------------------------------------------------------------------
+
+
+@router.get("/subjects", response_model=SubjectListResponse)
+async def list_subjects(
+    level_id: int | None = Query(None),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    _: None = require_permission("admin:subjects:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> SubjectListResponse:
+    """Liste paginee des matieres."""
+    return await admin_service.list_subjects(db, page=page, size=size, level_id=level_id)
+
+
+@router.post("/subjects", response_model=SubjectResponse, status_code=status.HTTP_201_CREATED)
+async def create_subject(
+    data: SubjectCreate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:subjects:create"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> SubjectResponse:
+    """Cree une nouvelle matiere."""
+    return await admin_service.create_subject(db, data, created_by=current_user.user_id)
+
+
+@router.get("/subjects/{subject_id}", response_model=SubjectResponse)
+async def get_subject(
+    subject_id: int,
+    _: None = require_permission("admin:subjects:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> SubjectResponse:
+    """Retourne une matiere par ID."""
+    return await admin_service.get_subject(db, subject_id)
+
+
+@router.patch("/subjects/{subject_id}", response_model=SubjectResponse)
+async def update_subject(
+    subject_id: int,
+    data: SubjectUpdate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:subjects:update"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> SubjectResponse:
+    """Met a jour une matiere (patch partiel)."""
+    return await admin_service.update_subject(
+        db, subject_id, data, updated_by=current_user.user_id
+    )
+
+
+@router.delete("/subjects/{subject_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_subject(
+    subject_id: int,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:subjects:delete"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> None:
+    """Supprime une matiere."""
+    await admin_service.delete_subject(db, subject_id, deleted_by=current_user.user_id)
+
+
+# ---------------------------------------------------------------------------
+# Academic Years
+# ---------------------------------------------------------------------------
+
+
+@router.get("/academic-years", response_model=AcademicYearListResponse)
+async def list_academic_years(
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    _: None = require_permission("admin:academic-years:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> AcademicYearListResponse:
+    """Liste paginee des annees academiques."""
+    return await admin_service.list_academic_years(db, page=page, size=size)
+
+
+@router.post(
+    "/academic-years",
+    response_model=AcademicYearResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_academic_year(
+    data: AcademicYearCreate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:academic-years:create"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> AcademicYearResponse:
+    """Cree une nouvelle annee academique."""
+    return await admin_service.create_academic_year(db, data, created_by=current_user.user_id)
+
+
+@router.get("/academic-years/{year_id}", response_model=AcademicYearResponse)
+async def get_academic_year(
+    year_id: int,
+    _: None = require_permission("admin:academic-years:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> AcademicYearResponse:
+    """Retourne une annee academique par ID."""
+    return await admin_service.get_academic_year(db, year_id)
+
+
+@router.patch("/academic-years/{year_id}", response_model=AcademicYearResponse)
+async def update_academic_year(
+    year_id: int,
+    data: AcademicYearUpdate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:academic-years:update"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> AcademicYearResponse:
+    """Met a jour une annee academique (patch partiel)."""
+    return await admin_service.update_academic_year(
+        db, year_id, data, updated_by=current_user.user_id
+    )
+
+
+@router.delete("/academic-years/{year_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_academic_year(
+    year_id: int,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:academic-years:delete"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> None:
+    """Supprime une annee academique."""
+    await admin_service.delete_academic_year(db, year_id, deleted_by=current_user.user_id)
+
+
+# ---------------------------------------------------------------------------
+# Levels
+# ---------------------------------------------------------------------------
+
+
+@router.get("/levels", response_model=LevelListResponse)
+async def list_levels(
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    _: None = require_permission("admin:levels:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> LevelListResponse:
+    """Liste paginee des niveaux."""
+    return await admin_service.list_levels(db, page=page, size=size)
+
+
+@router.post("/levels", response_model=LevelResponse, status_code=status.HTTP_201_CREATED)
+async def create_level(
+    data: LevelCreate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:levels:create"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> LevelResponse:
+    """Cree un nouveau niveau."""
+    return await admin_service.create_level(db, data, created_by=current_user.user_id)
+
+
+@router.get("/levels/{level_id}", response_model=LevelResponse)
+async def get_level(
+    level_id: int,
+    _: None = require_permission("admin:levels:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> LevelResponse:
+    """Retourne un niveau par ID."""
+    return await admin_service.get_level(db, level_id)
+
+
+@router.patch("/levels/{level_id}", response_model=LevelResponse)
+async def update_level(
+    level_id: int,
+    data: LevelUpdate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:levels:update"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> LevelResponse:
+    """Met a jour un niveau (patch partiel)."""
+    return await admin_service.update_level(
+        db, level_id, data, updated_by=current_user.user_id
+    )
+
+
+@router.delete("/levels/{level_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_level(
+    level_id: int,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:levels:delete"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> None:
+    """Supprime un niveau."""
+    await admin_service.delete_level(db, level_id, deleted_by=current_user.user_id)

--- a/app/schemas/admin.py
+++ b/app/schemas/admin.py
@@ -1,0 +1,334 @@
+"""Schémas Pydantic pour le CRUD admin des entités de base."""
+
+from datetime import date, datetime
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+
+# ---------------------------------------------------------------------------
+# Student
+# ---------------------------------------------------------------------------
+
+
+class StudentCreate(BaseModel):
+    first_name: str
+    last_name: str
+    birth_date: date | None = None
+    genre: str | None = None
+    enrollment_number: str | None = None
+    user_id: int | None = None
+
+    @field_validator("genre")
+    @classmethod
+    def valid_genre(cls, v: str | None) -> str | None:
+        if v is not None and v not in {"M", "F"}:
+            raise ValueError("genre must be 'M' or 'F'")
+        return v
+
+
+class StudentUpdate(BaseModel):
+    first_name: str | None = None
+    last_name: str | None = None
+    birth_date: date | None = None
+    genre: str | None = None
+    enrollment_number: str | None = None
+    user_id: int | None = None
+
+    @field_validator("genre")
+    @classmethod
+    def valid_genre(cls, v: str | None) -> str | None:
+        if v is not None and v not in {"M", "F"}:
+            raise ValueError("genre must be 'M' or 'F'")
+        return v
+
+
+class StudentResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    first_name: str
+    last_name: str
+    birth_date: date | None
+    genre: str | None
+    enrollment_number: str | None
+    user_id: int | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class StudentListResponse(BaseModel):
+    items: list[StudentResponse]
+    total: int
+    page: int
+    size: int
+
+
+# ---------------------------------------------------------------------------
+# TeacherProfile
+# ---------------------------------------------------------------------------
+
+
+class TeacherCreate(BaseModel):
+    first_name: str
+    last_name: str
+    speciality: str | None = None
+    phone: str | None = None
+    user_id: int
+
+
+class TeacherUpdate(BaseModel):
+    first_name: str | None = None
+    last_name: str | None = None
+    speciality: str | None = None
+    phone: str | None = None
+
+
+class TeacherResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    user_id: int
+    first_name: str
+    last_name: str
+    speciality: str | None
+    phone: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class TeacherListResponse(BaseModel):
+    items: list[TeacherResponse]
+    total: int
+    page: int
+    size: int
+
+
+# ---------------------------------------------------------------------------
+# StaffProfile
+# ---------------------------------------------------------------------------
+
+
+class StaffCreate(BaseModel):
+    first_name: str
+    last_name: str
+    position: str | None = None
+    phone: str | None = None
+    user_id: int
+
+
+class StaffUpdate(BaseModel):
+    first_name: str | None = None
+    last_name: str | None = None
+    position: str | None = None
+    phone: str | None = None
+
+
+class StaffResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    user_id: int
+    first_name: str
+    last_name: str
+    position: str | None
+    phone: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class StaffListResponse(BaseModel):
+    items: list[StaffResponse]
+    total: int
+    page: int
+    size: int
+
+
+# ---------------------------------------------------------------------------
+# Class
+# ---------------------------------------------------------------------------
+
+
+class ClassCreate(BaseModel):
+    name: str
+    level_id: int
+    series_id: int | None = None
+    academic_year_id: int
+    room_id: int | None = None
+    max_students: int = 40
+
+    @field_validator("max_students")
+    @classmethod
+    def positive_max(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("max_students must be positive")
+        return v
+
+
+class ClassUpdate(BaseModel):
+    name: str | None = None
+    level_id: int | None = None
+    series_id: int | None = None
+    academic_year_id: int | None = None
+    room_id: int | None = None
+    max_students: int | None = None
+
+    @field_validator("max_students")
+    @classmethod
+    def positive_max(cls, v: int | None) -> int | None:
+        if v is not None and v <= 0:
+            raise ValueError("max_students must be positive")
+        return v
+
+
+class ClassResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    level_id: int
+    series_id: int | None
+    academic_year_id: int
+    room_id: int | None
+    max_students: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class ClassListResponse(BaseModel):
+    items: list[ClassResponse]
+    total: int
+    page: int
+    size: int
+
+
+# ---------------------------------------------------------------------------
+# Subject
+# ---------------------------------------------------------------------------
+
+
+class SubjectCreate(BaseModel):
+    name: str
+    level_id: int | None = None
+    series_id: int | None = None
+    coefficient: int = 1
+    hours_per_week: int = 2
+
+    @field_validator("coefficient", "hours_per_week")
+    @classmethod
+    def positive_value(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("must be positive")
+        return v
+
+
+class SubjectUpdate(BaseModel):
+    name: str | None = None
+    level_id: int | None = None
+    series_id: int | None = None
+    coefficient: int | None = None
+    hours_per_week: int | None = None
+
+    @field_validator("coefficient", "hours_per_week")
+    @classmethod
+    def positive_value(cls, v: int | None) -> int | None:
+        if v is not None and v <= 0:
+            raise ValueError("must be positive")
+        return v
+
+
+class SubjectResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    level_id: int | None
+    series_id: int | None
+    coefficient: int
+    hours_per_week: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class SubjectListResponse(BaseModel):
+    items: list[SubjectResponse]
+    total: int
+    page: int
+    size: int
+
+
+# ---------------------------------------------------------------------------
+# AcademicYear
+# ---------------------------------------------------------------------------
+
+
+class AcademicYearCreate(BaseModel):
+    name: str
+    start_date: date
+    end_date: date
+    is_current: bool = False
+
+    @field_validator("end_date")
+    @classmethod
+    def end_after_start(cls, v: date, info: object) -> date:
+        # info.data contains already-validated fields
+        data = getattr(info, "data", {})
+        start = data.get("start_date")
+        if start and v <= start:
+            raise ValueError("end_date must be after start_date")
+        return v
+
+
+class AcademicYearUpdate(BaseModel):
+    name: str | None = None
+    start_date: date | None = None
+    end_date: date | None = None
+    is_current: bool | None = None
+
+
+class AcademicYearResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    start_date: date
+    end_date: date
+    is_current: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class AcademicYearListResponse(BaseModel):
+    items: list[AcademicYearResponse]
+    total: int
+    page: int
+    size: int
+
+
+# ---------------------------------------------------------------------------
+# Level
+# ---------------------------------------------------------------------------
+
+
+class LevelCreate(BaseModel):
+    name: str
+    order: int = 0
+
+
+class LevelUpdate(BaseModel):
+    name: str | None = None
+    order: int | None = None
+
+
+class LevelResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    order: int
+
+
+class LevelListResponse(BaseModel):
+    items: list[LevelResponse]
+    total: int
+    page: int
+    size: int

--- a/app/services/admin_service.py
+++ b/app/services/admin_service.py
@@ -1,0 +1,714 @@
+"""Service admin — logique métier CRUD pour les entités de base."""
+
+import logging
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.audit import AuditAction, audit_log
+from app.core.exceptions import NotFoundError
+from app.repositories import admin_repository as repo
+from app.schemas.admin import (
+    AcademicYearCreate,
+    AcademicYearListResponse,
+    AcademicYearResponse,
+    AcademicYearUpdate,
+    ClassCreate,
+    ClassListResponse,
+    ClassResponse,
+    ClassUpdate,
+    LevelCreate,
+    LevelListResponse,
+    LevelResponse,
+    LevelUpdate,
+    StaffCreate,
+    StaffListResponse,
+    StaffResponse,
+    StaffUpdate,
+    StudentCreate,
+    StudentListResponse,
+    StudentResponse,
+    StudentUpdate,
+    SubjectCreate,
+    SubjectListResponse,
+    SubjectResponse,
+    SubjectUpdate,
+    TeacherCreate,
+    TeacherListResponse,
+    TeacherResponse,
+    TeacherUpdate,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Student
+# ---------------------------------------------------------------------------
+
+
+def _student_to_response(s: object) -> StudentResponse:
+    return StudentResponse.model_validate(s)
+
+
+async def list_students(
+    db: AsyncSession,
+    *,
+    page: int = 1,
+    size: int = 20,
+    search: str | None = None,
+) -> StudentListResponse:
+    students, total = await repo.list_students(db, page=page, size=size, search=search)
+    return StudentListResponse(
+        items=[_student_to_response(s) for s in students],
+        total=total,
+        page=page,
+        size=size,
+    )
+
+
+async def get_student(db: AsyncSession, student_id: int) -> StudentResponse:
+    student = await repo.get_student_by_id(db, student_id)
+    if student is None:
+        raise NotFoundError("Student", student_id)
+    return _student_to_response(student)
+
+
+async def create_student(
+    db: AsyncSession, data: StudentCreate, *, created_by: int
+) -> StudentResponse:
+    async with db.begin_nested():
+        student = await repo.create_student(db, **data.model_dump())
+        await audit_log(
+            db,
+            entity_type="student",
+            action=AuditAction.CREATE,
+            user_id=created_by,
+            entity_id=student.id,
+            new_values=data.model_dump(),
+        )
+    await db.commit()
+    refreshed = await repo.get_student_by_id(db, student.id)
+    if refreshed is None:
+        raise NotFoundError("Student", student.id)
+    return _student_to_response(refreshed)
+
+
+async def update_student(
+    db: AsyncSession, student_id: int, data: StudentUpdate, *, updated_by: int
+) -> StudentResponse:
+    student = await repo.get_student_by_id(db, student_id)
+    if student is None:
+        raise NotFoundError("Student", student_id)
+    changes = data.model_dump(exclude_none=True)
+    if not changes:
+        return _student_to_response(student)
+    async with db.begin_nested():
+        await repo.update_student(db, student, **changes)
+        await audit_log(
+            db,
+            entity_type="student",
+            action=AuditAction.UPDATE,
+            user_id=updated_by,
+            entity_id=student_id,
+            new_values=changes,
+        )
+    await db.commit()
+    refreshed = await repo.get_student_by_id(db, student_id)
+    if refreshed is None:
+        raise NotFoundError("Student", student_id)
+    return _student_to_response(refreshed)
+
+
+async def delete_student(
+    db: AsyncSession, student_id: int, *, deleted_by: int
+) -> None:
+    student = await repo.get_student_by_id(db, student_id)
+    if student is None:
+        raise NotFoundError("Student", student_id)
+    async with db.begin_nested():
+        await repo.delete_student(db, student)
+        await audit_log(
+            db,
+            entity_type="student",
+            action=AuditAction.DELETE,
+            user_id=deleted_by,
+            entity_id=student_id,
+        )
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# TeacherProfile
+# ---------------------------------------------------------------------------
+
+
+def _teacher_to_response(t: object) -> TeacherResponse:
+    return TeacherResponse.model_validate(t)
+
+
+async def list_teachers(
+    db: AsyncSession,
+    *,
+    page: int = 1,
+    size: int = 20,
+    search: str | None = None,
+) -> TeacherListResponse:
+    teachers, total = await repo.list_teachers(db, page=page, size=size, search=search)
+    return TeacherListResponse(
+        items=[_teacher_to_response(t) for t in teachers],
+        total=total,
+        page=page,
+        size=size,
+    )
+
+
+async def get_teacher(db: AsyncSession, teacher_id: int) -> TeacherResponse:
+    teacher = await repo.get_teacher_by_id(db, teacher_id)
+    if teacher is None:
+        raise NotFoundError("Teacher", teacher_id)
+    return _teacher_to_response(teacher)
+
+
+async def create_teacher(
+    db: AsyncSession, data: TeacherCreate, *, created_by: int
+) -> TeacherResponse:
+    async with db.begin_nested():
+        teacher = await repo.create_teacher(db, **data.model_dump())
+        await audit_log(
+            db,
+            entity_type="teacher",
+            action=AuditAction.CREATE,
+            user_id=created_by,
+            entity_id=teacher.id,
+            new_values=data.model_dump(),
+        )
+    await db.commit()
+    refreshed = await repo.get_teacher_by_id(db, teacher.id)
+    if refreshed is None:
+        raise NotFoundError("Teacher", teacher.id)
+    return _teacher_to_response(refreshed)
+
+
+async def update_teacher(
+    db: AsyncSession, teacher_id: int, data: TeacherUpdate, *, updated_by: int
+) -> TeacherResponse:
+    teacher = await repo.get_teacher_by_id(db, teacher_id)
+    if teacher is None:
+        raise NotFoundError("Teacher", teacher_id)
+    changes = data.model_dump(exclude_none=True)
+    if not changes:
+        return _teacher_to_response(teacher)
+    async with db.begin_nested():
+        await repo.update_teacher(db, teacher, **changes)
+        await audit_log(
+            db,
+            entity_type="teacher",
+            action=AuditAction.UPDATE,
+            user_id=updated_by,
+            entity_id=teacher_id,
+            new_values=changes,
+        )
+    await db.commit()
+    refreshed = await repo.get_teacher_by_id(db, teacher_id)
+    if refreshed is None:
+        raise NotFoundError("Teacher", teacher_id)
+    return _teacher_to_response(refreshed)
+
+
+async def delete_teacher(
+    db: AsyncSession, teacher_id: int, *, deleted_by: int
+) -> None:
+    teacher = await repo.get_teacher_by_id(db, teacher_id)
+    if teacher is None:
+        raise NotFoundError("Teacher", teacher_id)
+    async with db.begin_nested():
+        await repo.delete_teacher(db, teacher)
+        await audit_log(
+            db,
+            entity_type="teacher",
+            action=AuditAction.DELETE,
+            user_id=deleted_by,
+            entity_id=teacher_id,
+        )
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# StaffProfile
+# ---------------------------------------------------------------------------
+
+
+def _staff_to_response(s: object) -> StaffResponse:
+    return StaffResponse.model_validate(s)
+
+
+async def list_staff(
+    db: AsyncSession,
+    *,
+    page: int = 1,
+    size: int = 20,
+    search: str | None = None,
+) -> StaffListResponse:
+    staff_list, total = await repo.list_staff(db, page=page, size=size, search=search)
+    return StaffListResponse(
+        items=[_staff_to_response(s) for s in staff_list],
+        total=total,
+        page=page,
+        size=size,
+    )
+
+
+async def get_staff(db: AsyncSession, staff_id: int) -> StaffResponse:
+    staff = await repo.get_staff_by_id(db, staff_id)
+    if staff is None:
+        raise NotFoundError("Staff", staff_id)
+    return _staff_to_response(staff)
+
+
+async def create_staff(
+    db: AsyncSession, data: StaffCreate, *, created_by: int
+) -> StaffResponse:
+    async with db.begin_nested():
+        staff = await repo.create_staff(db, **data.model_dump())
+        await audit_log(
+            db,
+            entity_type="staff",
+            action=AuditAction.CREATE,
+            user_id=created_by,
+            entity_id=staff.id,
+            new_values=data.model_dump(),
+        )
+    await db.commit()
+    refreshed = await repo.get_staff_by_id(db, staff.id)
+    if refreshed is None:
+        raise NotFoundError("Staff", staff.id)
+    return _staff_to_response(refreshed)
+
+
+async def update_staff(
+    db: AsyncSession, staff_id: int, data: StaffUpdate, *, updated_by: int
+) -> StaffResponse:
+    staff = await repo.get_staff_by_id(db, staff_id)
+    if staff is None:
+        raise NotFoundError("Staff", staff_id)
+    changes = data.model_dump(exclude_none=True)
+    if not changes:
+        return _staff_to_response(staff)
+    async with db.begin_nested():
+        await repo.update_staff(db, staff, **changes)
+        await audit_log(
+            db,
+            entity_type="staff",
+            action=AuditAction.UPDATE,
+            user_id=updated_by,
+            entity_id=staff_id,
+            new_values=changes,
+        )
+    await db.commit()
+    refreshed = await repo.get_staff_by_id(db, staff_id)
+    if refreshed is None:
+        raise NotFoundError("Staff", staff_id)
+    return _staff_to_response(refreshed)
+
+
+async def delete_staff(
+    db: AsyncSession, staff_id: int, *, deleted_by: int
+) -> None:
+    staff = await repo.get_staff_by_id(db, staff_id)
+    if staff is None:
+        raise NotFoundError("Staff", staff_id)
+    async with db.begin_nested():
+        await repo.delete_staff(db, staff)
+        await audit_log(
+            db,
+            entity_type="staff",
+            action=AuditAction.DELETE,
+            user_id=deleted_by,
+            entity_id=staff_id,
+        )
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Class
+# ---------------------------------------------------------------------------
+
+
+def _class_to_response(c: object) -> ClassResponse:
+    return ClassResponse.model_validate(c)
+
+
+async def list_classes(
+    db: AsyncSession,
+    *,
+    page: int = 1,
+    size: int = 20,
+    level_id: int | None = None,
+    academic_year_id: int | None = None,
+) -> ClassListResponse:
+    classes, total = await repo.list_classes(
+        db, page=page, size=size, level_id=level_id, academic_year_id=academic_year_id
+    )
+    return ClassListResponse(
+        items=[_class_to_response(c) for c in classes],
+        total=total,
+        page=page,
+        size=size,
+    )
+
+
+async def get_class(db: AsyncSession, class_id: int) -> ClassResponse:
+    cls = await repo.get_class_by_id(db, class_id)
+    if cls is None:
+        raise NotFoundError("Class", class_id)
+    return _class_to_response(cls)
+
+
+async def create_class(
+    db: AsyncSession, data: ClassCreate, *, created_by: int
+) -> ClassResponse:
+    async with db.begin_nested():
+        cls = await repo.create_class(db, **data.model_dump())
+        await audit_log(
+            db,
+            entity_type="class",
+            action=AuditAction.CREATE,
+            user_id=created_by,
+            entity_id=cls.id,
+            new_values=data.model_dump(),
+        )
+    await db.commit()
+    refreshed = await repo.get_class_by_id(db, cls.id)
+    if refreshed is None:
+        raise NotFoundError("Class", cls.id)
+    return _class_to_response(refreshed)
+
+
+async def update_class(
+    db: AsyncSession, class_id: int, data: ClassUpdate, *, updated_by: int
+) -> ClassResponse:
+    cls = await repo.get_class_by_id(db, class_id)
+    if cls is None:
+        raise NotFoundError("Class", class_id)
+    changes = data.model_dump(exclude_none=True)
+    if not changes:
+        return _class_to_response(cls)
+    async with db.begin_nested():
+        await repo.update_class(db, cls, **changes)
+        await audit_log(
+            db,
+            entity_type="class",
+            action=AuditAction.UPDATE,
+            user_id=updated_by,
+            entity_id=class_id,
+            new_values=changes,
+        )
+    await db.commit()
+    refreshed = await repo.get_class_by_id(db, class_id)
+    if refreshed is None:
+        raise NotFoundError("Class", class_id)
+    return _class_to_response(refreshed)
+
+
+async def delete_class(
+    db: AsyncSession, class_id: int, *, deleted_by: int
+) -> None:
+    cls = await repo.get_class_by_id(db, class_id)
+    if cls is None:
+        raise NotFoundError("Class", class_id)
+    async with db.begin_nested():
+        await repo.delete_class(db, cls)
+        await audit_log(
+            db,
+            entity_type="class",
+            action=AuditAction.DELETE,
+            user_id=deleted_by,
+            entity_id=class_id,
+        )
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Subject
+# ---------------------------------------------------------------------------
+
+
+def _subject_to_response(s: object) -> SubjectResponse:
+    return SubjectResponse.model_validate(s)
+
+
+async def list_subjects(
+    db: AsyncSession,
+    *,
+    page: int = 1,
+    size: int = 20,
+    level_id: int | None = None,
+) -> SubjectListResponse:
+    subjects, total = await repo.list_subjects(db, page=page, size=size, level_id=level_id)
+    return SubjectListResponse(
+        items=[_subject_to_response(s) for s in subjects],
+        total=total,
+        page=page,
+        size=size,
+    )
+
+
+async def get_subject(db: AsyncSession, subject_id: int) -> SubjectResponse:
+    subject = await repo.get_subject_by_id(db, subject_id)
+    if subject is None:
+        raise NotFoundError("Subject", subject_id)
+    return _subject_to_response(subject)
+
+
+async def create_subject(
+    db: AsyncSession, data: SubjectCreate, *, created_by: int
+) -> SubjectResponse:
+    async with db.begin_nested():
+        subject = await repo.create_subject(db, **data.model_dump())
+        await audit_log(
+            db,
+            entity_type="subject",
+            action=AuditAction.CREATE,
+            user_id=created_by,
+            entity_id=subject.id,
+            new_values=data.model_dump(),
+        )
+    await db.commit()
+    refreshed = await repo.get_subject_by_id(db, subject.id)
+    if refreshed is None:
+        raise NotFoundError("Subject", subject.id)
+    return _subject_to_response(refreshed)
+
+
+async def update_subject(
+    db: AsyncSession, subject_id: int, data: SubjectUpdate, *, updated_by: int
+) -> SubjectResponse:
+    subject = await repo.get_subject_by_id(db, subject_id)
+    if subject is None:
+        raise NotFoundError("Subject", subject_id)
+    changes = data.model_dump(exclude_none=True)
+    if not changes:
+        return _subject_to_response(subject)
+    async with db.begin_nested():
+        await repo.update_subject(db, subject, **changes)
+        await audit_log(
+            db,
+            entity_type="subject",
+            action=AuditAction.UPDATE,
+            user_id=updated_by,
+            entity_id=subject_id,
+            new_values=changes,
+        )
+    await db.commit()
+    refreshed = await repo.get_subject_by_id(db, subject_id)
+    if refreshed is None:
+        raise NotFoundError("Subject", subject_id)
+    return _subject_to_response(refreshed)
+
+
+async def delete_subject(
+    db: AsyncSession, subject_id: int, *, deleted_by: int
+) -> None:
+    subject = await repo.get_subject_by_id(db, subject_id)
+    if subject is None:
+        raise NotFoundError("Subject", subject_id)
+    async with db.begin_nested():
+        await repo.delete_subject(db, subject)
+        await audit_log(
+            db,
+            entity_type="subject",
+            action=AuditAction.DELETE,
+            user_id=deleted_by,
+            entity_id=subject_id,
+        )
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# AcademicYear
+# ---------------------------------------------------------------------------
+
+
+def _academic_year_to_response(a: object) -> AcademicYearResponse:
+    return AcademicYearResponse.model_validate(a)
+
+
+async def list_academic_years(
+    db: AsyncSession,
+    *,
+    page: int = 1,
+    size: int = 20,
+) -> AcademicYearListResponse:
+    years, total = await repo.list_academic_years(db, page=page, size=size)
+    return AcademicYearListResponse(
+        items=[_academic_year_to_response(a) for a in years],
+        total=total,
+        page=page,
+        size=size,
+    )
+
+
+async def get_academic_year(db: AsyncSession, year_id: int) -> AcademicYearResponse:
+    year = await repo.get_academic_year_by_id(db, year_id)
+    if year is None:
+        raise NotFoundError("AcademicYear", year_id)
+    return _academic_year_to_response(year)
+
+
+async def create_academic_year(
+    db: AsyncSession, data: AcademicYearCreate, *, created_by: int
+) -> AcademicYearResponse:
+    async with db.begin_nested():
+        year = await repo.create_academic_year(db, **data.model_dump())
+        await audit_log(
+            db,
+            entity_type="academic_year",
+            action=AuditAction.CREATE,
+            user_id=created_by,
+            entity_id=year.id,
+            new_values=data.model_dump(mode="json"),
+        )
+    await db.commit()
+    refreshed = await repo.get_academic_year_by_id(db, year.id)
+    if refreshed is None:
+        raise NotFoundError("AcademicYear", year.id)
+    return _academic_year_to_response(refreshed)
+
+
+async def update_academic_year(
+    db: AsyncSession, year_id: int, data: AcademicYearUpdate, *, updated_by: int
+) -> AcademicYearResponse:
+    year = await repo.get_academic_year_by_id(db, year_id)
+    if year is None:
+        raise NotFoundError("AcademicYear", year_id)
+    changes = data.model_dump(exclude_none=True)
+    if not changes:
+        return _academic_year_to_response(year)
+    async with db.begin_nested():
+        await repo.update_academic_year(db, year, **changes)
+        await audit_log(
+            db,
+            entity_type="academic_year",
+            action=AuditAction.UPDATE,
+            user_id=updated_by,
+            entity_id=year_id,
+            new_values=changes,
+        )
+    await db.commit()
+    refreshed = await repo.get_academic_year_by_id(db, year_id)
+    if refreshed is None:
+        raise NotFoundError("AcademicYear", year_id)
+    return _academic_year_to_response(refreshed)
+
+
+async def delete_academic_year(
+    db: AsyncSession, year_id: int, *, deleted_by: int
+) -> None:
+    year = await repo.get_academic_year_by_id(db, year_id)
+    if year is None:
+        raise NotFoundError("AcademicYear", year_id)
+    async with db.begin_nested():
+        await repo.delete_academic_year(db, year)
+        await audit_log(
+            db,
+            entity_type="academic_year",
+            action=AuditAction.DELETE,
+            user_id=deleted_by,
+            entity_id=year_id,
+        )
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Level
+# ---------------------------------------------------------------------------
+
+
+def _level_to_response(l: object) -> LevelResponse:
+    return LevelResponse.model_validate(l)
+
+
+async def list_levels(
+    db: AsyncSession,
+    *,
+    page: int = 1,
+    size: int = 20,
+) -> LevelListResponse:
+    levels, total = await repo.list_levels(db, page=page, size=size)
+    return LevelListResponse(
+        items=[_level_to_response(l) for l in levels],
+        total=total,
+        page=page,
+        size=size,
+    )
+
+
+async def get_level(db: AsyncSession, level_id: int) -> LevelResponse:
+    level = await repo.get_level_by_id(db, level_id)
+    if level is None:
+        raise NotFoundError("Level", level_id)
+    return _level_to_response(level)
+
+
+async def create_level(
+    db: AsyncSession, data: LevelCreate, *, created_by: int
+) -> LevelResponse:
+    async with db.begin_nested():
+        level = await repo.create_level(db, **data.model_dump())
+        await audit_log(
+            db,
+            entity_type="level",
+            action=AuditAction.CREATE,
+            user_id=created_by,
+            entity_id=level.id,
+            new_values=data.model_dump(),
+        )
+    await db.commit()
+    refreshed = await repo.get_level_by_id(db, level.id)
+    if refreshed is None:
+        raise NotFoundError("Level", level.id)
+    return _level_to_response(refreshed)
+
+
+async def update_level(
+    db: AsyncSession, level_id: int, data: LevelUpdate, *, updated_by: int
+) -> LevelResponse:
+    level = await repo.get_level_by_id(db, level_id)
+    if level is None:
+        raise NotFoundError("Level", level_id)
+    changes = data.model_dump(exclude_none=True)
+    if not changes:
+        return _level_to_response(level)
+    async with db.begin_nested():
+        await repo.update_level(db, level, **changes)
+        await audit_log(
+            db,
+            entity_type="level",
+            action=AuditAction.UPDATE,
+            user_id=updated_by,
+            entity_id=level_id,
+            new_values=changes,
+        )
+    await db.commit()
+    refreshed = await repo.get_level_by_id(db, level_id)
+    if refreshed is None:
+        raise NotFoundError("Level", level_id)
+    return _level_to_response(refreshed)
+
+
+async def delete_level(
+    db: AsyncSession, level_id: int, *, deleted_by: int
+) -> None:
+    level = await repo.get_level_by_id(db, level_id)
+    if level is None:
+        raise NotFoundError("Level", level_id)
+    async with db.begin_nested():
+        await repo.delete_level(db, level)
+        await audit_log(
+            db,
+            entity_type="level",
+            action=AuditAction.DELETE,
+            user_id=deleted_by,
+            entity_id=level_id,
+        )
+    await db.commit()

--- a/tests/routers/test_admin.py
+++ b/tests/routers/test_admin.py
@@ -1,0 +1,662 @@
+"""Tests des endpoints /admin (CRUD eleves, enseignants, personnel, classes, matieres, annees, niveaux)."""
+
+from datetime import UTC, date, datetime
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db
+from app.core.redis import get_redis
+from app.main import app
+from app.schemas.admin import (
+    AcademicYearListResponse,
+    AcademicYearResponse,
+    ClassListResponse,
+    ClassResponse,
+    LevelListResponse,
+    LevelResponse,
+    StaffListResponse,
+    StaffResponse,
+    StudentListResponse,
+    StudentResponse,
+    SubjectListResponse,
+    SubjectResponse,
+    TeacherListResponse,
+    TeacherResponse,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NOW = datetime.now(UTC)
+MOCK_USER = TokenData(user_id=1, tenant_id="local", email="admin@college.ci")
+
+
+def _override_deps() -> None:
+    app.dependency_overrides[get_current_user] = lambda: MOCK_USER
+    app.dependency_overrides[get_tenant_db] = lambda: AsyncMock()
+    app.dependency_overrides[get_redis] = lambda: AsyncMock()
+
+
+def _clear_deps() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_STUDENT = StudentResponse(
+    id=1,
+    first_name="Jean",
+    last_name="Kouassi",
+    birth_date=date(2010, 5, 15),
+    genre="M",
+    enrollment_number="ENR001",
+    user_id=None,
+    created_at=NOW,
+    updated_at=NOW,
+)
+
+SAMPLE_TEACHER = TeacherResponse(
+    id=1,
+    user_id=2,
+    first_name="Marie",
+    last_name="Diallo",
+    speciality="Mathematiques",
+    phone="+22507000000",
+    created_at=NOW,
+    updated_at=NOW,
+)
+
+SAMPLE_STAFF = StaffResponse(
+    id=1,
+    user_id=3,
+    first_name="Paul",
+    last_name="Kone",
+    position="Secretaire",
+    phone="+22508000000",
+    created_at=NOW,
+    updated_at=NOW,
+)
+
+SAMPLE_CLASS = ClassResponse(
+    id=1,
+    name="6eme A",
+    level_id=1,
+    series_id=None,
+    academic_year_id=1,
+    room_id=None,
+    max_students=40,
+    created_at=NOW,
+    updated_at=NOW,
+)
+
+SAMPLE_SUBJECT = SubjectResponse(
+    id=1,
+    name="Mathematiques",
+    level_id=1,
+    series_id=None,
+    coefficient=3,
+    hours_per_week=5,
+    created_at=NOW,
+    updated_at=NOW,
+)
+
+SAMPLE_ACADEMIC_YEAR = AcademicYearResponse(
+    id=1,
+    name="2024-2025",
+    start_date=date(2024, 9, 2),
+    end_date=date(2025, 7, 4),
+    is_current=True,
+    created_at=NOW,
+    updated_at=NOW,
+)
+
+SAMPLE_LEVEL = LevelResponse(
+    id=1,
+    name="6eme",
+    order=1,
+)
+
+SVC = "app.routers.admin.admin_service"
+
+
+# ---------------------------------------------------------------------------
+# Students
+# ---------------------------------------------------------------------------
+
+
+def test_list_students_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.list_students",
+            new_callable=AsyncMock,
+            return_value=StudentListResponse(items=[SAMPLE_STUDENT], total=1, page=1, size=20),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/admin/students")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["items"][0]["first_name"] == "Jean"
+
+
+def test_create_student_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.create_student",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_STUDENT,
+        ):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/admin/students",
+                    json={"first_name": "Jean", "last_name": "Kouassi"},
+                )
+    finally:
+        _clear_deps()
+    assert resp.status_code == 201
+    assert resp.json()["id"] == 1
+
+
+def test_create_student_missing_field() -> None:
+    _override_deps()
+    try:
+        with TestClient(app) as client:
+            resp = client.post("/admin/students", json={"first_name": "Jean"})
+    finally:
+        _clear_deps()
+    assert resp.status_code == 422
+
+
+def test_get_student_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.get_student",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_STUDENT,
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/admin/students/1")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 200
+    assert resp.json()["enrollment_number"] == "ENR001"
+
+
+def test_get_student_not_found() -> None:
+    from app.core.exceptions import NotFoundError
+
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.get_student",
+            new_callable=AsyncMock,
+            side_effect=NotFoundError("Student", 999),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/admin/students/999")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 404
+
+
+def test_update_student_success() -> None:
+    updated = SAMPLE_STUDENT.model_copy(update={"first_name": "Jacques"})
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.update_student",
+            new_callable=AsyncMock,
+            return_value=updated,
+        ):
+            with TestClient(app) as client:
+                resp = client.patch("/admin/students/1", json={"first_name": "Jacques"})
+    finally:
+        _clear_deps()
+    assert resp.status_code == 200
+    assert resp.json()["first_name"] == "Jacques"
+
+
+def test_delete_student_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.delete_student",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with TestClient(app) as client:
+                resp = client.delete("/admin/students/1")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 204
+
+
+def test_students_unauthenticated() -> None:
+    with TestClient(app) as client:
+        resp = client.get("/admin/students")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Teachers
+# ---------------------------------------------------------------------------
+
+
+def test_list_teachers_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.list_teachers",
+            new_callable=AsyncMock,
+            return_value=TeacherListResponse(items=[SAMPLE_TEACHER], total=1, page=1, size=20),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/admin/teachers")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 200
+    assert resp.json()["items"][0]["speciality"] == "Mathematiques"
+
+
+def test_create_teacher_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.create_teacher",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_TEACHER,
+        ):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/admin/teachers",
+                    json={"first_name": "Marie", "last_name": "Diallo", "user_id": 2},
+                )
+    finally:
+        _clear_deps()
+    assert resp.status_code == 201
+
+
+def test_get_teacher_not_found() -> None:
+    from app.core.exceptions import NotFoundError
+
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.get_teacher",
+            new_callable=AsyncMock,
+            side_effect=NotFoundError("Teacher", 999),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/admin/teachers/999")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 404
+
+
+def test_delete_teacher_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.delete_teacher",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with TestClient(app) as client:
+                resp = client.delete("/admin/teachers/1")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# Staff
+# ---------------------------------------------------------------------------
+
+
+def test_list_staff_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.list_staff",
+            new_callable=AsyncMock,
+            return_value=StaffListResponse(items=[SAMPLE_STAFF], total=1, page=1, size=20),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/admin/staff")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 200
+    assert resp.json()["items"][0]["position"] == "Secretaire"
+
+
+def test_create_staff_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.create_staff",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_STAFF,
+        ):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/admin/staff",
+                    json={"first_name": "Paul", "last_name": "Kone", "user_id": 3},
+                )
+    finally:
+        _clear_deps()
+    assert resp.status_code == 201
+
+
+def test_delete_staff_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.delete_staff",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with TestClient(app) as client:
+                resp = client.delete("/admin/staff/1")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# Classes
+# ---------------------------------------------------------------------------
+
+
+def test_list_classes_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.list_classes",
+            new_callable=AsyncMock,
+            return_value=ClassListResponse(items=[SAMPLE_CLASS], total=1, page=1, size=20),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/admin/classes")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 200
+    assert resp.json()["items"][0]["name"] == "6eme A"
+
+
+def test_list_classes_with_filters() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.list_classes",
+            new_callable=AsyncMock,
+            return_value=ClassListResponse(items=[], total=0, page=1, size=20),
+        ) as mock_list:
+            with TestClient(app) as client:
+                resp = client.get("/admin/classes?level_id=1&academic_year_id=1")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 200
+    call_kwargs = mock_list.call_args.kwargs
+    assert call_kwargs["level_id"] == 1
+    assert call_kwargs["academic_year_id"] == 1
+
+
+def test_create_class_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.create_class",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_CLASS,
+        ):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/admin/classes",
+                    json={"name": "6eme A", "level_id": 1, "academic_year_id": 1},
+                )
+    finally:
+        _clear_deps()
+    assert resp.status_code == 201
+    assert resp.json()["max_students"] == 40
+
+
+def test_delete_class_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.delete_class",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with TestClient(app) as client:
+                resp = client.delete("/admin/classes/1")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# Subjects
+# ---------------------------------------------------------------------------
+
+
+def test_list_subjects_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.list_subjects",
+            new_callable=AsyncMock,
+            return_value=SubjectListResponse(items=[SAMPLE_SUBJECT], total=1, page=1, size=20),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/admin/subjects")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 200
+    assert resp.json()["items"][0]["coefficient"] == 3
+
+
+def test_create_subject_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.create_subject",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_SUBJECT,
+        ):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/admin/subjects",
+                    json={"name": "Mathematiques", "coefficient": 3, "hours_per_week": 5},
+                )
+    finally:
+        _clear_deps()
+    assert resp.status_code == 201
+
+
+def test_create_subject_invalid_coefficient() -> None:
+    _override_deps()
+    try:
+        with TestClient(app) as client:
+            resp = client.post(
+                "/admin/subjects",
+                json={"name": "Bad", "coefficient": 0},
+            )
+    finally:
+        _clear_deps()
+    assert resp.status_code == 422
+
+
+def test_delete_subject_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.delete_subject",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with TestClient(app) as client:
+                resp = client.delete("/admin/subjects/1")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# Academic Years
+# ---------------------------------------------------------------------------
+
+
+def test_list_academic_years_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.list_academic_years",
+            new_callable=AsyncMock,
+            return_value=AcademicYearListResponse(
+                items=[SAMPLE_ACADEMIC_YEAR], total=1, page=1, size=20
+            ),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/admin/academic-years")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 200
+    assert resp.json()["items"][0]["name"] == "2024-2025"
+
+
+def test_create_academic_year_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.create_academic_year",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_ACADEMIC_YEAR,
+        ):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/admin/academic-years",
+                    json={
+                        "name": "2024-2025",
+                        "start_date": "2024-09-02",
+                        "end_date": "2025-07-04",
+                        "is_current": True,
+                    },
+                )
+    finally:
+        _clear_deps()
+    assert resp.status_code == 201
+    assert resp.json()["is_current"] is True
+
+
+def test_create_academic_year_invalid_dates() -> None:
+    _override_deps()
+    try:
+        with TestClient(app) as client:
+            resp = client.post(
+                "/admin/academic-years",
+                json={
+                    "name": "bad",
+                    "start_date": "2025-09-01",
+                    "end_date": "2024-07-01",
+                },
+            )
+    finally:
+        _clear_deps()
+    assert resp.status_code == 422
+
+
+def test_delete_academic_year_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.delete_academic_year",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with TestClient(app) as client:
+                resp = client.delete("/admin/academic-years/1")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# Levels
+# ---------------------------------------------------------------------------
+
+
+def test_list_levels_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.list_levels",
+            new_callable=AsyncMock,
+            return_value=LevelListResponse(items=[SAMPLE_LEVEL], total=1, page=1, size=20),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/admin/levels")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 200
+    assert resp.json()["items"][0]["name"] == "6eme"
+
+
+def test_create_level_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.create_level",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_LEVEL,
+        ):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/admin/levels",
+                    json={"name": "6eme", "order": 1},
+                )
+    finally:
+        _clear_deps()
+    assert resp.status_code == 201
+    assert resp.json()["order"] == 1
+
+
+def test_delete_level_success() -> None:
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.delete_level",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with TestClient(app) as client:
+                resp = client.delete("/admin/levels/1")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 204
+
+
+def test_get_level_not_found() -> None:
+    from app.core.exceptions import NotFoundError
+
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.get_level",
+            new_callable=AsyncMock,
+            side_effect=NotFoundError("Level", 999),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/admin/levels/999")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
Closes #29

CRUD complet pour les 7 entités de base — 35 endpoints au total (5 par entité).

### Endpoints créés

| Préfixe | Entité | Permissions |
|---------|--------|-------------|
| `/admin/students` | Student | `admin:students:{read,create,update,delete}` |
| `/admin/teachers` | TeacherProfile | `admin:teachers:{read,create,update,delete}` |
| `/admin/staff` | StaffProfile | `admin:staff:{read,create,update,delete}` |
| `/admin/classes` | Class | `admin:classes:{read,create,update,delete}` |
| `/admin/subjects` | Subject | `admin:subjects:{read,create,update,delete}` |
| `/admin/academic-years` | AcademicYear | `admin:academic-years:{read,create,update,delete}` |
| `/admin/levels` | Level | `admin:levels:{read,create,update,delete}` |

### Architecture
- `app/schemas/admin.py` — 334 lignes, Pydantic v2 (Create/Update/Response/ListResponse × 7)
- `app/repositories/admin_repository.py` — 356 lignes, SQLAlchemy 2.0 async
- `app/services/admin_service.py` — 714 lignes, logique métier + audit log
- `app/routers/admin.py` — 485 lignes, router unique préfixé `/admin`
- `tests/routers/test_admin.py` — 662 lignes, 34 tests

## Test plan
- [ ] `pytest tests/routers/test_admin.py -v`
- [ ] Verify 401 on unauthenticated requests
- [ ] Verify 422 on invalid input (bad genre, negative coefficient, etc.)
- [ ] Verify audit logs on mutations