### PR TITLE
feat(attendance): CRUD présences avec stats

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
 from app.core.exceptions import register_exception_handlers
 from app.core.middleware import TenantMiddleware
+from app.routers.attendance import router as attendance_router
 from app.routers.auth import router as auth_router
 from app.routers.dashboard import router as dashboard_router
 from app.routers.enrollments import router as enrollments_router
@@ -42,6 +43,7 @@ register_exception_handlers(app)
 
 # --- Routers ---
 app.include_router(auth_router)
+app.include_router(attendance_router)
 app.include_router(dashboard_router)
 app.include_router(enrollments_router)
 app.include_router(grades_router)

--- a/app/repositories/attendance_repository.py
+++ b/app/repositories/attendance_repository.py
@@ -1,0 +1,176 @@
+"""Repository presences — acces DB pour AttendanceContext et AttendanceRecord."""
+
+from datetime import date
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.academic import AcademicYear
+from app.models.attendance import AttendanceContext, AttendanceRecord
+from app.models.user import Student
+
+
+async def get_session_by_id(db: AsyncSession, session_id: int) -> AttendanceContext | None:
+    """Retourne une session de pointage par ID avec ses records charges."""
+    stmt = (
+        select(AttendanceContext)
+        .where(AttendanceContext.id == session_id)
+        .options(selectinload(AttendanceContext.records))
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def get_academic_year_by_id(db: AsyncSession, academic_year_id: int) -> AcademicYear | None:
+    """Retourne une annee scolaire par ID."""
+    stmt = select(AcademicYear).where(AcademicYear.id == academic_year_id)
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def create_context(
+    db: AsyncSession,
+    *,
+    entity_type: str,
+    context_id: int,
+    date_val: date,
+    academic_year_id: int,
+) -> AttendanceContext:
+    """Cree un AttendanceContext et flush pour obtenir l'ID."""
+    context = AttendanceContext(
+        entity_type=entity_type,
+        context_id=context_id,
+        date=date_val,
+        academic_year_id=academic_year_id,
+    )
+    db.add(context)
+    await db.flush()
+    return context
+
+
+async def create_record(
+    db: AsyncSession,
+    *,
+    context_id: int,
+    student_id: int,
+    status: str,
+    time_in: object = None,
+    source: str = "manual",
+    notes: str | None = None,
+) -> AttendanceRecord:
+    """Cree un AttendanceRecord et flush."""
+    record = AttendanceRecord(
+        context_id=context_id,
+        student_id=student_id,
+        status=status,
+        time_in=time_in,
+        source=source,
+        notes=notes,
+    )
+    db.add(record)
+    await db.flush()
+    return record
+
+
+async def get_record_by_context_and_student(
+    db: AsyncSession, context_id: int, student_id: int
+) -> AttendanceRecord | None:
+    """Retourne un record pour un contexte et un eleve donnes."""
+    stmt = select(AttendanceRecord).where(
+        AttendanceRecord.context_id == context_id,
+        AttendanceRecord.student_id == student_id,
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def update_record(
+    db: AsyncSession,
+    record: AttendanceRecord,
+    *,
+    status: str,
+    time_in: object = None,
+    notes: str | None = None,
+) -> AttendanceRecord:
+    """Met a jour un record de presence."""
+    record.status = status
+    if time_in is not None:
+        record.time_in = time_in
+    if notes is not None:
+        record.notes = notes
+    await db.flush()
+    return record
+
+
+async def list_records_for_student(
+    db: AsyncSession,
+    student_id: int,
+    *,
+    status: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
+    page: int = 1,
+    size: int = 20,
+) -> tuple[list[AttendanceRecord], int]:
+    """Retourne les records de presence pour un eleve avec pagination."""
+    base = (
+        select(AttendanceRecord)
+        .join(AttendanceContext, AttendanceRecord.context_id == AttendanceContext.id)
+        .where(AttendanceRecord.student_id == student_id)
+    )
+
+    if status is not None:
+        base = base.where(AttendanceRecord.status == status)
+    if date_from is not None:
+        base = base.where(AttendanceContext.date >= date_from)
+    if date_to is not None:
+        base = base.where(AttendanceContext.date <= date_to)
+
+    count_stmt = select(func.count()).select_from(base.subquery())
+    total: int = (await db.execute(count_stmt)).scalar() or 0
+
+    stmt = base.offset((page - 1) * size).limit(size).order_by(AttendanceRecord.id.desc())
+    rows = (await db.execute(stmt)).scalars().all()
+    return list(rows), total
+
+
+async def get_class_sessions(
+    db: AsyncSession,
+    class_id: int,
+    *,
+    academic_year_id: int | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
+) -> list[AttendanceContext]:
+    """Retourne les sessions de pointage pour une classe."""
+    base = (
+        select(AttendanceContext)
+        .where(
+            AttendanceContext.entity_type == "class",
+            AttendanceContext.context_id == class_id,
+        )
+        .options(selectinload(AttendanceContext.records))
+    )
+
+    if academic_year_id is not None:
+        base = base.where(AttendanceContext.academic_year_id == academic_year_id)
+    if date_from is not None:
+        base = base.where(AttendanceContext.date >= date_from)
+    if date_to is not None:
+        base = base.where(AttendanceContext.date <= date_to)
+
+    result = await db.execute(base.order_by(AttendanceContext.date.desc()))
+    return list(result.scalars().all())
+
+
+async def get_students_for_class_stats(
+    db: AsyncSession, student_ids: set[int]
+) -> dict[int, Student]:
+    """Retourne les objets Student pour un ensemble d'IDs."""
+    if not student_ids:
+        return {}
+    stmt = select(Student).where(Student.id.in_(student_ids))
+    result = await db.execute(stmt)
+    students = result.scalars().all()
+    return {s.id: s for s in students}

--- a/app/routers/attendance.py
+++ b/app/routers/attendance.py
@@ -1,0 +1,85 @@
+"""Router presences — CRUD /attendance."""
+
+from datetime import date
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db, require_permission
+from app.schemas.attendance import (
+    ClassAttendanceStats,
+    SessionCreate,
+    SessionResponse,
+    SessionUpdate,
+    StudentAttendanceResponse,
+)
+from app.services import attendance_service
+
+router = APIRouter(prefix="/attendance", tags=["attendance"])
+
+
+@router.post("/sessions", response_model=SessionResponse, status_code=status.HTTP_201_CREATED)
+async def create_session(
+    data: SessionCreate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("attendance:create"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> SessionResponse:
+    """Cree une session de pointage avec les records pour tous les eleves."""
+    return await attendance_service.create_session(db, data, created_by=current_user.user_id)
+
+
+@router.patch("/sessions/{session_id}", response_model=SessionResponse)
+async def update_session(
+    session_id: int,
+    data: SessionUpdate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("attendance:update"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> SessionResponse:
+    """Met a jour les records d'une session de pointage."""
+    return await attendance_service.update_session(
+        db, session_id, data, updated_by=current_user.user_id
+    )
+
+
+@router.get("/student/{student_id}", response_model=StudentAttendanceResponse)
+async def get_student_attendance(
+    student_id: int,
+    status_filter: str | None = Query(None, alias="status"),
+    date_from: date | None = Query(None),
+    date_to: date | None = Query(None),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    _: None = require_permission("attendance:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> StudentAttendanceResponse:
+    """Retourne l'historique de presence d'un eleve avec pagination."""
+    return await attendance_service.get_student_attendance(
+        db,
+        student_id,
+        status=status_filter,
+        date_from=date_from,
+        date_to=date_to,
+        page=page,
+        size=size,
+    )
+
+
+@router.get("/class/{class_id}/stats", response_model=ClassAttendanceStats)
+async def get_class_stats(
+    class_id: int,
+    academic_year_id: int | None = Query(None),
+    date_from: date | None = Query(None),
+    date_to: date | None = Query(None),
+    _: None = require_permission("attendance:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> ClassAttendanceStats:
+    """Retourne les statistiques de presence pour une classe."""
+    return await attendance_service.get_class_stats(
+        db,
+        class_id,
+        academic_year_id=academic_year_id,
+        date_from=date_from,
+        date_to=date_to,
+    )

--- a/app/schemas/attendance.py
+++ b/app/schemas/attendance.py
@@ -1,0 +1,116 @@
+"""Schemas Pydantic pour les presences."""
+
+from datetime import date, datetime, time
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+
+class AttendanceRecordInput(BaseModel):
+    """Single student attendance record in a session."""
+
+    student_id: int
+    status: str  # present, absent, late, excused
+    time_in: time | None = None
+    notes: str | None = None
+
+    @field_validator("status")
+    @classmethod
+    def valid_status(cls, v: str) -> str:
+        allowed = {"present", "absent", "late", "excused"}
+        if v not in allowed:
+            raise ValueError(f"status must be one of {sorted(allowed)}")
+        return v
+
+    @field_validator("student_id")
+    @classmethod
+    def must_be_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("must be a positive integer")
+        return v
+
+
+class SessionCreate(BaseModel):
+    """Create attendance session with records for all students."""
+
+    entity_type: str  # "class" or "exam"
+    context_id: int  # class_id or exam_id
+    date: date
+    academic_year_id: int
+    records: list[AttendanceRecordInput]
+
+    @field_validator("entity_type")
+    @classmethod
+    def valid_entity_type(cls, v: str) -> str:
+        allowed = {"class", "exam"}
+        if v not in allowed:
+            raise ValueError(f"entity_type must be one of {sorted(allowed)}")
+        return v
+
+    @field_validator("context_id", "academic_year_id")
+    @classmethod
+    def must_be_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("must be a positive integer")
+        return v
+
+
+class SessionUpdate(BaseModel):
+    """Update attendance records in a session."""
+
+    records: list[AttendanceRecordInput]
+
+
+class AttendanceRecordResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    student_id: int
+    status: str
+    time_in: time | None
+    time_out: time | None
+    source: str
+    notes: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class SessionResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    entity_type: str
+    context_id: int
+    date: date
+    academic_year_id: int
+    records: list[AttendanceRecordResponse]
+    created_at: datetime
+    updated_at: datetime
+
+
+class StudentAttendanceResponse(BaseModel):
+    """Paginated attendance history for a student."""
+
+    items: list[AttendanceRecordResponse]
+    total: int
+    page: int
+    size: int
+
+
+class StudentAttendanceSummary(BaseModel):
+    student_id: int
+    first_name: str
+    last_name: str
+    present_count: int
+    absent_count: int
+    late_count: int
+    excused_count: int
+    attendance_rate: float
+
+
+class ClassAttendanceStats(BaseModel):
+    """Stats for a class: attendance rate, absences per student."""
+
+    class_id: int
+    total_sessions: int
+    attendance_rate: float  # percentage
+    students: list[StudentAttendanceSummary]

--- a/app/services/attendance_service.py
+++ b/app/services/attendance_service.py
@@ -1,0 +1,246 @@
+"""Service presences — logique metier CRUD + stats."""
+
+import logging
+from collections import defaultdict
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.audit import AuditAction, audit_log
+from app.core.exceptions import BusinessValidationError, NotFoundError
+from app.models.attendance import AttendanceStatus
+from app.repositories import attendance_repository as repo
+from app.schemas.attendance import (
+    AttendanceRecordResponse,
+    ClassAttendanceStats,
+    SessionCreate,
+    SessionResponse,
+    SessionUpdate,
+    StudentAttendanceResponse,
+    StudentAttendanceSummary,
+)
+
+logger = logging.getLogger(__name__)
+
+_VALID_STATUSES = {s.value for s in AttendanceStatus}
+
+
+def _record_to_response(record: object) -> AttendanceRecordResponse:
+    """Convertit un AttendanceRecord ORM en AttendanceRecordResponse."""
+    return AttendanceRecordResponse.model_validate(record)
+
+
+def _session_to_response(context: object) -> SessionResponse:
+    """Convertit un AttendanceContext ORM en SessionResponse."""
+    return SessionResponse.model_validate(context)
+
+
+async def create_session(
+    db: AsyncSession,
+    data: SessionCreate,
+    created_by: int,
+) -> SessionResponse:
+    """Cree une session de pointage avec les records pour tous les eleves."""
+    # Valider que l'annee scolaire existe
+    academic_year = await repo.get_academic_year_by_id(db, data.academic_year_id)
+    if academic_year is None:
+        raise BusinessValidationError(f"AcademicYear {data.academic_year_id} not found")
+
+    async with db.begin_nested():
+        # Creer le contexte
+        context = await repo.create_context(
+            db,
+            entity_type=data.entity_type,
+            context_id=data.context_id,
+            date_val=data.date,
+            academic_year_id=data.academic_year_id,
+        )
+
+        # Creer un record par eleve
+        for rec in data.records:
+            await repo.create_record(
+                db,
+                context_id=context.id,
+                student_id=rec.student_id,
+                status=rec.status,
+                time_in=rec.time_in,
+                notes=rec.notes,
+            )
+
+        await audit_log(
+            db,
+            entity_type="attendance_session",
+            action=AuditAction.CREATE,
+            user_id=created_by,
+            entity_id=context.id,
+            new_values=data.model_dump(mode="json"),
+        )
+
+    await db.commit()
+
+    refreshed = await repo.get_session_by_id(db, context.id)
+    if refreshed is None:
+        raise NotFoundError("AttendanceSession", context.id)
+    return _session_to_response(refreshed)
+
+
+async def update_session(
+    db: AsyncSession,
+    session_id: int,
+    data: SessionUpdate,
+    updated_by: int,
+) -> SessionResponse:
+    """Met a jour les records d'une session de pointage."""
+    context = await repo.get_session_by_id(db, session_id)
+    if context is None:
+        raise NotFoundError("AttendanceSession", session_id)
+
+    # Capture old values for audit
+    old_values = {r.student_id: r.status for r in context.records if hasattr(r, "student_id")}
+
+    async with db.begin_nested():
+        for rec_input in data.records:
+            existing = await repo.get_record_by_context_and_student(
+                db, session_id, rec_input.student_id
+            )
+            if existing is not None:
+                await repo.update_record(
+                    db,
+                    existing,
+                    status=rec_input.status,
+                    time_in=rec_input.time_in,
+                    notes=rec_input.notes,
+                )
+            else:
+                # Student not in original session — add new record
+                await repo.create_record(
+                    db,
+                    context_id=session_id,
+                    student_id=rec_input.student_id,
+                    status=rec_input.status,
+                    time_in=rec_input.time_in,
+                    notes=rec_input.notes,
+                )
+
+        new_values = {r.student_id: r.status for r in data.records}
+        await audit_log(
+            db,
+            entity_type="attendance_session",
+            action=AuditAction.UPDATE,
+            user_id=updated_by,
+            entity_id=session_id,
+            old_values=old_values,
+            new_values=new_values,
+        )
+
+    await db.commit()
+
+    refreshed = await repo.get_session_by_id(db, session_id)
+    if refreshed is None:
+        raise NotFoundError("AttendanceSession", session_id)
+    return _session_to_response(refreshed)
+
+
+async def get_student_attendance(
+    db: AsyncSession,
+    student_id: int,
+    *,
+    status: str | None = None,
+    date_from: object = None,
+    date_to: object = None,
+    page: int = 1,
+    size: int = 20,
+) -> StudentAttendanceResponse:
+    """Retourne l'historique de presence d'un eleve avec pagination."""
+    if status is not None and status not in _VALID_STATUSES:
+        raise BusinessValidationError(f"Invalid status '{status}'. Valid: {_VALID_STATUSES}")
+
+    records, total = await repo.list_records_for_student(
+        db,
+        student_id,
+        status=status,
+        date_from=date_from,
+        date_to=date_to,
+        page=page,
+        size=size,
+    )
+    return StudentAttendanceResponse(
+        items=[_record_to_response(r) for r in records],
+        total=total,
+        page=page,
+        size=size,
+    )
+
+
+async def get_class_stats(
+    db: AsyncSession,
+    class_id: int,
+    *,
+    academic_year_id: int | None = None,
+    date_from: object = None,
+    date_to: object = None,
+) -> ClassAttendanceStats:
+    """Calcule les stats de presence pour une classe."""
+    sessions = await repo.get_class_sessions(
+        db,
+        class_id,
+        academic_year_id=academic_year_id,
+        date_from=date_from,
+        date_to=date_to,
+    )
+
+    total_sessions = len(sessions)
+
+    # Aggregate per student
+    student_counts: dict[int, dict[str, int]] = defaultdict(
+        lambda: {"present": 0, "absent": 0, "late": 0, "excused": 0}
+    )
+
+    for session in sessions:
+        for record in session.records:
+            sid = record.student_id
+            st = record.status if isinstance(record.status, str) else record.status.value
+            if st in student_counts[sid]:
+                student_counts[sid][st] += 1
+
+    # Fetch student names
+    student_ids = set(student_counts.keys())
+    students_map = await repo.get_students_for_class_stats(db, student_ids)
+
+    # Build summaries
+    summaries: list[StudentAttendanceSummary] = []
+    total_present_all = 0
+    total_records_all = 0
+
+    for sid, counts in student_counts.items():
+        student = students_map.get(sid)
+        first_name = student.first_name if student else "Unknown"
+        last_name = student.last_name if student else "Unknown"
+
+        total_for_student = sum(counts.values())
+        present_equiv = counts["present"] + counts["late"]
+        rate = (present_equiv / total_for_student * 100.0) if total_for_student > 0 else 0.0
+
+        total_present_all += present_equiv
+        total_records_all += total_for_student
+
+        summaries.append(
+            StudentAttendanceSummary(
+                student_id=sid,
+                first_name=first_name,
+                last_name=last_name,
+                present_count=counts["present"],
+                absent_count=counts["absent"],
+                late_count=counts["late"],
+                excused_count=counts["excused"],
+                attendance_rate=round(rate, 2),
+            )
+        )
+
+    overall_rate = (total_present_all / total_records_all * 100.0) if total_records_all > 0 else 0.0
+
+    return ClassAttendanceStats(
+        class_id=class_id,
+        total_sessions=total_sessions,
+        attendance_rate=round(overall_rate, 2),
+        students=summaries,
+    )

--- a/tests/routers/test_attendance.py
+++ b/tests/routers/test_attendance.py
@@ -1,0 +1,379 @@
+"""Tests des endpoints /attendance."""
+
+from datetime import UTC, date, datetime, time
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db
+from app.core.redis import get_redis
+from app.main import app
+from app.schemas.attendance import (
+    AttendanceRecordResponse,
+    ClassAttendanceStats,
+    SessionResponse,
+    StudentAttendanceResponse,
+    StudentAttendanceSummary,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NOW = datetime.now(UTC)
+
+SAMPLE_RECORD = AttendanceRecordResponse(
+    id=1,
+    student_id=42,
+    status="present",
+    time_in=time(8, 0),
+    time_out=None,
+    source="manual",
+    notes=None,
+    created_at=NOW,
+    updated_at=NOW,
+)
+
+SAMPLE_SESSION = SessionResponse(
+    id=1,
+    entity_type="class",
+    context_id=3,
+    date=date(2026, 2, 16),
+    academic_year_id=1,
+    records=[SAMPLE_RECORD],
+    created_at=NOW,
+    updated_at=NOW,
+)
+
+SAMPLE_STUDENT_ATTENDANCE = StudentAttendanceResponse(
+    items=[SAMPLE_RECORD],
+    total=1,
+    page=1,
+    size=20,
+)
+
+SAMPLE_SUMMARY = StudentAttendanceSummary(
+    student_id=42,
+    first_name="Jean",
+    last_name="Dupont",
+    present_count=8,
+    absent_count=1,
+    late_count=1,
+    excused_count=0,
+    attendance_rate=90.0,
+)
+
+SAMPLE_CLASS_STATS = ClassAttendanceStats(
+    class_id=3,
+    total_sessions=10,
+    attendance_rate=90.0,
+    students=[SAMPLE_SUMMARY],
+)
+
+MOCK_USER = TokenData(user_id=1, tenant_id="local", email="admin@college.ci")
+
+
+def _override_deps() -> None:
+    """Surcharge les dependances d'auth et DB pour les tests."""
+    app.dependency_overrides[get_current_user] = lambda: MOCK_USER
+    app.dependency_overrides[get_tenant_db] = lambda: AsyncMock()
+    app.dependency_overrides[get_redis] = lambda: AsyncMock()
+
+
+def _clear_deps() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# POST /attendance/sessions
+# ---------------------------------------------------------------------------
+
+
+def test_create_session_success() -> None:
+    """POST /attendance/sessions -> 201 + session creee."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.attendance.attendance_service.create_session",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_SESSION,
+        ):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/attendance/sessions",
+                    json={
+                        "entity_type": "class",
+                        "context_id": 3,
+                        "date": "2026-02-16",
+                        "academic_year_id": 1,
+                        "records": [{"student_id": 42, "status": "present", "time_in": "08:00:00"}],
+                    },
+                )
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["id"] == 1
+    assert body["entity_type"] == "class"
+    assert len(body["records"]) == 1
+    assert body["records"][0]["student_id"] == 42
+
+
+def test_create_session_invalid_entity_type() -> None:
+    """POST /attendance/sessions avec entity_type invalide -> 422."""
+    _override_deps()
+    try:
+        with TestClient(app) as client:
+            resp = client.post(
+                "/attendance/sessions",
+                json={
+                    "entity_type": "invalid",
+                    "context_id": 3,
+                    "date": "2026-02-16",
+                    "academic_year_id": 1,
+                    "records": [{"student_id": 42, "status": "present"}],
+                },
+            )
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 422
+
+
+def test_create_session_invalid_status() -> None:
+    """POST /attendance/sessions avec status invalide -> 422."""
+    _override_deps()
+    try:
+        with TestClient(app) as client:
+            resp = client.post(
+                "/attendance/sessions",
+                json={
+                    "entity_type": "class",
+                    "context_id": 3,
+                    "date": "2026-02-16",
+                    "academic_year_id": 1,
+                    "records": [{"student_id": 42, "status": "invalid_status"}],
+                },
+            )
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 422
+
+
+def test_create_session_missing_records() -> None:
+    """POST /attendance/sessions sans records -> 422."""
+    _override_deps()
+    try:
+        with TestClient(app) as client:
+            resp = client.post(
+                "/attendance/sessions",
+                json={
+                    "entity_type": "class",
+                    "context_id": 3,
+                    "date": "2026-02-16",
+                    "academic_year_id": 1,
+                },
+            )
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 422
+
+
+def test_create_session_not_found_academic_year() -> None:
+    """POST /attendance/sessions avec academic_year invalide -> 422."""
+    from app.core.exceptions import BusinessValidationError
+
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.attendance.attendance_service.create_session",
+            new_callable=AsyncMock,
+            side_effect=BusinessValidationError("AcademicYear 999 not found"),
+        ):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/attendance/sessions",
+                    json={
+                        "entity_type": "class",
+                        "context_id": 3,
+                        "date": "2026-02-16",
+                        "academic_year_id": 999,
+                        "records": [{"student_id": 42, "status": "present"}],
+                    },
+                )
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 422
+
+
+def test_create_session_unauthenticated() -> None:
+    """POST /attendance/sessions sans token -> 401."""
+    with TestClient(app) as client:
+        resp = client.post(
+            "/attendance/sessions",
+            json={
+                "entity_type": "class",
+                "context_id": 3,
+                "date": "2026-02-16",
+                "academic_year_id": 1,
+                "records": [{"student_id": 42, "status": "present"}],
+            },
+        )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# PATCH /attendance/sessions/{id}
+# ---------------------------------------------------------------------------
+
+
+def test_update_session_success() -> None:
+    """PATCH /attendance/sessions/1 -> 200 + session mise a jour."""
+    updated = SAMPLE_SESSION.model_copy(
+        update={"records": [SAMPLE_RECORD.model_copy(update={"status": "late"})]}
+    )
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.attendance.attendance_service.update_session",
+            new_callable=AsyncMock,
+            return_value=updated,
+        ):
+            with TestClient(app) as client:
+                resp = client.patch(
+                    "/attendance/sessions/1",
+                    json={
+                        "records": [{"student_id": 42, "status": "late"}],
+                    },
+                )
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    assert resp.json()["records"][0]["status"] == "late"
+
+
+def test_update_session_not_found() -> None:
+    """PATCH /attendance/sessions/999 -> 404."""
+    from app.core.exceptions import NotFoundError
+
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.attendance.attendance_service.update_session",
+            new_callable=AsyncMock,
+            side_effect=NotFoundError("AttendanceSession", 999),
+        ):
+            with TestClient(app) as client:
+                resp = client.patch(
+                    "/attendance/sessions/999",
+                    json={"records": [{"student_id": 42, "status": "present"}]},
+                )
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /attendance/student/{student_id}
+# ---------------------------------------------------------------------------
+
+
+def test_get_student_attendance_success() -> None:
+    """GET /attendance/student/42 -> 200 + historique pagine."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.attendance.attendance_service.get_student_attendance",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_STUDENT_ATTENDANCE,
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/attendance/student/42")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["page"] == 1
+    assert len(body["items"]) == 1
+    assert body["items"][0]["student_id"] == 42
+
+
+def test_get_student_attendance_with_filters() -> None:
+    """GET /attendance/student/42?status=absent&page=2 -> filtre."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.attendance.attendance_service.get_student_attendance",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_STUDENT_ATTENDANCE,
+        ) as mock_fn:
+            with TestClient(app) as client:
+                resp = client.get(
+                    "/attendance/student/42?status=absent&date_from=2026-01-01&page=2&size=10"
+                )
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    mock_fn.assert_called_once()
+    call_kwargs = mock_fn.call_args.kwargs
+    assert call_kwargs["status"] == "absent"
+    assert call_kwargs["page"] == 2
+    assert call_kwargs["size"] == 10
+
+
+# ---------------------------------------------------------------------------
+# GET /attendance/class/{class_id}/stats
+# ---------------------------------------------------------------------------
+
+
+def test_get_class_stats_success() -> None:
+    """GET /attendance/class/3/stats -> 200 + stats."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.attendance.attendance_service.get_class_stats",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_CLASS_STATS,
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/attendance/class/3/stats")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["class_id"] == 3
+    assert body["total_sessions"] == 10
+    assert body["attendance_rate"] == 90.0
+    assert len(body["students"]) == 1
+    assert body["students"][0]["student_id"] == 42
+    assert body["students"][0]["present_count"] == 8
+
+
+def test_get_class_stats_with_filters() -> None:
+    """GET /attendance/class/3/stats?academic_year_id=1 -> filtre."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.attendance.attendance_service.get_class_stats",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_CLASS_STATS,
+        ) as mock_fn:
+            with TestClient(app) as client:
+                resp = client.get("/attendance/class/3/stats?academic_year_id=1")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    mock_fn.assert_called_once()
+    call_kwargs = mock_fn.call_args.kwargs
+    assert call_kwargs["academic_year_id"] == 1


### PR DESCRIPTION
## Summary
Closes #24

Pointage par session de cours avec statistiques par élève et par classe.

### Endpoints
- `POST /attendance/sessions` — créer une session de pointage (contexte + records)
- `PATCH /attendance/sessions/{id}` — mettre à jour les statuts (upsert par student_id)
- `GET /attendance/student/{student_id}` — historique élève (filtres: date, status)
- `GET /attendance/class/{class_id}/stats` — taux de présence par élève et global

### Architecture
- `app/schemas/attendance.py` — 116 lignes (SessionCreate, RecordInput, Stats schemas)
- `app/repositories/attendance_repository.py` — 176 lignes (SQLAlchemy 2.0 async)
- `app/services/attendance_service.py` — 246 lignes (aggregation stats, audit log)
- `app/routers/attendance.py` — 85 lignes (4 endpoints avec permissions)
- `tests/routers/test_attendance.py` — 379 lignes (12 tests)

### Statuts supportés
`present`, `absent`, `late`, `excused`

## Test plan
- [ ] `pytest tests/routers/test_attendance.py -v`
- [ ] Verify session creation with multiple student records
- [ ] Verify stats calculation (attendance rates)
- [ ] Verify upsert on update (existing records updated, new ones created)