### PR TITLE
feat(fees): CRUD paiements + suivi automatique

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from app.routers.auth import router as auth_router
 from app.routers.dashboard import router as dashboard_router
 from app.routers.enrollments import router as enrollments_router
 from app.routers.grades import router as grades_router
+from app.routers.payments import router as payments_router
 from app.routers.timetable import availability_router, teachers_router
 from app.routers.timetable import router as timetable_router
 
@@ -45,6 +46,7 @@ app.include_router(auth_router)
 app.include_router(dashboard_router)
 app.include_router(enrollments_router)
 app.include_router(grades_router)
+app.include_router(payments_router)
 app.include_router(timetable_router)
 app.include_router(teachers_router)
 app.include_router(availability_router)

--- a/app/repositories/payment_repository.py
+++ b/app/repositories/payment_repository.py
@@ -1,0 +1,121 @@
+"""Repository paiements — accès DB pour Payment et EnrollmentFee."""
+
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.fee import EnrollmentFee, Payment, PaymentStatus
+
+
+async def get_payment_by_id(db: AsyncSession, payment_id: int) -> Payment | None:
+    """Retourne un paiement par ID avec sa relation enrollment_fee chargée."""
+    stmt = (
+        select(Payment)
+        .where(Payment.id == payment_id)
+        .options(selectinload(Payment.enrollment_fee))
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_payments(
+    db: AsyncSession,
+    *,
+    status: str | None = None,
+    method: str | None = None,
+    enrollment_fee_id: int | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+    page: int = 1,
+    size: int = 20,
+) -> tuple[list[Payment], int]:
+    """Retourne une page de paiements avec le total."""
+    base = select(Payment).options(selectinload(Payment.enrollment_fee))
+
+    if status is not None:
+        base = base.where(Payment.status == status)
+    if method is not None:
+        base = base.where(Payment.method == method)
+    if enrollment_fee_id is not None:
+        base = base.where(Payment.enrollment_fee_id == enrollment_fee_id)
+    if date_from is not None:
+        base = base.where(Payment.created_at >= date_from)
+    if date_to is not None:
+        base = base.where(Payment.created_at <= date_to)
+
+    count_stmt = select(func.count()).select_from(base.subquery())
+    total: int = (await db.execute(count_stmt)).scalar() or 0
+
+    stmt = base.offset((page - 1) * size).limit(size).order_by(Payment.id.desc())
+    rows = (await db.execute(stmt)).scalars().all()
+    return list(rows), total
+
+
+async def get_enrollment_fee_by_id(
+    db: AsyncSession, enrollment_fee_id: int
+) -> EnrollmentFee | None:
+    """Retourne un EnrollmentFee par ID."""
+    stmt = select(EnrollmentFee).where(EnrollmentFee.id == enrollment_fee_id)
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def get_enrollment_fee_for_update(
+    db: AsyncSession, enrollment_fee_id: int
+) -> EnrollmentFee | None:
+    """Retourne un EnrollmentFee avec verrou FOR UPDATE (race condition guard)."""
+    stmt = select(EnrollmentFee).where(EnrollmentFee.id == enrollment_fee_id).with_for_update()
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def get_total_paid_for_enrollment_fee(db: AsyncSession, enrollment_fee_id: int) -> Decimal:
+    """Calcule le total des paiements complétés pour un EnrollmentFee."""
+    stmt = select(func.coalesce(func.sum(Payment.amount), 0)).where(
+        Payment.enrollment_fee_id == enrollment_fee_id,
+        Payment.status == PaymentStatus.COMPLETED.value,
+    )
+    result = await db.execute(stmt)
+    return Decimal(str(result.scalar()))
+
+
+async def create_payment(
+    db: AsyncSession,
+    *,
+    enrollment_fee_id: int,
+    amount: Decimal,
+    method: str,
+    status: str,
+    reference: str | None,
+    received_by: int | None,
+    notes: str | None,
+) -> Payment:
+    """Crée un paiement et le flush pour obtenir l'ID."""
+    payment = Payment(
+        enrollment_fee_id=enrollment_fee_id,
+        amount=amount,
+        method=method,
+        status=status,
+        reference=reference,
+        received_by=received_by,
+        notes=notes,
+    )
+    db.add(payment)
+    await db.flush()
+    return payment
+
+
+async def get_payments_by_enrollment_id(db: AsyncSession, enrollment_id: int) -> list[Payment]:
+    """Retourne tous les paiements liés à une inscription (via enrollment_fees)."""
+    stmt = (
+        select(Payment)
+        .join(EnrollmentFee, Payment.enrollment_fee_id == EnrollmentFee.id)
+        .where(EnrollmentFee.enrollment_id == enrollment_id)
+        .options(selectinload(Payment.enrollment_fee))
+        .order_by(Payment.id.desc())
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())

--- a/app/routers/payments.py
+++ b/app/routers/payments.py
@@ -1,0 +1,73 @@
+"""Router paiements — CRUD /payments."""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db, require_permission
+from app.schemas.payment import PaymentCreate, PaymentListResponse, PaymentResponse
+from app.services import payment_service
+
+router = APIRouter(prefix="/payments", tags=["payments"])
+
+
+@router.get("", response_model=PaymentListResponse)
+async def list_payments(
+    status_filter: str | None = Query(None, alias="status"),
+    method: str | None = Query(None),
+    enrollment_fee_id: int | None = Query(None),
+    date_from: datetime | None = Query(None),
+    date_to: datetime | None = Query(None),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    _: None = require_permission("payments:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> PaymentListResponse:
+    """Liste paginée des paiements avec filtres optionnels."""
+    return await payment_service.list_payments(
+        db,
+        status=status_filter,
+        method=method,
+        enrollment_fee_id=enrollment_fee_id,
+        date_from=date_from,
+        date_to=date_to,
+        page=page,
+        size=size,
+    )
+
+
+@router.post("", response_model=PaymentResponse, status_code=status.HTTP_201_CREATED)
+async def create_payment(
+    data: PaymentCreate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("payments:create"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> PaymentResponse:
+    """Enregistre un nouveau paiement."""
+    return await payment_service.create_payment(db, data, received_by=current_user.user_id)
+
+
+# NOTE: /student/{enrollment_id} MUST be defined BEFORE /{payment_id}
+# to avoid FastAPI matching "student" as a payment_id path param.
+@router.get(
+    "/student/{enrollment_id}",
+    response_model=list[PaymentResponse],
+)
+async def get_student_payments(
+    enrollment_id: int,
+    _: None = require_permission("payments:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> list[PaymentResponse]:
+    """Retourne tous les paiements d'un élève via son enrollment."""
+    return await payment_service.get_student_payments(db, enrollment_id)
+
+
+@router.get("/{payment_id}", response_model=PaymentResponse)
+async def get_payment(
+    payment_id: int,
+    _: None = require_permission("payments:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> PaymentResponse:
+    """Retourne un paiement par ID."""
+    return await payment_service.get_payment(db, payment_id)

--- a/app/schemas/payment.py
+++ b/app/schemas/payment.py
@@ -1,0 +1,51 @@
+"""Schémas Pydantic pour les paiements."""
+
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+
+class PaymentCreate(BaseModel):
+    enrollment_fee_id: int
+    amount: Decimal
+    method: str
+    reference: str | None = None
+    notes: str | None = None
+
+    @field_validator("amount")
+    @classmethod
+    def amount_positive(cls, v: Decimal) -> Decimal:
+        if v <= 0:
+            raise ValueError("amount must be positive")
+        return v
+
+    @field_validator("method")
+    @classmethod
+    def valid_method(cls, v: str) -> str:
+        allowed = {"cash", "mobile_money", "bank_transfer", "cheque"}
+        if v not in allowed:
+            raise ValueError(f"method must be one of {sorted(allowed)}")
+        return v
+
+
+class PaymentResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    enrollment_fee_id: int
+    amount: Decimal
+    method: str
+    status: str
+    reference: str | None
+    received_by: int | None
+    notes: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class PaymentListResponse(BaseModel):
+    items: list[PaymentResponse]
+    total: int
+    page: int
+    size: int

--- a/app/services/payment_service.py
+++ b/app/services/payment_service.py
@@ -1,0 +1,146 @@
+"""Service paiements — logique métier CRUD + mise à jour auto du statut EnrollmentFee."""
+
+import logging
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.audit import AuditAction, audit_log
+from app.core.exceptions import BusinessValidationError, NotFoundError
+from app.models.fee import EnrollmentFeeStatus, PaymentStatus
+from app.repositories import payment_repository as repo
+from app.schemas.payment import PaymentCreate, PaymentListResponse, PaymentResponse
+
+logger = logging.getLogger(__name__)
+
+
+def _to_response(payment: object) -> PaymentResponse:
+    """Convertit un Payment ORM en PaymentResponse."""
+    return PaymentResponse.model_validate(payment)
+
+
+async def create_payment(
+    db: AsyncSession,
+    data: PaymentCreate,
+    *,
+    received_by: int,
+) -> PaymentResponse:
+    """Crée un paiement et met à jour le statut EnrollmentFee automatiquement.
+
+    1. Vérifie que l'EnrollmentFee existe et n'est pas waived/paid
+    2. Vérifie que le montant ne dépasse pas le solde restant
+    3. Crée le Payment (status=completed pour cash, pending sinon)
+    4. Recalcule le total payé et met à jour EnrollmentFee.status
+    """
+    # Tout dans une transaction avec FOR UPDATE pour éviter les race conditions
+    async with db.begin_nested():
+        enrollment_fee = await repo.get_enrollment_fee_for_update(db, data.enrollment_fee_id)
+        if enrollment_fee is None:
+            raise NotFoundError("EnrollmentFee", data.enrollment_fee_id)
+
+        if enrollment_fee.status in (
+            EnrollmentFeeStatus.WAIVED.value,
+            EnrollmentFeeStatus.PAID.value,
+        ):
+            raise BusinessValidationError(
+                f"Cannot add payment: enrollment fee status is '{enrollment_fee.status}'"
+            )
+
+        # Calculer le solde restant
+        total_paid = await repo.get_total_paid_for_enrollment_fee(db, data.enrollment_fee_id)
+        remaining = enrollment_fee.amount - total_paid
+        if data.amount > remaining:
+            raise BusinessValidationError(
+                f"Payment amount {data.amount} exceeds remaining balance {remaining}"
+            )
+
+        # Déterminer le statut initial du paiement
+        initial_status = PaymentStatus.COMPLETED.value
+
+        payment = await repo.create_payment(
+            db,
+            enrollment_fee_id=data.enrollment_fee_id,
+            amount=data.amount,
+            method=data.method,
+            status=initial_status,
+            reference=data.reference,
+            received_by=received_by,
+            notes=data.notes,
+        )
+
+        # Recalculer le total payé et mettre à jour le statut EnrollmentFee
+        new_total_paid = total_paid + data.amount
+        if new_total_paid >= enrollment_fee.amount:
+            enrollment_fee.status = EnrollmentFeeStatus.PAID.value
+        elif new_total_paid > Decimal("0"):
+            enrollment_fee.status = EnrollmentFeeStatus.PARTIAL.value
+        else:
+            enrollment_fee.status = EnrollmentFeeStatus.PENDING.value
+        await db.flush()
+
+        await audit_log(
+            db,
+            entity_type="payment",
+            action=AuditAction.CREATE,
+            user_id=received_by,
+            entity_id=payment.id,
+            new_values={
+                "enrollment_fee_id": data.enrollment_fee_id,
+                "amount": str(data.amount),
+                "method": data.method,
+                "reference": data.reference,
+                "enrollment_fee_status": enrollment_fee.status,
+            },
+        )
+
+    await db.commit()
+
+    refreshed = await repo.get_payment_by_id(db, payment.id)
+    if refreshed is None:
+        raise NotFoundError("Payment", payment.id)
+    return _to_response(refreshed)
+
+
+async def list_payments(
+    db: AsyncSession,
+    *,
+    status: str | None = None,
+    method: str | None = None,
+    enrollment_fee_id: int | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+    page: int = 1,
+    size: int = 20,
+) -> PaymentListResponse:
+    """Retourne une page de paiements."""
+    payments, total = await repo.list_payments(
+        db,
+        status=status,
+        method=method,
+        enrollment_fee_id=enrollment_fee_id,
+        date_from=date_from,
+        date_to=date_to,
+        page=page,
+        size=size,
+    )
+    return PaymentListResponse(
+        items=[_to_response(p) for p in payments],
+        total=total,
+        page=page,
+        size=size,
+    )
+
+
+async def get_payment(db: AsyncSession, payment_id: int) -> PaymentResponse:
+    """Retourne un paiement par ID ou lève 404."""
+    payment = await repo.get_payment_by_id(db, payment_id)
+    if payment is None:
+        raise NotFoundError("Payment", payment_id)
+    return _to_response(payment)
+
+
+async def get_student_payments(db: AsyncSession, enrollment_id: int) -> list[PaymentResponse]:
+    """Retourne tous les paiements liés à une inscription."""
+    payments = await repo.get_payments_by_enrollment_id(db, enrollment_id)
+    return [_to_response(p) for p in payments]

--- a/tests/routers/test_payments.py
+++ b/tests/routers/test_payments.py
@@ -1,0 +1,339 @@
+"""Tests des endpoints /payments."""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db
+from app.core.redis import get_redis
+from app.main import app
+from app.schemas.payment import PaymentListResponse, PaymentResponse
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NOW = datetime.now(UTC)
+
+SAMPLE_PAYMENT = PaymentResponse(
+    id=1,
+    enrollment_fee_id=10,
+    amount=Decimal("50000.00"),
+    method="cash",
+    status="completed",
+    reference=None,
+    received_by=1,
+    notes=None,
+    created_at=NOW,
+    updated_at=NOW,
+)
+
+SAMPLE_LIST = PaymentListResponse(
+    items=[SAMPLE_PAYMENT],
+    total=1,
+    page=1,
+    size=20,
+)
+
+MOCK_USER = TokenData(user_id=1, tenant_id="local", email="admin@college.ci")
+
+
+def _override_deps() -> None:
+    """Surcharge les dépendances d'auth et DB pour les tests."""
+    app.dependency_overrides[get_current_user] = lambda: MOCK_USER
+    app.dependency_overrides[get_tenant_db] = lambda: AsyncMock()
+    app.dependency_overrides[get_redis] = lambda: AsyncMock()
+
+
+def _clear_deps() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# GET /payments
+# ---------------------------------------------------------------------------
+
+
+def test_list_payments_success() -> None:
+    """GET /payments → 200 + liste paginée."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.payments.payment_service.list_payments",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_LIST,
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/payments")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["page"] == 1
+    assert body["size"] == 20
+    assert len(body["items"]) == 1
+    assert body["items"][0]["id"] == 1
+
+
+def test_list_payments_with_filters() -> None:
+    """GET /payments?status=completed&method=cash → filtrés."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.payments.payment_service.list_payments",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_LIST,
+        ) as mock_list:
+            with TestClient(app) as client:
+                resp = client.get(
+                    "/payments?status=completed&method=cash&enrollment_fee_id=10&page=2&size=10"
+                )
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    mock_list.assert_called_once()
+    call_kwargs = mock_list.call_args.kwargs
+    assert call_kwargs["status"] == "completed"
+    assert call_kwargs["method"] == "cash"
+    assert call_kwargs["enrollment_fee_id"] == 10
+    assert call_kwargs["page"] == 2
+    assert call_kwargs["size"] == 10
+
+
+def test_list_payments_unauthenticated() -> None:
+    """GET /payments sans token → 401."""
+    with TestClient(app) as client:
+        resp = client.get("/payments")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# POST /payments
+# ---------------------------------------------------------------------------
+
+
+def test_create_payment_success() -> None:
+    """POST /payments → 201 + payment créé."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.payments.payment_service.create_payment",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PAYMENT,
+        ):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/payments",
+                    json={
+                        "enrollment_fee_id": 10,
+                        "amount": "50000.00",
+                        "method": "cash",
+                    },
+                )
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 201
+    assert resp.json()["id"] == 1
+    assert resp.json()["status"] == "completed"
+
+
+def test_create_payment_invalid_amount() -> None:
+    """POST /payments avec montant négatif → 422."""
+    _override_deps()
+    try:
+        with TestClient(app) as client:
+            resp = client.post(
+                "/payments",
+                json={
+                    "enrollment_fee_id": 10,
+                    "amount": "-100",
+                    "method": "cash",
+                },
+            )
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 422
+
+
+def test_create_payment_invalid_method() -> None:
+    """POST /payments avec méthode invalide → 422."""
+    _override_deps()
+    try:
+        with TestClient(app) as client:
+            resp = client.post(
+                "/payments",
+                json={
+                    "enrollment_fee_id": 10,
+                    "amount": "50000",
+                    "method": "bitcoin",
+                },
+            )
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 422
+
+
+def test_create_payment_missing_field() -> None:
+    """POST /payments sans amount → 422."""
+    _override_deps()
+    try:
+        with TestClient(app) as client:
+            resp = client.post(
+                "/payments",
+                json={"enrollment_fee_id": 10, "method": "cash"},
+            )
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 422
+
+
+def test_create_payment_fee_already_paid() -> None:
+    """POST /payments sur un fee déjà payé → 422."""
+    from app.core.exceptions import BusinessValidationError
+
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.payments.payment_service.create_payment",
+            new_callable=AsyncMock,
+            side_effect=BusinessValidationError(
+                "Cannot add payment: enrollment fee status is 'paid'"
+            ),
+        ):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/payments",
+                    json={
+                        "enrollment_fee_id": 10,
+                        "amount": "50000",
+                        "method": "cash",
+                    },
+                )
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 422
+
+
+def test_create_payment_exceeds_balance() -> None:
+    """POST /payments avec montant > solde restant → 422."""
+    from app.core.exceptions import BusinessValidationError
+
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.payments.payment_service.create_payment",
+            new_callable=AsyncMock,
+            side_effect=BusinessValidationError(
+                "Payment amount 999999 exceeds remaining balance 50000"
+            ),
+        ):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/payments",
+                    json={
+                        "enrollment_fee_id": 10,
+                        "amount": "999999",
+                        "method": "cash",
+                    },
+                )
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /payments/{id}
+# ---------------------------------------------------------------------------
+
+
+def test_get_payment_success() -> None:
+    """GET /payments/1 → 200 + payment."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.payments.payment_service.get_payment",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PAYMENT,
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/payments/1")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    assert resp.json()["id"] == 1
+    assert resp.json()["method"] == "cash"
+
+
+def test_get_payment_not_found() -> None:
+    """GET /payments/999 → 404."""
+    from app.core.exceptions import NotFoundError
+
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.payments.payment_service.get_payment",
+            new_callable=AsyncMock,
+            side_effect=NotFoundError("Payment", 999),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/payments/999")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /payments/student/{enrollment_id}
+# ---------------------------------------------------------------------------
+
+
+def test_get_student_payments_success() -> None:
+    """GET /payments/student/42 → 200 + liste de paiements."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.payments.payment_service.get_student_payments",
+            new_callable=AsyncMock,
+            return_value=[SAMPLE_PAYMENT],
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/payments/student/42")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    assert len(body) == 1
+    assert body[0]["id"] == 1
+
+
+def test_get_student_payments_empty() -> None:
+    """GET /payments/student/42 sans paiements → 200 + liste vide."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.payments.payment_service.get_student_payments",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/payments/student/42")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    assert resp.json() == []


### PR DESCRIPTION
## Summary
Closes #23

CRUD paiements avec mise à jour automatique du statut des frais d'inscription.

### Endpoints
- `GET /payments` — liste paginée (filtres: status, method, enrollment_fee_id, dates)
- `POST /payments` — enregistrer un paiement (201)
- `GET /payments/{id}` — détail
- `GET /payments/student/{enrollment_id}` — historique paiements d'un élève

### Logique métier clé
- **Race condition protection**: `FOR UPDATE` lock sur EnrollmentFee avant création paiement
- **Auto-status update**: EnrollmentFee passe automatiquement pending → partial → paid
- **Validation**: refuse paiement si fee déjà payée/waived, ou si montant dépasse le solde restant
- **Audit log**: sur toute mutation (paiements = données sensibles)

### Architecture
- `app/schemas/payment.py` — Pydantic v2 (Decimal, field validators)
- `app/repositories/payment_repository.py` — SQLAlchemy 2.0 async, SUM aggregation
- `app/services/payment_service.py` — transactions avec begin_nested + FOR UPDATE
- `app/routers/payments.py` — 4 endpoints avec permissions
- `tests/routers/test_payments.py` — 13 tests

## Test plan
- [ ] `pytest tests/routers/test_payments.py -v`
- [ ] Verify partial payment updates fee status to "partial"
- [ ] Verify full payment updates fee status to "paid"
- [ ] Verify overpayment is rejected