### PR TITLE
feat(students): endpoints portail élève

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from app.routers.auth import router as auth_router
 from app.routers.dashboard import router as dashboard_router
 from app.routers.enrollments import router as enrollments_router
 from app.routers.grades import router as grades_router
+from app.routers.student_portal import router as student_portal_router
 from app.routers.timetable import availability_router, teachers_router
 from app.routers.timetable import router as timetable_router
 
@@ -45,6 +46,7 @@ app.include_router(auth_router)
 app.include_router(dashboard_router)
 app.include_router(enrollments_router)
 app.include_router(grades_router)
+app.include_router(student_portal_router)
 app.include_router(timetable_router)
 app.include_router(teachers_router)
 app.include_router(availability_router)

--- a/app/repositories/student_portal_repository.py
+++ b/app/repositories/student_portal_repository.py
@@ -1,0 +1,120 @@
+"""Repository portail eleve — requetes DB read-only scopees par student."""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.academic import AcademicYear, Class, Subject
+from app.models.enrollment import Enrollment, EnrollmentStatus
+from app.models.fee import EnrollmentFee, FeeVariant, Payment
+from app.models.grade import Bulletin, Evaluation, Grade
+from app.models.timetable import Timetable, TimetableSlot
+from app.models.user import Student, TeacherProfile
+
+
+async def get_student_by_user_id(db: AsyncSession, user_id: int) -> Student | None:
+    """Retourne le profil eleve lie a un user_id."""
+    stmt = select(Student).where(Student.user_id == user_id)
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def get_active_enrollment_for_student(
+    db: AsyncSession, student_id: int
+) -> Enrollment | None:
+    """Retourne l'inscription active (non annulee/rejetee) la plus recente."""
+    stmt = (
+        select(Enrollment)
+        .where(
+            Enrollment.student_id == student_id,
+            Enrollment.status.not_in([EnrollmentStatus.ANNULE, EnrollmentStatus.REJETE]),
+        )
+        .options(
+            selectinload(Enrollment.class_),
+            selectinload(Enrollment.academic_year),
+        )
+        .order_by(Enrollment.id.desc())
+        .limit(1)
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def get_grades_for_student(
+    db: AsyncSession,
+    student_id: int,
+    *,
+    trimester: int | None = None,
+    subject_id: int | None = None,
+) -> list[Grade]:
+    """Retourne les notes d'un eleve avec details evaluation et matiere."""
+    stmt = (
+        select(Grade)
+        .join(Grade.evaluation)
+        .where(Grade.student_id == student_id)
+        .options(
+            selectinload(Grade.evaluation).selectinload(Evaluation.subject),
+        )
+    )
+    if trimester is not None:
+        stmt = stmt.where(Evaluation.trimester == trimester)
+    if subject_id is not None:
+        stmt = stmt.where(Evaluation.subject_id == subject_id)
+
+    stmt = stmt.order_by(Evaluation.date.desc())
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_timetable_slots_for_class(
+    db: AsyncSession, class_id: int
+) -> list[TimetableSlot]:
+    """Retourne les creneaux emploi du temps d'une classe."""
+    stmt = (
+        select(TimetableSlot)
+        .where(TimetableSlot.class_id == class_id)
+        .options(
+            selectinload(TimetableSlot.subject),
+            selectinload(TimetableSlot.teacher),
+            selectinload(TimetableSlot.room),
+        )
+        .order_by(TimetableSlot.day, TimetableSlot.start_time)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_enrollment_fees_for_enrollment(
+    db: AsyncSession, enrollment_id: int
+) -> list[EnrollmentFee]:
+    """Retourne les frais d'une inscription avec paiements et categorie."""
+    stmt = (
+        select(EnrollmentFee)
+        .where(EnrollmentFee.enrollment_id == enrollment_id)
+        .options(
+            selectinload(EnrollmentFee.payments),
+            selectinload(EnrollmentFee.fee_variant).selectinload(FeeVariant.category),
+        )
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_published_bulletins_for_student(
+    db: AsyncSession, student_id: int
+) -> list[Bulletin]:
+    """Retourne les bulletins publies d'un eleve."""
+    stmt = (
+        select(Bulletin)
+        .where(
+            Bulletin.student_id == student_id,
+            Bulletin.is_published.is_(True),
+        )
+        .options(
+            selectinload(Bulletin.class_),
+            selectinload(Bulletin.academic_year),
+        )
+        .order_by(Bulletin.academic_year_id.desc(), Bulletin.trimester.desc())
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())

--- a/app/routers/student_portal.py
+++ b/app/routers/student_portal.py
@@ -1,0 +1,65 @@
+"""Router portail eleve — endpoints read-only /student."""
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db
+from app.schemas.student_portal import (
+    StudentBulletinsListResponse,
+    StudentFeesResponse,
+    StudentGradesListResponse,
+    StudentProfileResponse,
+    StudentTimetableResponse,
+)
+from app.services import student_portal_service
+
+router = APIRouter(prefix="/student", tags=["student-portal"])
+
+
+@router.get("/grades", response_model=StudentGradesListResponse)
+async def get_grades(
+    trimester: int | None = Query(None, ge=1, le=3),
+    subject_id: int | None = Query(None, ge=1),
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> StudentGradesListResponse:
+    """Notes de l'eleve connecte, filtrage optionnel par trimestre/matiere."""
+    return await student_portal_service.get_grades(
+        db, current_user.user_id, trimester=trimester, subject_id=subject_id
+    )
+
+
+@router.get("/timetable", response_model=StudentTimetableResponse)
+async def get_timetable(
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> StudentTimetableResponse:
+    """Emploi du temps de la classe de l'eleve."""
+    return await student_portal_service.get_timetable(db, current_user.user_id)
+
+
+@router.get("/fees", response_model=StudentFeesResponse)
+async def get_fees(
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> StudentFeesResponse:
+    """Frais et paiements de l'eleve."""
+    return await student_portal_service.get_fees(db, current_user.user_id)
+
+
+@router.get("/bulletins", response_model=StudentBulletinsListResponse)
+async def get_bulletins(
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> StudentBulletinsListResponse:
+    """Bulletins publies de l'eleve."""
+    return await student_portal_service.get_bulletins(db, current_user.user_id)
+
+
+@router.get("/profile", response_model=StudentProfileResponse)
+async def get_profile(
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> StudentProfileResponse:
+    """Profil complet de l'eleve."""
+    return await student_portal_service.get_profile(db, current_user.user_id)

--- a/app/schemas/student_portal.py
+++ b/app/schemas/student_portal.py
@@ -1,0 +1,137 @@
+"""Schemas Pydantic pour le portail eleve (read-only)."""
+
+from datetime import date, datetime, time
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict
+
+
+# ---------------------------------------------------------------------------
+# Grades
+# ---------------------------------------------------------------------------
+
+
+class EvaluationDetail(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    title: str
+    type: str
+    date: date
+    coefficient: int
+    trimester: int
+    subject_name: str
+
+
+class StudentGradeResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    value: Decimal | None
+    status: str
+    evaluation: EvaluationDetail
+
+
+class StudentGradesListResponse(BaseModel):
+    items: list[StudentGradeResponse]
+    total: int
+
+
+# ---------------------------------------------------------------------------
+# Timetable
+# ---------------------------------------------------------------------------
+
+
+class TimetableSlotResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    day: str
+    start_time: time
+    end_time: time
+    subject_name: str
+    teacher_name: str
+    room_name: str | None
+
+
+class StudentTimetableResponse(BaseModel):
+    class_name: str
+    slots: list[TimetableSlotResponse]
+
+
+# ---------------------------------------------------------------------------
+# Fees
+# ---------------------------------------------------------------------------
+
+
+class PaymentResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    amount: Decimal
+    method: str
+    status: str
+    reference: str | None
+    created_at: datetime
+
+
+class EnrollmentFeeResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    fee_category_name: str
+    amount: Decimal
+    status: str
+    payments: list[PaymentResponse]
+
+
+class StudentFeesResponse(BaseModel):
+    total_due: Decimal
+    total_paid: Decimal
+    balance: Decimal
+    fees: list[EnrollmentFeeResponse]
+
+
+# ---------------------------------------------------------------------------
+# Bulletins
+# ---------------------------------------------------------------------------
+
+
+class BulletinResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    trimester: int
+    average: Decimal | None
+    rank: int | None
+    mention: str | None
+    class_name: str
+    academic_year_name: str
+    file_url: str | None
+    generated_at: datetime | None
+
+
+class StudentBulletinsListResponse(BaseModel):
+    items: list[BulletinResponse]
+    total: int
+
+
+# ---------------------------------------------------------------------------
+# Profile
+# ---------------------------------------------------------------------------
+
+
+class StudentProfileResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    first_name: str
+    last_name: str
+    birth_date: date | None
+    genre: str | None
+    enrollment_number: str | None
+    email: str | None
+    class_name: str | None
+    class_id: int | None
+    enrollment_status: str | None
+    academic_year_name: str | None

--- a/app/services/student_portal_service.py
+++ b/app/services/student_portal_service.py
@@ -1,0 +1,198 @@
+"""Service portail eleve — logique metier read-only."""
+
+from decimal import Decimal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import NotFoundError
+from app.models.fee import PaymentStatus
+from app.models.user import Student
+from app.repositories import student_portal_repository as repo
+from app.schemas.student_portal import (
+    BulletinResponse,
+    EnrollmentFeeResponse,
+    EvaluationDetail,
+    PaymentResponse,
+    StudentBulletinsListResponse,
+    StudentFeesResponse,
+    StudentGradeResponse,
+    StudentGradesListResponse,
+    StudentProfileResponse,
+    StudentTimetableResponse,
+    TimetableSlotResponse,
+)
+
+
+async def _get_student_for_user(db: AsyncSession, user_id: int) -> Student:
+    """Retourne le profil eleve ou leve 404."""
+    student = await repo.get_student_by_user_id(db, user_id)
+    if student is None:
+        raise NotFoundError("Student profile not found for this user", user_id)
+    return student
+
+
+async def get_grades(
+    db: AsyncSession,
+    user_id: int,
+    *,
+    trimester: int | None = None,
+    subject_id: int | None = None,
+) -> StudentGradesListResponse:
+    """Retourne les notes de l'eleve connecte."""
+    student = await _get_student_for_user(db, user_id)
+    grades = await repo.get_grades_for_student(
+        db, student.id, trimester=trimester, subject_id=subject_id
+    )
+
+    items = [
+        StudentGradeResponse(
+            id=g.id,
+            value=g.value,
+            status=g.status,
+            evaluation=EvaluationDetail(
+                id=g.evaluation.id,
+                title=g.evaluation.title,
+                type=g.evaluation.type,
+                date=g.evaluation.date,
+                coefficient=g.evaluation.coefficient,
+                trimester=g.evaluation.trimester,
+                subject_name=g.evaluation.subject.name,
+            ),
+        )
+        for g in grades
+    ]
+    return StudentGradesListResponse(items=items, total=len(items))
+
+
+async def get_timetable(db: AsyncSession, user_id: int) -> StudentTimetableResponse:
+    """Retourne l'emploi du temps de la classe de l'eleve."""
+    student = await _get_student_for_user(db, user_id)
+    enrollment = await repo.get_active_enrollment_for_student(db, student.id)
+    if enrollment is None:
+        raise NotFoundError("Active enrollment not found for student", student.id)
+
+    slots = await repo.get_timetable_slots_for_class(db, enrollment.class_id)
+
+    slot_responses = [
+        TimetableSlotResponse(
+            id=s.id,
+            day=s.day,
+            start_time=s.start_time,
+            end_time=s.end_time,
+            subject_name=s.subject.name,
+            teacher_name=f"{s.teacher.first_name} {s.teacher.last_name}",
+            room_name=s.room.name if s.room else None,
+        )
+        for s in slots
+    ]
+    return StudentTimetableResponse(
+        class_name=enrollment.class_.name,
+        slots=slot_responses,
+    )
+
+
+async def get_fees(db: AsyncSession, user_id: int) -> StudentFeesResponse:
+    """Retourne les frais et paiements de l'eleve."""
+    student = await _get_student_for_user(db, user_id)
+    enrollment = await repo.get_active_enrollment_for_student(db, student.id)
+    if enrollment is None:
+        raise NotFoundError("Active enrollment not found for student", student.id)
+
+    enrollment_fees = await repo.get_enrollment_fees_for_enrollment(db, enrollment.id)
+
+    total_due = Decimal("0.00")
+    total_paid = Decimal("0.00")
+    fee_responses = []
+
+    for ef in enrollment_fees:
+        total_due += ef.amount
+        payments = [
+            PaymentResponse(
+                id=p.id,
+                amount=p.amount,
+                method=p.method,
+                status=p.status,
+                reference=p.reference,
+                created_at=p.created_at,
+            )
+            for p in ef.payments
+        ]
+        for p in ef.payments:
+            if p.status == PaymentStatus.COMPLETED:
+                total_paid += p.amount
+
+        category_name = ef.fee_variant.category.name if ef.fee_variant and ef.fee_variant.category else "N/A"
+        fee_responses.append(
+            EnrollmentFeeResponse(
+                id=ef.id,
+                fee_category_name=category_name,
+                amount=ef.amount,
+                status=ef.status,
+                payments=payments,
+            )
+        )
+
+    return StudentFeesResponse(
+        total_due=total_due,
+        total_paid=total_paid,
+        balance=total_due - total_paid,
+        fees=fee_responses,
+    )
+
+
+async def get_bulletins(db: AsyncSession, user_id: int) -> StudentBulletinsListResponse:
+    """Retourne les bulletins publies de l'eleve."""
+    student = await _get_student_for_user(db, user_id)
+    bulletins = await repo.get_published_bulletins_for_student(db, student.id)
+
+    items = [
+        BulletinResponse(
+            id=b.id,
+            trimester=b.trimester,
+            average=b.average,
+            rank=b.rank,
+            mention=b.mention,
+            class_name=b.class_.name,
+            academic_year_name=b.academic_year.name,
+            file_url=b.file_url,
+            generated_at=b.generated_at,
+        )
+        for b in bulletins
+    ]
+    return StudentBulletinsListResponse(items=items, total=len(items))
+
+
+async def get_profile(db: AsyncSession, user_id: int) -> StudentProfileResponse:
+    """Retourne le profil complet de l'eleve."""
+    student = await _get_student_for_user(db, user_id)
+    enrollment = await repo.get_active_enrollment_for_student(db, student.id)
+
+    # Recuperer l'email depuis le user lie
+    email: str | None = None
+    if student.user:
+        email = student.user.email
+
+    class_name: str | None = None
+    class_id: int | None = None
+    enrollment_status: str | None = None
+    academic_year_name: str | None = None
+
+    if enrollment:
+        class_name = enrollment.class_.name
+        class_id = enrollment.class_id
+        enrollment_status = enrollment.status
+        academic_year_name = enrollment.academic_year.name
+
+    return StudentProfileResponse(
+        id=student.id,
+        first_name=student.first_name,
+        last_name=student.last_name,
+        birth_date=student.birth_date,
+        genre=student.genre,
+        enrollment_number=student.enrollment_number,
+        email=email,
+        class_name=class_name,
+        class_id=class_id,
+        enrollment_status=enrollment_status,
+        academic_year_name=academic_year_name,
+    )

--- a/tests/routers/test_student_portal.py
+++ b/tests/routers/test_student_portal.py
@@ -1,0 +1,367 @@
+"""Tests des endpoints /student (portail eleve)."""
+
+from datetime import UTC, datetime, time
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db
+from app.core.exceptions import NotFoundError
+from app.core.redis import get_redis
+from app.main import app
+from app.schemas.student_portal import (
+    BulletinResponse,
+    EnrollmentFeeResponse,
+    EvaluationDetail,
+    PaymentResponse,
+    StudentBulletinsListResponse,
+    StudentFeesResponse,
+    StudentGradeResponse,
+    StudentGradesListResponse,
+    StudentProfileResponse,
+    StudentTimetableResponse,
+    TimetableSlotResponse,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NOW = datetime.now(UTC)
+
+MOCK_USER = TokenData(user_id=1, tenant_id="local", email="student@college.ci")
+
+
+def _override_deps() -> None:
+    app.dependency_overrides[get_current_user] = lambda: MOCK_USER
+    app.dependency_overrides[get_tenant_db] = lambda: AsyncMock()
+    app.dependency_overrides[get_redis] = lambda: AsyncMock()
+
+
+def _clear_deps() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_GRADES = StudentGradesListResponse(
+    items=[
+        StudentGradeResponse(
+            id=1,
+            value=Decimal("15.50"),
+            status="entered",
+            evaluation=EvaluationDetail(
+                id=10,
+                title="Controle Maths T1",
+                type="controle",
+                date=NOW.date(),
+                coefficient=2,
+                trimester=1,
+                subject_name="Mathematiques",
+            ),
+        ),
+    ],
+    total=1,
+)
+
+SAMPLE_TIMETABLE = StudentTimetableResponse(
+    class_name="6eme A",
+    slots=[
+        TimetableSlotResponse(
+            id=1,
+            day="monday",
+            start_time=time(8, 0),
+            end_time=time(10, 0),
+            subject_name="Mathematiques",
+            teacher_name="Jean Dupont",
+            room_name="Salle 101",
+        ),
+    ],
+)
+
+SAMPLE_FEES = StudentFeesResponse(
+    total_due=Decimal("150000.00"),
+    total_paid=Decimal("75000.00"),
+    balance=Decimal("75000.00"),
+    fees=[
+        EnrollmentFeeResponse(
+            id=1,
+            fee_category_name="Scolarite T1",
+            amount=Decimal("150000.00"),
+            status="partial",
+            payments=[
+                PaymentResponse(
+                    id=1,
+                    amount=Decimal("75000.00"),
+                    method="mobile_money",
+                    status="completed",
+                    reference="PAY-001",
+                    created_at=NOW,
+                ),
+            ],
+        ),
+    ],
+)
+
+SAMPLE_BULLETINS = StudentBulletinsListResponse(
+    items=[
+        BulletinResponse(
+            id=1,
+            trimester=1,
+            average=Decimal("14.25"),
+            rank=3,
+            mention="B",
+            class_name="6eme A",
+            academic_year_name="2025-2026",
+            file_url="/bulletins/1.pdf",
+            generated_at=NOW,
+        ),
+    ],
+    total=1,
+)
+
+SAMPLE_PROFILE = StudentProfileResponse(
+    id=42,
+    first_name="Awa",
+    last_name="Kone",
+    birth_date=None,
+    genre="F",
+    enrollment_number="STU-001",
+    email="student@college.ci",
+    class_name="6eme A",
+    class_id=3,
+    enrollment_status="valide",
+    academic_year_name="2025-2026",
+)
+
+
+# ---------------------------------------------------------------------------
+# GET /student/grades
+# ---------------------------------------------------------------------------
+
+
+def test_get_grades_success() -> None:
+    """GET /student/grades -> 200 + liste de notes."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.student_portal.student_portal_service.get_grades",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_GRADES,
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/student/grades")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["items"][0]["value"] == "15.50"
+    assert body["items"][0]["evaluation"]["subject_name"] == "Mathematiques"
+
+
+def test_get_grades_with_filters() -> None:
+    """GET /student/grades?trimester=1&subject_id=5 -> filtres transmis."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.student_portal.student_portal_service.get_grades",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_GRADES,
+        ) as mock_fn:
+            with TestClient(app) as client:
+                resp = client.get("/student/grades?trimester=1&subject_id=5")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    mock_fn.assert_called_once()
+    _, kwargs = mock_fn.call_args
+    assert kwargs["trimester"] == 1
+    assert kwargs["subject_id"] == 5
+
+
+def test_get_grades_student_not_found() -> None:
+    """GET /student/grades sans profil eleve -> 404."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.student_portal.student_portal_service.get_grades",
+            new_callable=AsyncMock,
+            side_effect=NotFoundError("Student profile not found for this user", 1),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/student/grades")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 404
+
+
+def test_get_grades_unauthenticated() -> None:
+    """GET /student/grades sans token -> 401."""
+    with TestClient(app) as client:
+        resp = client.get("/student/grades")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /student/timetable
+# ---------------------------------------------------------------------------
+
+
+def test_get_timetable_success() -> None:
+    """GET /student/timetable -> 200 + emploi du temps."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.student_portal.student_portal_service.get_timetable",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_TIMETABLE,
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/student/timetable")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["class_name"] == "6eme A"
+    assert len(body["slots"]) == 1
+    assert body["slots"][0]["subject_name"] == "Mathematiques"
+
+
+def test_get_timetable_no_enrollment() -> None:
+    """GET /student/timetable sans inscription active -> 404."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.student_portal.student_portal_service.get_timetable",
+            new_callable=AsyncMock,
+            side_effect=NotFoundError("Active enrollment not found for student", 42),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/student/timetable")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /student/fees
+# ---------------------------------------------------------------------------
+
+
+def test_get_fees_success() -> None:
+    """GET /student/fees -> 200 + frais et paiements."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.student_portal.student_portal_service.get_fees",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_FEES,
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/student/fees")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_due"] == "150000.00"
+    assert body["total_paid"] == "75000.00"
+    assert body["balance"] == "75000.00"
+    assert len(body["fees"]) == 1
+    assert body["fees"][0]["fee_category_name"] == "Scolarite T1"
+
+
+def test_get_fees_no_enrollment() -> None:
+    """GET /student/fees sans inscription active -> 404."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.student_portal.student_portal_service.get_fees",
+            new_callable=AsyncMock,
+            side_effect=NotFoundError("Active enrollment not found for student", 42),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/student/fees")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /student/bulletins
+# ---------------------------------------------------------------------------
+
+
+def test_get_bulletins_success() -> None:
+    """GET /student/bulletins -> 200 + bulletins publies."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.student_portal.student_portal_service.get_bulletins",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_BULLETINS,
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/student/bulletins")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["items"][0]["average"] == "14.25"
+    assert body["items"][0]["mention"] == "B"
+
+
+# ---------------------------------------------------------------------------
+# GET /student/profile
+# ---------------------------------------------------------------------------
+
+
+def test_get_profile_success() -> None:
+    """GET /student/profile -> 200 + profil complet."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.student_portal.student_portal_service.get_profile",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PROFILE,
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/student/profile")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["first_name"] == "Awa"
+    assert body["last_name"] == "Kone"
+    assert body["class_name"] == "6eme A"
+    assert body["enrollment_status"] == "valide"
+
+
+def test_get_profile_not_found() -> None:
+    """GET /student/profile sans profil eleve -> 404."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.student_portal.student_portal_service.get_profile",
+            new_callable=AsyncMock,
+            side_effect=NotFoundError("Student profile not found for this user", 1),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/student/profile")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
Closes #26

Portail élève — 5 endpoints read-only, scoped au student connecté via JWT.

### Endpoints
- `GET /student/grades` — notes par trimestre/matière
- `GET /student/timetable` — emploi du temps de sa classe
- `GET /student/fees` — frais et paiements (total_due, total_paid, balance)
- `GET /student/bulletins` — bulletins publiés uniquement
- `GET /student/profile` — profil complet avec classe et inscription

### Architecture
- `app/schemas/student_portal.py` — 137 lignes
- `app/repositories/student_portal_repository.py` — 120 lignes (selectinload)
- `app/services/student_portal_service.py` — 198 lignes
- `app/routers/student_portal.py` — 65 lignes
- `tests/routers/test_student_portal.py` — 367 lignes (11 tests)

### Securite
Auth via `get_current_user` — toutes les queries filtrées par `student.user_id`

## Test plan
- [ ] `pytest tests/routers/test_student_portal.py -v`
- [ ] Verify 404 when user has no student profile
- [ ] Verify student can only see own data