### PR TITLE
feat(teachers): endpoints portail enseignant

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from app.routers.auth import router as auth_router
 from app.routers.dashboard import router as dashboard_router
 from app.routers.enrollments import router as enrollments_router
 from app.routers.grades import router as grades_router
+from app.routers.teacher_portal import router as teacher_portal_router
 from app.routers.timetable import availability_router, teachers_router
 from app.routers.timetable import router as timetable_router
 
@@ -45,6 +46,7 @@ app.include_router(auth_router)
 app.include_router(dashboard_router)
 app.include_router(enrollments_router)
 app.include_router(grades_router)
+app.include_router(teacher_portal_router)
 app.include_router(timetable_router)
 app.include_router(teachers_router)
 app.include_router(availability_router)

--- a/app/repositories/teacher_portal_repository.py
+++ b/app/repositories/teacher_portal_repository.py
@@ -1,0 +1,157 @@
+"""Repository portail enseignant — accès DB read-only pour le teacher portal."""
+
+from datetime import date
+
+from sqlalchemy import distinct, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.academic import Class, Level, Room, Subject
+from app.models.enrollment import Enrollment, EnrollmentStatus
+from app.models.grade import Evaluation, Grade
+from app.models.timetable import TimetableSlot
+from app.models.user import TeacherProfile
+
+
+async def get_teacher_by_user_id(db: AsyncSession, user_id: int) -> TeacherProfile | None:
+    """Retourne le profil enseignant associé à un user_id."""
+    stmt = select(TeacherProfile).where(TeacherProfile.user_id == user_id)
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def get_teacher_classes(
+    db: AsyncSession, teacher_id: int
+) -> list[dict]:
+    """Retourne les classes distinctes assignées à un enseignant via timetable_slots."""
+    stmt = (
+        select(
+            TimetableSlot.class_id,
+            Class.name.label("class_name"),
+            Level.name.label("level_name"),
+            Subject.name.label("subject_name"),
+            TimetableSlot.subject_id,
+        )
+        .join(Class, TimetableSlot.class_id == Class.id)
+        .join(Level, Class.level_id == Level.id)
+        .join(Subject, TimetableSlot.subject_id == Subject.id)
+        .where(TimetableSlot.teacher_id == teacher_id)
+        .distinct()
+        .order_by(Class.name, Subject.name)
+    )
+    rows = (await db.execute(stmt)).all()
+
+    results = []
+    for row in rows:
+        count_stmt = (
+            select(func.count())
+            .select_from(Enrollment)
+            .where(
+                Enrollment.class_id == row.class_id,
+                Enrollment.status.not_in([EnrollmentStatus.ANNULE, EnrollmentStatus.REJETE]),
+            )
+        )
+        student_count = (await db.execute(count_stmt)).scalar() or 0
+        results.append(
+            {
+                "class_id": row.class_id,
+                "class_name": row.class_name,
+                "level_name": row.level_name,
+                "subject_name": row.subject_name,
+                "student_count": student_count,
+            }
+        )
+
+    return results
+
+
+async def get_teacher_schedule(
+    db: AsyncSession, teacher_id: int
+) -> list[TimetableSlot]:
+    """Retourne les créneaux emploi du temps d'un enseignant."""
+    stmt = (
+        select(TimetableSlot)
+        .where(TimetableSlot.teacher_id == teacher_id)
+        .options(
+            selectinload(TimetableSlot.subject),
+            selectinload(TimetableSlot.class_),
+            selectinload(TimetableSlot.room),
+        )
+        .order_by(TimetableSlot.day, TimetableSlot.start_time)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def count_distinct_classes(db: AsyncSession, teacher_id: int) -> int:
+    """Compte les classes distinctes assignées à un enseignant."""
+    stmt = (
+        select(func.count(distinct(TimetableSlot.class_id)))
+        .where(TimetableSlot.teacher_id == teacher_id)
+    )
+    return (await db.execute(stmt)).scalar() or 0
+
+
+async def count_total_students(
+    db: AsyncSession, teacher_id: int
+) -> int:
+    """Compte le nombre total d'élèves dans les classes de l'enseignant."""
+    class_ids_stmt = (
+        select(distinct(TimetableSlot.class_id))
+        .where(TimetableSlot.teacher_id == teacher_id)
+    )
+    stmt = (
+        select(func.count())
+        .select_from(Enrollment)
+        .where(
+            Enrollment.class_id.in_(class_ids_stmt),
+            Enrollment.status.not_in([EnrollmentStatus.ANNULE, EnrollmentStatus.REJETE]),
+        )
+    )
+    return (await db.execute(stmt)).scalar() or 0
+
+
+async def count_upcoming_evaluations(
+    db: AsyncSession, teacher_id: int
+) -> int:
+    """Compte les évaluations à venir pour cet enseignant."""
+    today = date.today()
+    stmt = (
+        select(func.count())
+        .select_from(Evaluation)
+        .where(
+            Evaluation.teacher_id == teacher_id,
+            Evaluation.date > today,
+        )
+    )
+    return (await db.execute(stmt)).scalar() or 0
+
+
+async def get_class_averages(
+    db: AsyncSession, teacher_id: int
+) -> list[dict]:
+    """Calcule la moyenne par classe/matière pour les évaluations de l'enseignant."""
+    stmt = (
+        select(
+            Evaluation.class_id,
+            Class.name.label("class_name"),
+            Subject.name.label("subject_name"),
+            func.avg(Grade.value).label("average"),
+        )
+        .join(Grade, Grade.evaluation_id == Evaluation.id)
+        .join(Class, Evaluation.class_id == Class.id)
+        .join(Subject, Evaluation.subject_id == Subject.id)
+        .where(Evaluation.teacher_id == teacher_id)
+        .group_by(Evaluation.class_id, Class.name, Subject.name)
+        .order_by(Class.name, Subject.name)
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        {
+            "class_id": row.class_id,
+            "class_name": row.class_name,
+            "subject_name": row.subject_name,
+            "average": round(float(row.average), 2) if row.average is not None else None,
+        }
+        for row in rows
+    ]

--- a/app/routers/teacher_portal.py
+++ b/app/routers/teacher_portal.py
@@ -1,0 +1,41 @@
+"""Router portail enseignant — endpoints read-only /teacher."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db
+from app.schemas.teacher_portal import (
+    TeacherClassesListResponse,
+    TeacherDashboardStats,
+    TeacherScheduleResponse,
+)
+from app.services import teacher_portal_service
+
+router = APIRouter(prefix="/teacher", tags=["teacher-portal"])
+
+
+@router.get("/classes", response_model=TeacherClassesListResponse)
+async def get_teacher_classes(
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> TeacherClassesListResponse:
+    """Retourne les classes assignées à l'enseignant connecté."""
+    return await teacher_portal_service.get_classes(db, current_user.user_id)
+
+
+@router.get("/schedule", response_model=TeacherScheduleResponse)
+async def get_teacher_schedule(
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> TeacherScheduleResponse:
+    """Retourne l'emploi du temps personnel de l'enseignant connecté."""
+    return await teacher_portal_service.get_schedule(db, current_user.user_id)
+
+
+@router.get("/dashboard-stats", response_model=TeacherDashboardStats)
+async def get_teacher_dashboard_stats(
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> TeacherDashboardStats:
+    """Retourne les KPIs du dashboard enseignant."""
+    return await teacher_portal_service.get_dashboard_stats(db, current_user.user_id)

--- a/app/schemas/teacher_portal.py
+++ b/app/schemas/teacher_portal.py
@@ -1,0 +1,68 @@
+"""Schemas Pydantic pour le portail enseignant (read-only)."""
+
+from datetime import time
+
+from pydantic import BaseModel, ConfigDict
+
+
+# ---------------------------------------------------------------------------
+# Classes
+# ---------------------------------------------------------------------------
+
+
+class TeacherClassResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    class_id: int
+    class_name: str
+    level_name: str
+    subject_name: str
+    student_count: int
+
+
+class TeacherClassesListResponse(BaseModel):
+    items: list[TeacherClassResponse]
+    total: int
+
+
+# ---------------------------------------------------------------------------
+# Schedule
+# ---------------------------------------------------------------------------
+
+
+class TeacherScheduleSlot(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    day: str
+    start_time: time
+    end_time: time
+    subject_name: str
+    class_name: str
+    room_name: str | None
+
+
+class TeacherScheduleResponse(BaseModel):
+    items: list[TeacherScheduleSlot]
+    total: int
+
+
+# ---------------------------------------------------------------------------
+# Dashboard Stats
+# ---------------------------------------------------------------------------
+
+
+class ClassAverageItem(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    class_id: int
+    class_name: str
+    subject_name: str
+    average: float | None
+
+
+class TeacherDashboardStats(BaseModel):
+    total_classes: int
+    total_students: int
+    upcoming_evaluations: int
+    class_averages: list[ClassAverageItem]

--- a/app/services/teacher_portal_service.py
+++ b/app/services/teacher_portal_service.py
@@ -1,0 +1,73 @@
+"""Service portail enseignant — logique métier read-only."""
+
+import logging
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import NotFoundError
+from app.models.user import TeacherProfile
+from app.repositories import teacher_portal_repository as repo
+from app.schemas.teacher_portal import (
+    ClassAverageItem,
+    TeacherClassesListResponse,
+    TeacherClassResponse,
+    TeacherDashboardStats,
+    TeacherScheduleResponse,
+    TeacherScheduleSlot,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def _get_teacher_for_user(db: AsyncSession, user_id: int) -> TeacherProfile:
+    """Retourne le profil enseignant ou lève NotFoundError."""
+    teacher = await repo.get_teacher_by_user_id(db, user_id)
+    if teacher is None:
+        raise NotFoundError("TeacherProfile", user_id)
+    return teacher
+
+
+async def get_classes(db: AsyncSession, user_id: int) -> TeacherClassesListResponse:
+    """Retourne les classes assignées à l'enseignant via timetable_slots."""
+    teacher = await _get_teacher_for_user(db, user_id)
+    classes = await repo.get_teacher_classes(db, teacher.id)
+    items = [TeacherClassResponse(**c) for c in classes]
+    return TeacherClassesListResponse(items=items, total=len(items))
+
+
+async def get_schedule(db: AsyncSession, user_id: int) -> TeacherScheduleResponse:
+    """Retourne l'emploi du temps personnel de l'enseignant."""
+    teacher = await _get_teacher_for_user(db, user_id)
+    slots = await repo.get_teacher_schedule(db, teacher.id)
+    items = [
+        TeacherScheduleSlot(
+            id=slot.id,
+            day=slot.day,
+            start_time=slot.start_time,
+            end_time=slot.end_time,
+            subject_name=slot.subject.name,
+            class_name=slot.class_.name,
+            room_name=slot.room.name if slot.room else None,
+        )
+        for slot in slots
+    ]
+    return TeacherScheduleResponse(items=items, total=len(items))
+
+
+async def get_dashboard_stats(db: AsyncSession, user_id: int) -> TeacherDashboardStats:
+    """Retourne les KPIs du dashboard enseignant."""
+    teacher = await _get_teacher_for_user(db, user_id)
+
+    total_classes = await repo.count_distinct_classes(db, teacher.id)
+    total_students = await repo.count_total_students(db, teacher.id)
+    upcoming_evaluations = await repo.count_upcoming_evaluations(db, teacher.id)
+    averages_raw = await repo.get_class_averages(db, teacher.id)
+
+    class_averages = [ClassAverageItem(**a) for a in averages_raw]
+
+    return TeacherDashboardStats(
+        total_classes=total_classes,
+        total_students=total_students,
+        upcoming_evaluations=upcoming_evaluations,
+        class_averages=class_averages,
+    )

--- a/tests/routers/test_teacher_portal.py
+++ b/tests/routers/test_teacher_portal.py
@@ -1,0 +1,222 @@
+"""Tests des endpoints /teacher (portail enseignant)."""
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db
+from app.core.redis import get_redis
+from app.main import app
+from app.schemas.teacher_portal import (
+    ClassAverageItem,
+    TeacherClassesListResponse,
+    TeacherClassResponse,
+    TeacherDashboardStats,
+    TeacherScheduleResponse,
+    TeacherScheduleSlot,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MOCK_USER = TokenData(user_id=10, tenant_id="local", email="teacher@college.ci")
+
+SAMPLE_CLASS = TeacherClassResponse(
+    class_id=1,
+    class_name="Terminale C",
+    level_name="Terminale",
+    subject_name="Mathematiques",
+    student_count=35,
+)
+
+SAMPLE_CLASSES_LIST = TeacherClassesListResponse(
+    items=[SAMPLE_CLASS],
+    total=1,
+)
+
+SAMPLE_SLOT = TeacherScheduleSlot(
+    id=1,
+    day="monday",
+    start_time="08:00:00",
+    end_time="10:00:00",
+    subject_name="Mathematiques",
+    class_name="Terminale C",
+    room_name="Salle 101",
+)
+
+SAMPLE_SCHEDULE = TeacherScheduleResponse(
+    items=[SAMPLE_SLOT],
+    total=1,
+)
+
+SAMPLE_AVERAGE = ClassAverageItem(
+    class_id=1,
+    class_name="Terminale C",
+    subject_name="Mathematiques",
+    average=14.5,
+)
+
+SAMPLE_STATS = TeacherDashboardStats(
+    total_classes=3,
+    total_students=105,
+    upcoming_evaluations=2,
+    class_averages=[SAMPLE_AVERAGE],
+)
+
+
+def _override_deps() -> None:
+    """Surcharge les dépendances d'auth et DB pour les tests."""
+    app.dependency_overrides[get_current_user] = lambda: MOCK_USER
+    app.dependency_overrides[get_tenant_db] = lambda: AsyncMock()
+    app.dependency_overrides[get_redis] = lambda: AsyncMock()
+
+
+def _clear_deps() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# GET /teacher/classes
+# ---------------------------------------------------------------------------
+
+
+def test_get_teacher_classes_success() -> None:
+    """GET /teacher/classes → 200 + liste des classes."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.teacher_portal.teacher_portal_service.get_classes",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_CLASSES_LIST,
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/teacher/classes")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert len(body["items"]) == 1
+    assert body["items"][0]["class_name"] == "Terminale C"
+    assert body["items"][0]["student_count"] == 35
+
+
+def test_get_teacher_classes_not_a_teacher() -> None:
+    """GET /teacher/classes sans profil enseignant → 404."""
+    from app.core.exceptions import NotFoundError
+
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.teacher_portal.teacher_portal_service.get_classes",
+            new_callable=AsyncMock,
+            side_effect=NotFoundError("TeacherProfile", 10),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/teacher/classes")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 404
+
+
+def test_get_teacher_classes_unauthenticated() -> None:
+    """GET /teacher/classes sans token → 401."""
+    with TestClient(app) as client:
+        resp = client.get("/teacher/classes")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /teacher/schedule
+# ---------------------------------------------------------------------------
+
+
+def test_get_teacher_schedule_success() -> None:
+    """GET /teacher/schedule → 200 + emploi du temps."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.teacher_portal.teacher_portal_service.get_schedule",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_SCHEDULE,
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/teacher/schedule")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["items"][0]["day"] == "monday"
+    assert body["items"][0]["subject_name"] == "Mathematiques"
+    assert body["items"][0]["room_name"] == "Salle 101"
+
+
+def test_get_teacher_schedule_not_a_teacher() -> None:
+    """GET /teacher/schedule sans profil enseignant → 404."""
+    from app.core.exceptions import NotFoundError
+
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.teacher_portal.teacher_portal_service.get_schedule",
+            new_callable=AsyncMock,
+            side_effect=NotFoundError("TeacherProfile", 10),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/teacher/schedule")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /teacher/dashboard-stats
+# ---------------------------------------------------------------------------
+
+
+def test_get_teacher_dashboard_stats_success() -> None:
+    """GET /teacher/dashboard-stats → 200 + KPIs."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.teacher_portal.teacher_portal_service.get_dashboard_stats",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_STATS,
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/teacher/dashboard-stats")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_classes"] == 3
+    assert body["total_students"] == 105
+    assert body["upcoming_evaluations"] == 2
+    assert len(body["class_averages"]) == 1
+    assert body["class_averages"][0]["average"] == 14.5
+
+
+def test_get_teacher_dashboard_stats_not_a_teacher() -> None:
+    """GET /teacher/dashboard-stats sans profil enseignant → 404."""
+    from app.core.exceptions import NotFoundError
+
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.teacher_portal.teacher_portal_service.get_dashboard_stats",
+            new_callable=AsyncMock,
+            side_effect=NotFoundError("TeacherProfile", 10),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/teacher/dashboard-stats")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
Closes #28

Portail enseignant — 3 endpoints read-only avec dashboard stats.

### Endpoints
- `GET /teacher/classes` — classes assignées (via timetable_slots)
- `GET /teacher/schedule` — emploi du temps personnel
- `GET /teacher/dashboard-stats` — KPIs (nb classes, nb élèves, moyennes, évaluations)

### Architecture
- `app/schemas/teacher_portal.py` — 68 lignes
- `app/repositories/teacher_portal_repository.py` — 157 lignes
- `app/services/teacher_portal_service.py` — 73 lignes
- `app/routers/teacher_portal.py` — 41 lignes
- `tests/routers/test_teacher_portal.py` — 222 lignes

### Securite
Scoped au teacher connecté via `teacher_profiles.user_id`

## Test plan
- [ ] `pytest tests/routers/test_teacher_portal.py -v`
- [ ] Verify 404 when no teacher profile
- [ ] Verify teacher only sees own assignments