### PR TITLE
feat(parents): endpoints portail parent

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,9 @@ from app.routers.auth import router as auth_router
 from app.routers.dashboard import router as dashboard_router
 from app.routers.enrollments import router as enrollments_router
 from app.routers.grades import router as grades_router
+from app.routers.parent_portal import router as parent_portal_router
+from app.routers.student_portal import router as student_portal_router
+from app.routers.teacher_portal import router as teacher_portal_router
 from app.routers.timetable import availability_router, teachers_router
 from app.routers.timetable import router as timetable_router
 
@@ -45,6 +48,9 @@ app.include_router(auth_router)
 app.include_router(dashboard_router)
 app.include_router(enrollments_router)
 app.include_router(grades_router)
+app.include_router(parent_portal_router)
+app.include_router(student_portal_router)
+app.include_router(teacher_portal_router)
 app.include_router(timetable_router)
 app.include_router(teachers_router)
 app.include_router(availability_router)

--- a/app/repositories/parent_portal_repository.py
+++ b/app/repositories/parent_portal_repository.py
@@ -1,0 +1,105 @@
+"""Repository portail parent — accès DB lecture seule pour les données enfants."""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.academic import AcademicYear, Class
+from app.models.enrollment import Enrollment, EnrollmentStatus
+from app.models.fee import EnrollmentFee, FeeVariant, Payment
+from app.models.grade import Bulletin, Evaluation, Grade
+from app.models.user import Parent, ParentStudent, Student
+
+
+async def get_parent_by_user_id(db: AsyncSession, user_id: int) -> Parent | None:
+    """Retourne le profil parent lié à un user_id."""
+    stmt = select(Parent).where(Parent.user_id == user_id)
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def get_parent_student_link(
+    db: AsyncSession, parent_id: int, student_id: int
+) -> ParentStudent | None:
+    """Vérifie le lien parent-enfant."""
+    stmt = select(ParentStudent).where(
+        ParentStudent.parent_id == parent_id,
+        ParentStudent.student_id == student_id,
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_children(db: AsyncSession, parent_id: int) -> list[ParentStudent]:
+    """Retourne les liens parent-enfant avec les étudiants et leur inscription active."""
+    stmt = (
+        select(ParentStudent)
+        .where(ParentStudent.parent_id == parent_id)
+        .options(
+            selectinload(ParentStudent.student).selectinload(Student.enrollments).selectinload(
+                Enrollment.class_
+            ),
+            selectinload(ParentStudent.student)
+            .selectinload(Student.enrollments)
+            .selectinload(Enrollment.academic_year),
+        )
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_student_grades(
+    db: AsyncSession, student_id: int, trimester: int | None = None
+) -> list[Grade]:
+    """Retourne les notes d'un élève avec détails évaluation."""
+    stmt = (
+        select(Grade)
+        .where(Grade.student_id == student_id)
+        .options(
+            selectinload(Grade.evaluation).selectinload(Evaluation.subject),
+        )
+    )
+    if trimester is not None:
+        stmt = stmt.join(Grade.evaluation).where(Evaluation.trimester == trimester)
+    stmt = stmt.order_by(Grade.id.desc())
+    result = await db.execute(stmt)
+    return list(result.scalars().unique().all())
+
+
+async def get_student_active_enrollment(
+    db: AsyncSession, student_id: int
+) -> Enrollment | None:
+    """Retourne l'inscription active d'un élève avec ses frais et paiements."""
+    stmt = (
+        select(Enrollment)
+        .where(
+            Enrollment.student_id == student_id,
+            Enrollment.status.not_in([EnrollmentStatus.ANNULE, EnrollmentStatus.REJETE]),
+        )
+        .options(
+            selectinload(Enrollment.enrollment_fees).selectinload(EnrollmentFee.fee_variant).selectinload(FeeVariant.category),
+            selectinload(Enrollment.enrollment_fees).selectinload(EnrollmentFee.payments),
+        )
+        .order_by(Enrollment.id.desc())
+        .limit(1)
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def get_student_bulletins(db: AsyncSession, student_id: int) -> list[Bulletin]:
+    """Retourne les bulletins publiés d'un élève."""
+    stmt = (
+        select(Bulletin)
+        .where(
+            Bulletin.student_id == student_id,
+            Bulletin.is_published.is_(True),
+        )
+        .options(
+            selectinload(Bulletin.class_),
+            selectinload(Bulletin.academic_year),
+        )
+        .order_by(Bulletin.trimester.desc())
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())

--- a/app/routers/parent_portal.py
+++ b/app/routers/parent_portal.py
@@ -1,0 +1,58 @@
+"""Router portail parent — endpoints /parent."""
+
+from fastapi import APIRouter, Depends, Query
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db
+from app.schemas.parent_portal import (
+    ChildBulletinsResponse,
+    ChildFeesResponse,
+    ChildGradesResponse,
+    ChildrenListResponse,
+)
+from app.services import parent_portal_service
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+router = APIRouter(prefix="/parent", tags=["parent-portal"])
+
+
+@router.get("/children", response_model=ChildrenListResponse)
+async def list_children(
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> ChildrenListResponse:
+    """Liste les enfants inscrits du parent connecté."""
+    return await parent_portal_service.list_children(db, current_user.user_id)
+
+
+@router.get("/children/{student_id}/grades", response_model=ChildGradesResponse)
+async def get_child_grades(
+    student_id: int,
+    trimester: int | None = Query(None, ge=1, le=3),
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> ChildGradesResponse:
+    """Retourne les notes d'un enfant du parent connecté."""
+    return await parent_portal_service.get_child_grades(
+        db, current_user.user_id, student_id, trimester=trimester
+    )
+
+
+@router.get("/children/{student_id}/fees", response_model=ChildFeesResponse)
+async def get_child_fees(
+    student_id: int,
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> ChildFeesResponse:
+    """Retourne les frais d'un enfant du parent connecté."""
+    return await parent_portal_service.get_child_fees(db, current_user.user_id, student_id)
+
+
+@router.get("/children/{student_id}/bulletins", response_model=ChildBulletinsResponse)
+async def get_child_bulletins(
+    student_id: int,
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> ChildBulletinsResponse:
+    """Retourne les bulletins publiés d'un enfant du parent connecté."""
+    return await parent_portal_service.get_child_bulletins(db, current_user.user_id, student_id)

--- a/app/schemas/parent_portal.py
+++ b/app/schemas/parent_portal.py
@@ -1,0 +1,131 @@
+"""Schémas Pydantic pour le portail parent."""
+
+from datetime import date, datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict
+
+
+# ---------------------------------------------------------------------------
+# Children
+# ---------------------------------------------------------------------------
+
+
+class ChildEnrollmentInfo(BaseModel):
+    """Résumé de l'inscription active d'un enfant."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    enrollment_id: int
+    class_id: int
+    class_name: str
+    academic_year_name: str
+    status: str
+
+
+class ChildResponse(BaseModel):
+    """Enfant vu par le parent."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    first_name: str
+    last_name: str
+    birth_date: date | None
+    enrollment_number: str | None
+    relationship_type: str
+    enrollment: ChildEnrollmentInfo | None = None
+
+
+class ChildrenListResponse(BaseModel):
+    children: list[ChildResponse]
+
+
+# ---------------------------------------------------------------------------
+# Grades
+# ---------------------------------------------------------------------------
+
+
+class GradeDetail(BaseModel):
+    """Note d'un enfant pour une évaluation."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    value: Decimal | None
+    status: str
+    evaluation_title: str
+    evaluation_type: str
+    evaluation_date: date
+    subject_name: str
+    coefficient: int
+    trimester: int
+
+
+class ChildGradesResponse(BaseModel):
+    student_id: int
+    grades: list[GradeDetail]
+
+
+# ---------------------------------------------------------------------------
+# Fees
+# ---------------------------------------------------------------------------
+
+
+class PaymentDetail(BaseModel):
+    """Détail d'un paiement."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    amount: Decimal
+    method: str
+    status: str
+    reference: str | None
+    created_at: datetime
+
+
+class FeeDetail(BaseModel):
+    """Frais d'inscription avec paiements."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    amount: Decimal
+    status: str
+    category_name: str
+    payments: list[PaymentDetail]
+
+
+class ChildFeesResponse(BaseModel):
+    student_id: int
+    enrollment_id: int | None
+    fees: list[FeeDetail]
+    total_due: Decimal
+    total_paid: Decimal
+
+
+# ---------------------------------------------------------------------------
+# Bulletins
+# ---------------------------------------------------------------------------
+
+
+class BulletinDetail(BaseModel):
+    """Bulletin trimestriel d'un enfant."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    trimester: int
+    average: Decimal | None
+    rank: int | None
+    mention: str | None
+    class_name: str
+    academic_year_name: str
+    is_published: bool
+    generated_at: datetime | None
+
+
+class ChildBulletinsResponse(BaseModel):
+    student_id: int
+    bulletins: list[BulletinDetail]

--- a/app/services/parent_portal_service.py
+++ b/app/services/parent_portal_service.py
@@ -1,0 +1,210 @@
+"""Service portail parent — logique métier lecture seule."""
+
+import logging
+from decimal import Decimal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import NotFoundError, PermissionDeniedError
+from app.models.enrollment import EnrollmentStatus
+from app.models.fee import PaymentStatus
+from app.models.user import Parent, ParentStudent
+from app.repositories import parent_portal_repository as repo
+from app.schemas.parent_portal import (
+    BulletinDetail,
+    ChildBulletinsResponse,
+    ChildEnrollmentInfo,
+    ChildFeesResponse,
+    ChildGradesResponse,
+    ChildrenListResponse,
+    ChildResponse,
+    FeeDetail,
+    GradeDetail,
+    PaymentDetail,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers internes
+# ---------------------------------------------------------------------------
+
+
+async def _get_parent_for_user(db: AsyncSession, user_id: int) -> Parent:
+    """Récupère le profil parent ou lève NotFoundError."""
+    parent = await repo.get_parent_by_user_id(db, user_id)
+    if parent is None:
+        raise NotFoundError("Parent", user_id)
+    return parent
+
+
+async def _verify_child_access(db: AsyncSession, parent_id: int, student_id: int) -> ParentStudent:
+    """Vérifie que l'enfant appartient au parent ou lève PermissionDeniedError."""
+    link = await repo.get_parent_student_link(db, parent_id, student_id)
+    if link is None:
+        raise PermissionDeniedError("access to this student")
+    return link
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+async def list_children(db: AsyncSession, user_id: int) -> ChildrenListResponse:
+    """Liste les enfants du parent avec leur inscription active."""
+    parent = await _get_parent_for_user(db, user_id)
+    links = await repo.list_children(db, parent.id)
+
+    children: list[ChildResponse] = []
+    for link in links:
+        student = link.student
+        enrollment_info: ChildEnrollmentInfo | None = None
+
+        # Trouver l'inscription active la plus récente
+        active_enrollments = [
+            e
+            for e in student.enrollments
+            if e.status not in (EnrollmentStatus.ANNULE, EnrollmentStatus.REJETE)
+        ]
+        if active_enrollments:
+            active = max(active_enrollments, key=lambda e: e.id)
+            enrollment_info = ChildEnrollmentInfo(
+                enrollment_id=active.id,
+                class_id=active.class_id,
+                class_name=active.class_.name if active.class_ else str(active.class_id),
+                academic_year_name=(
+                    active.academic_year.name if active.academic_year else str(active.academic_year_id)
+                ),
+                status=active.status,
+            )
+
+        children.append(
+            ChildResponse(
+                id=student.id,
+                first_name=student.first_name,
+                last_name=student.last_name,
+                birth_date=student.birth_date,
+                enrollment_number=student.enrollment_number,
+                relationship_type=link.relationship_type,
+                enrollment=enrollment_info,
+            )
+        )
+
+    return ChildrenListResponse(children=children)
+
+
+async def get_child_grades(
+    db: AsyncSession, user_id: int, student_id: int, trimester: int | None = None
+) -> ChildGradesResponse:
+    """Retourne les notes d'un enfant."""
+    parent = await _get_parent_for_user(db, user_id)
+    await _verify_child_access(db, parent.id, student_id)
+
+    grades = await repo.get_student_grades(db, student_id, trimester=trimester)
+
+    grade_details = [
+        GradeDetail(
+            id=g.id,
+            value=g.value,
+            status=g.status,
+            evaluation_title=g.evaluation.title,
+            evaluation_type=g.evaluation.type,
+            evaluation_date=g.evaluation.date,
+            subject_name=g.evaluation.subject.name if g.evaluation.subject else "N/A",
+            coefficient=g.evaluation.coefficient,
+            trimester=g.evaluation.trimester,
+        )
+        for g in grades
+    ]
+
+    return ChildGradesResponse(student_id=student_id, grades=grade_details)
+
+
+async def get_child_fees(
+    db: AsyncSession, user_id: int, student_id: int
+) -> ChildFeesResponse:
+    """Retourne les frais d'un enfant pour son inscription active."""
+    parent = await _get_parent_for_user(db, user_id)
+    await _verify_child_access(db, parent.id, student_id)
+
+    enrollment = await repo.get_student_active_enrollment(db, student_id)
+
+    if enrollment is None:
+        return ChildFeesResponse(
+            student_id=student_id,
+            enrollment_id=None,
+            fees=[],
+            total_due=Decimal("0.00"),
+            total_paid=Decimal("0.00"),
+        )
+
+    fees: list[FeeDetail] = []
+    total_due = Decimal("0.00")
+    total_paid = Decimal("0.00")
+
+    for ef in enrollment.enrollment_fees:
+        total_due += ef.amount
+        payments = [
+            PaymentDetail(
+                id=p.id,
+                amount=p.amount,
+                method=p.method,
+                status=p.status,
+                reference=p.reference,
+                created_at=p.created_at,
+            )
+            for p in ef.payments
+        ]
+        for p in ef.payments:
+            if p.status == PaymentStatus.COMPLETED:
+                total_paid += p.amount
+
+        category_name = (
+            ef.fee_variant.category.name if ef.fee_variant and ef.fee_variant.category else "N/A"
+        )
+        fees.append(
+            FeeDetail(
+                id=ef.id,
+                amount=ef.amount,
+                status=ef.status,
+                category_name=category_name,
+                payments=payments,
+            )
+        )
+
+    return ChildFeesResponse(
+        student_id=student_id,
+        enrollment_id=enrollment.id,
+        fees=fees,
+        total_due=total_due,
+        total_paid=total_paid,
+    )
+
+
+async def get_child_bulletins(
+    db: AsyncSession, user_id: int, student_id: int
+) -> ChildBulletinsResponse:
+    """Retourne les bulletins publiés d'un enfant."""
+    parent = await _get_parent_for_user(db, user_id)
+    await _verify_child_access(db, parent.id, student_id)
+
+    bulletins = await repo.get_student_bulletins(db, student_id)
+
+    bulletin_details = [
+        BulletinDetail(
+            id=b.id,
+            trimester=b.trimester,
+            average=b.average,
+            rank=b.rank,
+            mention=b.mention,
+            class_name=b.class_.name if b.class_ else "N/A",
+            academic_year_name=b.academic_year.name if b.academic_year else "N/A",
+            is_published=b.is_published,
+            generated_at=b.generated_at,
+        )
+        for b in bulletins
+    ]
+
+    return ChildBulletinsResponse(student_id=student_id, bulletins=bulletin_details)

--- a/tests/routers/test_parent_portal.py
+++ b/tests/routers/test_parent_portal.py
@@ -1,0 +1,324 @@
+"""Tests des endpoints /parent."""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db
+from app.core.redis import get_redis
+from app.main import app
+from app.schemas.parent_portal import (
+    BulletinDetail,
+    ChildBulletinsResponse,
+    ChildEnrollmentInfo,
+    ChildFeesResponse,
+    ChildGradesResponse,
+    ChildrenListResponse,
+    ChildResponse,
+    FeeDetail,
+    GradeDetail,
+    PaymentDetail,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NOW = datetime.now(UTC)
+
+MOCK_USER = TokenData(user_id=10, tenant_id="local", email="parent@college.ci")
+
+SAMPLE_CHILD = ChildResponse(
+    id=42,
+    first_name="Aya",
+    last_name="Koné",
+    birth_date=None,
+    enrollment_number="STU-001",
+    relationship_type="mother",
+    enrollment=ChildEnrollmentInfo(
+        enrollment_id=1,
+        class_id=3,
+        class_name="6ème A",
+        academic_year_name="2025-2026",
+        status="valide",
+    ),
+)
+
+SAMPLE_CHILDREN_LIST = ChildrenListResponse(children=[SAMPLE_CHILD])
+
+SAMPLE_GRADE = GradeDetail(
+    id=1,
+    value=Decimal("14.50"),
+    status="entered",
+    evaluation_title="Devoir 1 Maths",
+    evaluation_type="devoir",
+    evaluation_date=NOW.date(),
+    subject_name="Mathématiques",
+    coefficient=2,
+    trimester=1,
+)
+
+SAMPLE_GRADES_RESPONSE = ChildGradesResponse(student_id=42, grades=[SAMPLE_GRADE])
+
+SAMPLE_PAYMENT = PaymentDetail(
+    id=1,
+    amount=Decimal("50000.00"),
+    method="mobile_money",
+    status="completed",
+    reference="PAY-001",
+    created_at=NOW,
+)
+
+SAMPLE_FEE = FeeDetail(
+    id=1,
+    amount=Decimal("100000.00"),
+    status="partial",
+    category_name="Inscription",
+    payments=[SAMPLE_PAYMENT],
+)
+
+SAMPLE_FEES_RESPONSE = ChildFeesResponse(
+    student_id=42,
+    enrollment_id=1,
+    fees=[SAMPLE_FEE],
+    total_due=Decimal("100000.00"),
+    total_paid=Decimal("50000.00"),
+)
+
+SAMPLE_BULLETIN = BulletinDetail(
+    id=1,
+    trimester=1,
+    average=Decimal("13.50"),
+    rank=5,
+    mention="AB",
+    class_name="6ème A",
+    academic_year_name="2025-2026",
+    is_published=True,
+    generated_at=NOW,
+)
+
+SAMPLE_BULLETINS_RESPONSE = ChildBulletinsResponse(student_id=42, bulletins=[SAMPLE_BULLETIN])
+
+
+def _override_deps() -> None:
+    """Surcharge les dépendances d'auth et DB pour les tests."""
+    app.dependency_overrides[get_current_user] = lambda: MOCK_USER
+    app.dependency_overrides[get_tenant_db] = lambda: AsyncMock()
+    app.dependency_overrides[get_redis] = lambda: AsyncMock()
+
+
+def _clear_deps() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# GET /parent/children
+# ---------------------------------------------------------------------------
+
+
+def test_list_children_success() -> None:
+    """GET /parent/children → 200 + liste d'enfants."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.parent_portal.parent_portal_service.list_children",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_CHILDREN_LIST,
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/parent/children")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["children"]) == 1
+    assert body["children"][0]["id"] == 42
+    assert body["children"][0]["first_name"] == "Aya"
+    assert body["children"][0]["enrollment"]["class_name"] == "6ème A"
+
+
+def test_list_children_unauthenticated() -> None:
+    """GET /parent/children sans token → 401."""
+    with TestClient(app) as client:
+        resp = client.get("/parent/children")
+    assert resp.status_code == 401
+
+
+def test_list_children_no_parent_profile() -> None:
+    """GET /parent/children avec user sans profil parent → 404."""
+    from app.core.exceptions import NotFoundError
+
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.parent_portal.parent_portal_service.list_children",
+            new_callable=AsyncMock,
+            side_effect=NotFoundError("Parent", 10),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/parent/children")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /parent/children/{student_id}/grades
+# ---------------------------------------------------------------------------
+
+
+def test_get_child_grades_success() -> None:
+    """GET /parent/children/42/grades → 200 + notes."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.parent_portal.parent_portal_service.get_child_grades",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_GRADES_RESPONSE,
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/parent/children/42/grades")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["student_id"] == 42
+    assert len(body["grades"]) == 1
+    assert body["grades"][0]["evaluation_title"] == "Devoir 1 Maths"
+
+
+def test_get_child_grades_with_trimester_filter() -> None:
+    """GET /parent/children/42/grades?trimester=1 → filtre trimestre."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.parent_portal.parent_portal_service.get_child_grades",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_GRADES_RESPONSE,
+        ) as mock_grades:
+            with TestClient(app) as client:
+                resp = client.get("/parent/children/42/grades?trimester=1")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    mock_grades.assert_called_once()
+    call_kwargs = mock_grades.call_args.kwargs
+    assert call_kwargs["trimester"] == 1
+
+
+def test_get_child_grades_permission_denied() -> None:
+    """GET /parent/children/99/grades pour un enfant non lié → 403."""
+    from app.core.exceptions import PermissionDeniedError
+
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.parent_portal.parent_portal_service.get_child_grades",
+            new_callable=AsyncMock,
+            side_effect=PermissionDeniedError("access to this student"),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/parent/children/99/grades")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# GET /parent/children/{student_id}/fees
+# ---------------------------------------------------------------------------
+
+
+def test_get_child_fees_success() -> None:
+    """GET /parent/children/42/fees → 200 + frais."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.parent_portal.parent_portal_service.get_child_fees",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_FEES_RESPONSE,
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/parent/children/42/fees")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["student_id"] == 42
+    assert body["enrollment_id"] == 1
+    assert len(body["fees"]) == 1
+    assert body["total_due"] == "100000.00"
+    assert body["total_paid"] == "50000.00"
+
+
+def test_get_child_fees_permission_denied() -> None:
+    """GET /parent/children/99/fees pour un enfant non lié → 403."""
+    from app.core.exceptions import PermissionDeniedError
+
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.parent_portal.parent_portal_service.get_child_fees",
+            new_callable=AsyncMock,
+            side_effect=PermissionDeniedError("access to this student"),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/parent/children/99/fees")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# GET /parent/children/{student_id}/bulletins
+# ---------------------------------------------------------------------------
+
+
+def test_get_child_bulletins_success() -> None:
+    """GET /parent/children/42/bulletins → 200 + bulletins."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.parent_portal.parent_portal_service.get_child_bulletins",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_BULLETINS_RESPONSE,
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/parent/children/42/bulletins")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["student_id"] == 42
+    assert len(body["bulletins"]) == 1
+    assert body["bulletins"][0]["trimester"] == 1
+    assert body["bulletins"][0]["mention"] == "AB"
+
+
+def test_get_child_bulletins_permission_denied() -> None:
+    """GET /parent/children/99/bulletins pour un enfant non lié → 403."""
+    from app.core.exceptions import PermissionDeniedError
+
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.parent_portal.parent_portal_service.get_child_bulletins",
+            new_callable=AsyncMock,
+            side_effect=PermissionDeniedError("access to this student"),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/parent/children/99/bulletins")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
Closes #27

Portail parent — 4 endpoints read-only avec vérification parent-enfant.

### Endpoints
- `GET /parent/children` — liste des enfants inscrits
- `GET /parent/children/{student_id}/grades` — notes d'un enfant (filtre trimestre)
- `GET /parent/children/{student_id}/fees` — frais d'un enfant (totaux calculés)
- `GET /parent/children/{student_id}/bulletins` — bulletins publiés d'un enfant

### Architecture
- `app/schemas/parent_portal.py` — 131 lignes
- `app/repositories/parent_portal_repository.py` — 105 lignes
- `app/services/parent_portal_service.py` — 210 lignes
- `app/routers/parent_portal.py` — 58 lignes
- `tests/routers/test_parent_portal.py` — 324 lignes (11 tests)

### Securite
- Verification `parent_students` link avant chaque accès enfant
- `PermissionDeniedError` si le parent n'est pas lié à l'enfant

## Test plan
- [ ] `pytest tests/routers/test_parent_portal.py -v`
- [ ] Verify 403 when accessing unlinked child
- [ ] Verify 404 when no parent profile