### PR TITLE
feat(reports): bulletin scolaire trimestriel conforme Côte d'Ivoire

### DIFF
--- a/alembic/versions/20260406_0003_add_bulletin_columns_and_subject_averages.py
+++ b/alembic/versions/20260406_0003_add_bulletin_columns_and_subject_averages.py
@@ -1,0 +1,62 @@
+"""Add bulletin columns (teacher_comment, council_decision) and subject_averages table.
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-04-06
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0003"
+down_revision: str | None = "0002"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    # --- Add columns to bulletins ---
+    op.add_column("bulletins", sa.Column("teacher_comment", sa.Text(), nullable=True))
+    op.add_column(
+        "bulletins",
+        sa.Column(
+            "council_decision",
+            sa.Enum("passage", "repechage", "redoublement", "exclusion", name="council_decision"),
+            nullable=True,
+        ),
+    )
+
+    # --- Create subject_averages table ---
+    op.create_table(
+        "subject_averages",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("bulletin_id", sa.BigInteger(), nullable=False),
+        sa.Column("subject_id", sa.BigInteger(), nullable=False),
+        sa.Column("student_id", sa.BigInteger(), nullable=False),
+        sa.Column("trimester", sa.Integer(), nullable=False),
+        sa.Column("average", sa.Numeric(4, 2), nullable=False),
+        sa.Column("coefficient", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["bulletin_id"], ["bulletins.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["subject_id"], ["subjects.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["student_id"], ["students.id"], ondelete="RESTRICT"),
+    )
+    op.create_index("idx_subject_averages_bulletin_id", "subject_averages", ["bulletin_id"])
+    op.create_index("idx_subject_averages_subject_id", "subject_averages", ["subject_id"])
+    op.create_index("idx_subject_averages_student_id", "subject_averages", ["student_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("subject_averages")
+    op.drop_column("bulletins", "council_decision")
+    op.drop_column("bulletins", "teacher_comment")
+    op.execute("DROP TYPE IF EXISTS council_decision")

--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from app.routers.auth import router as auth_router
 from app.routers.dashboard import router as dashboard_router
 from app.routers.enrollments import router as enrollments_router
 from app.routers.grades import router as grades_router
+from app.routers.reports import router as reports_router
 from app.routers.timetable import availability_router, teachers_router
 from app.routers.timetable import router as timetable_router
 
@@ -45,6 +46,7 @@ app.include_router(auth_router)
 app.include_router(dashboard_router)
 app.include_router(enrollments_router)
 app.include_router(grades_router)
+app.include_router(reports_router)
 app.include_router(timetable_router)
 app.include_router(teachers_router)
 app.include_router(availability_router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -50,11 +50,13 @@ from app.models.fee import (  # noqa: F401
 # Notes et bulletins
 from app.models.grade import (  # noqa: F401
     Bulletin,
+    CouncilDecision,
     Evaluation,
     EvaluationType,
     Grade,
     GradeStatus,
     Mention,
+    SubjectAverage,
 )
 
 # Messagerie interne

--- a/app/models/grade.py
+++ b/app/models/grade.py
@@ -1,4 +1,4 @@
-"""Modèles de notes : Evaluation, Grade, Bulletin."""
+"""Modèles de notes : Evaluation, Grade, Bulletin, SubjectAverage."""
 
 from __future__ import annotations
 
@@ -17,6 +17,7 @@ from sqlalchemy import (
     Integer,
     Numeric,
     String,
+    Text,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -46,6 +47,13 @@ class Mention(str, enum.Enum):
     ASSEZ_BIEN = "AB"  # >= 12
     PASSABLE = "P"  # >= 10
     MEDIOCRE = "M"  # < 10
+
+
+class CouncilDecision(str, enum.Enum):
+    PASSAGE = "passage"
+    REPECHAGE = "repechage"
+    REDOUBLEMENT = "redoublement"
+    EXCLUSION = "exclusion"
 
 
 class Evaluation(Base, TimestampMixin):
@@ -132,7 +140,36 @@ class Bulletin(Base, TimestampMixin):
     file_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     generated_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     is_published: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    teacher_comment: Mapped[str | None] = mapped_column(Text, nullable=True)
+    council_decision: Mapped[str | None] = mapped_column(
+        ValueEnum(CouncilDecision, name="council_decision"), nullable=True
+    )
 
     student: Mapped[Student] = relationship()
     class_: Mapped[Class] = relationship()
     academic_year: Mapped[AcademicYear] = relationship()
+    subject_averages: Mapped[list[SubjectAverage]] = relationship(back_populates="bulletin")
+
+
+class SubjectAverage(Base, TimestampMixin):
+    """Moyenne par matière pour un bulletin trimestriel."""
+
+    __tablename__ = "subject_averages"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    bulletin_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("bulletins.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    subject_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("subjects.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    student_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("students.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    trimester: Mapped[int] = mapped_column(Integer, nullable=False)
+    average: Mapped[Decimal] = mapped_column(Numeric(4, 2), nullable=False)
+    coefficient: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+
+    bulletin: Mapped[Bulletin] = relationship(back_populates="subject_averages")
+    subject: Mapped[Subject] = relationship()
+    student: Mapped[Student] = relationship()

--- a/app/repositories/reports_repository.py
+++ b/app/repositories/reports_repository.py
@@ -1,0 +1,218 @@
+"""Repository reports — accès DB pour Bulletin et SubjectAverage."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.enrollment import Enrollment
+from app.models.grade import (
+    Bulletin,
+    Evaluation,
+    Grade,
+    GradeStatus,
+    SubjectAverage,
+)
+from app.models.user import Student
+
+
+async def get_enrolled_students(
+    db: AsyncSession, class_id: int, academic_year_id: int
+) -> list[Student]:
+    """Retourne les eleves inscrits (valide) dans une classe."""
+    stmt = (
+        select(Student)
+        .join(Enrollment, Enrollment.student_id == Student.id)
+        .where(
+            Enrollment.class_id == class_id,
+            Enrollment.academic_year_id == academic_year_id,
+            Enrollment.status == "valide",
+        )
+        .order_by(Student.last_name, Student.first_name)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_evaluations_for_class_trimester(
+    db: AsyncSession,
+    class_id: int,
+    trimester: int,
+    academic_year_id: int,
+) -> list[Evaluation]:
+    """Retourne toutes les evaluations d'une classe pour un trimestre."""
+    stmt = (
+        select(Evaluation)
+        .where(
+            Evaluation.class_id == class_id,
+            Evaluation.trimester == trimester,
+            Evaluation.academic_year_id == academic_year_id,
+        )
+        .options(selectinload(Evaluation.subject))
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_entered_grades_for_evaluations(
+    db: AsyncSession, eval_ids: list[int]
+) -> list[Grade]:
+    """Retourne toutes les notes saisies pour une liste d'evaluations."""
+    if not eval_ids:
+        return []
+    stmt = (
+        select(Grade)
+        .where(
+            Grade.evaluation_id.in_(eval_ids),
+            Grade.status == GradeStatus.ENTERED,
+        )
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_bulletin(
+    db: AsyncSession,
+    student_id: int,
+    class_id: int,
+    academic_year_id: int,
+    trimester: int,
+) -> Bulletin | None:
+    """Retourne un bulletin existant ou None."""
+    stmt = select(Bulletin).where(
+        Bulletin.student_id == student_id,
+        Bulletin.class_id == class_id,
+        Bulletin.academic_year_id == academic_year_id,
+        Bulletin.trimester == trimester,
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def upsert_bulletin(
+    db: AsyncSession,
+    *,
+    student_id: int,
+    class_id: int,
+    academic_year_id: int,
+    trimester: int,
+    average: Decimal | None,
+    rank: int | None,
+    mention: str | None,
+    teacher_comment: str | None = None,
+    council_decision: str | None = None,
+) -> Bulletin:
+    """Cree ou met a jour un bulletin."""
+    bulletin = await get_bulletin(db, student_id, class_id, academic_year_id, trimester)
+
+    if bulletin is None:
+        bulletin = Bulletin(
+            student_id=student_id,
+            class_id=class_id,
+            academic_year_id=academic_year_id,
+            trimester=trimester,
+            average=average,
+            rank=rank,
+            mention=mention,
+            teacher_comment=teacher_comment,
+            council_decision=council_decision,
+        )
+        db.add(bulletin)
+    else:
+        bulletin.average = average
+        bulletin.rank = rank
+        bulletin.mention = mention
+        bulletin.teacher_comment = teacher_comment
+        bulletin.council_decision = council_decision
+
+    await db.flush()
+    return bulletin
+
+
+async def delete_subject_averages_for_bulletin(db: AsyncSession, bulletin_id: int) -> None:
+    """Supprime les moyennes par matiere d'un bulletin (avant regeneration)."""
+    stmt = delete(SubjectAverage).where(SubjectAverage.bulletin_id == bulletin_id)
+    await db.execute(stmt)
+
+
+async def create_subject_average(
+    db: AsyncSession,
+    *,
+    bulletin_id: int,
+    subject_id: int,
+    student_id: int,
+    trimester: int,
+    average: Decimal,
+    coefficient: int,
+) -> SubjectAverage:
+    """Cree une moyenne par matiere."""
+    sa_record = SubjectAverage(
+        bulletin_id=bulletin_id,
+        subject_id=subject_id,
+        student_id=student_id,
+        trimester=trimester,
+        average=average,
+        coefficient=coefficient,
+    )
+    db.add(sa_record)
+    await db.flush()
+    return sa_record
+
+
+async def list_bulletins_for_class(
+    db: AsyncSession,
+    class_id: int,
+    trimester: int,
+    academic_year_id: int,
+) -> list[Bulletin]:
+    """Retourne tous les bulletins d'une classe pour un trimestre."""
+    stmt = (
+        select(Bulletin)
+        .where(
+            Bulletin.class_id == class_id,
+            Bulletin.trimester == trimester,
+            Bulletin.academic_year_id == academic_year_id,
+        )
+        .options(
+            selectinload(Bulletin.student),
+            selectinload(Bulletin.class_),
+            selectinload(Bulletin.subject_averages).selectinload(SubjectAverage.subject),
+        )
+        .order_by(Bulletin.rank.asc().nullslast())
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_bulletin_by_id(db: AsyncSession, bulletin_id: int) -> Bulletin | None:
+    """Retourne un bulletin par ID avec ses relations."""
+    stmt = (
+        select(Bulletin)
+        .where(Bulletin.id == bulletin_id)
+        .options(
+            selectinload(Bulletin.student),
+            selectinload(Bulletin.class_),
+            selectinload(Bulletin.subject_averages).selectinload(SubjectAverage.subject),
+        )
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def count_enrolled_students(
+    db: AsyncSession, class_id: int, academic_year_id: int
+) -> int:
+    """Compte les eleves inscrits valides dans une classe."""
+    stmt = (
+        select(func.count())
+        .select_from(Enrollment)
+        .where(
+            Enrollment.class_id == class_id,
+            Enrollment.academic_year_id == academic_year_id,
+            Enrollment.status == "valide",
+        )
+    )
+    return (await db.execute(stmt)).scalar() or 0

--- a/app/routers/reports.py
+++ b/app/routers/reports.py
@@ -1,0 +1,64 @@
+"""Router reports — generation et consultation des bulletins scolaires."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db, require_permission
+from app.schemas.reports import (
+    BulletinGenerateRequest,
+    BulletinGenerateResponse,
+    BulletinListResponse,
+)
+from app.services import reports_service as service
+
+router = APIRouter(prefix="/reports", tags=["reports"])
+
+
+@router.post(
+    "/bulletins/generate",
+    response_model=BulletinGenerateResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def generate_bulletins(
+    data: BulletinGenerateRequest,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("reports:generate"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> Any:
+    """Genere les bulletins pour une classe et un trimestre."""
+    return await service.generate_bulletins(
+        db,
+        class_id=data.class_id,
+        trimester=data.trimester,
+        academic_year_id=data.academic_year_id,
+        generated_by=current_user.user_id,
+    )
+
+
+@router.get(
+    "/bulletins/{class_id}/{trimester}",
+    response_model=BulletinListResponse,
+)
+async def list_bulletins(
+    class_id: int,
+    trimester: int,
+    academic_year_id: int = Query(...),
+    _: None = require_permission("reports:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> Any:
+    """Liste les bulletins generes pour une classe/trimestre."""
+    return await service.list_bulletins(db, class_id, trimester, academic_year_id)
+
+
+@router.get("/bulletins/{bulletin_id}/pdf")
+async def get_bulletin_pdf(
+    bulletin_id: int,
+    _: None = require_permission("reports:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> Any:
+    """Retourne l'URL du PDF d'un bulletin (placeholder)."""
+    return await service.get_bulletin_pdf(db, bulletin_id)

--- a/app/schemas/reports.py
+++ b/app/schemas/reports.py
@@ -1,0 +1,71 @@
+"""Schémas Pydantic pour les bulletins scolaires (reports)."""
+
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# ---------------------------------------------------------------------------
+# Request
+# ---------------------------------------------------------------------------
+
+
+class BulletinGenerateRequest(BaseModel):
+    class_id: int
+    trimester: int = Field(ge=1, le=3)
+    academic_year_id: int
+
+
+# ---------------------------------------------------------------------------
+# Response — Subject Average
+# ---------------------------------------------------------------------------
+
+
+class SubjectAverageResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    subject_id: int
+    subject_name: str
+    average: Decimal
+    coefficient: int
+
+
+# ---------------------------------------------------------------------------
+# Response — Bulletin
+# ---------------------------------------------------------------------------
+
+
+class BulletinResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    student_id: int
+    student_name: str
+    class_id: int
+    class_name: str
+    academic_year_id: int
+    trimester: int
+    average: Decimal | None
+    rank: int | None
+    total_students: int
+    mention: str | None
+    teacher_comment: str | None
+    council_decision: str | None
+    file_url: str | None
+    generated_at: datetime | None
+    is_published: bool
+    subject_averages: list[SubjectAverageResponse]
+    created_at: datetime
+    updated_at: datetime
+
+
+class BulletinListResponse(BaseModel):
+    items: list[BulletinResponse]
+    total: int
+
+
+class BulletinGenerateResponse(BaseModel):
+    message: str
+    generated: int
+    bulletins: list[BulletinResponse]

--- a/app/services/reports_service.py
+++ b/app/services/reports_service.py
@@ -1,0 +1,338 @@
+"""Service reports — generation des bulletins scolaires trimestriels."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.audit import AuditAction, audit_log
+from app.core.exceptions import BusinessValidationError, NotFoundError
+from app.models.grade import Bulletin, CouncilDecision, Mention, SubjectAverage
+from app.repositories import reports_repository as repo
+from app.schemas.reports import (
+    BulletinGenerateResponse,
+    BulletinListResponse,
+    BulletinResponse,
+    SubjectAverageResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _quantize(value: Decimal) -> Decimal:
+    return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _compute_mention(avg: Decimal | None) -> str | None:
+    if avg is None:
+        return None
+    if avg >= 16:
+        return Mention.TRES_BIEN.value
+    if avg >= 14:
+        return Mention.BIEN.value
+    if avg >= 12:
+        return Mention.ASSEZ_BIEN.value
+    if avg >= 10:
+        return Mention.PASSABLE.value
+    return Mention.MEDIOCRE.value
+
+
+def _compute_council_decision(mga: Decimal | None) -> str | None:
+    """Determine la decision du conseil de classe (trimestre 3 uniquement)."""
+    if mga is None:
+        return None
+    if mga >= 10:
+        return CouncilDecision.PASSAGE.value
+    if mga >= Decimal("9.5"):
+        return CouncilDecision.REPECHAGE.value
+    if mga >= Decimal("8.5"):
+        return CouncilDecision.REDOUBLEMENT.value
+    return CouncilDecision.EXCLUSION.value
+
+
+def _student_full_name(student: Any) -> str:
+    return f"{student.first_name} {student.last_name}"
+
+
+def _bulletin_to_response(bulletin: Bulletin, total_students: int) -> BulletinResponse:
+    subject_avgs = [
+        SubjectAverageResponse(
+            subject_id=sa.subject_id,
+            subject_name=sa.subject.name if sa.subject else "",
+            average=sa.average,
+            coefficient=sa.coefficient,
+        )
+        for sa in (bulletin.subject_averages or [])
+    ]
+    return BulletinResponse(
+        id=bulletin.id,
+        student_id=bulletin.student_id,
+        student_name=_student_full_name(bulletin.student) if bulletin.student else "",
+        class_id=bulletin.class_id,
+        class_name=bulletin.class_.name if bulletin.class_ else "",
+        academic_year_id=bulletin.academic_year_id,
+        trimester=bulletin.trimester,
+        average=bulletin.average,
+        rank=bulletin.rank,
+        total_students=total_students,
+        mention=bulletin.mention,
+        teacher_comment=bulletin.teacher_comment,
+        council_decision=bulletin.council_decision,
+        file_url=bulletin.file_url,
+        generated_at=bulletin.generated_at,
+        is_published=bulletin.is_published,
+        subject_averages=subject_avgs,
+        created_at=bulletin.created_at,
+        updated_at=bulletin.updated_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Generate bulletins
+# ---------------------------------------------------------------------------
+
+
+async def generate_bulletins(
+    db: AsyncSession,
+    *,
+    class_id: int,
+    trimester: int,
+    academic_year_id: int,
+    generated_by: int,
+) -> BulletinGenerateResponse:
+    """Genere les bulletins pour tous les eleves d'une classe/trimestre."""
+    # 1. Recuperer les eleves inscrits
+    students = await repo.get_enrolled_students(db, class_id, academic_year_id)
+    if not students:
+        raise BusinessValidationError(
+            f"No enrolled students found for class {class_id} / year {academic_year_id}"
+        )
+
+    # 2. Recuperer les evaluations du trimestre
+    evaluations = await repo.get_evaluations_for_class_trimester(
+        db, class_id, trimester, academic_year_id
+    )
+    if not evaluations:
+        raise BusinessValidationError(
+            f"No evaluations found for class {class_id} / trimester {trimester}"
+        )
+
+    eval_map = {e.id: e for e in evaluations}
+    eval_ids = list(eval_map.keys())
+
+    # 3. Recuperer toutes les notes saisies
+    grades = await repo.get_entered_grades_for_evaluations(db, eval_ids)
+
+    # 4. Calculer les moyennes par matiere pour chaque eleve
+    # Structure: {student_id: {subject_id: [(grade_value, eval_coefficient)]}}
+    student_subject_grades: dict[int, dict[int, list[tuple[Decimal, int]]]] = {}
+    for g in grades:
+        if g.value is None:
+            continue
+        ev = eval_map.get(g.evaluation_id)
+        if ev is None:
+            continue
+        student_subject_grades.setdefault(g.student_id, {}).setdefault(
+            ev.subject_id, []
+        ).append((g.value, ev.coefficient))
+
+    # Subject coefficient map
+    subject_coeff_map: dict[int, int] = {}
+    for ev in evaluations:
+        if ev.subject and ev.subject_id not in subject_coeff_map:
+            subject_coeff_map[ev.subject_id] = ev.subject.coefficient
+
+    # Subject name map for later
+    subject_name_map: dict[int, str] = {}
+    for ev in evaluations:
+        if ev.subject and ev.subject_id not in subject_name_map:
+            subject_name_map[ev.subject_id] = ev.subject.name
+
+    # 5. Pour chaque eleve: calculer moyenne matiere, puis moyenne trimestrielle
+    student_averages: dict[int, Decimal | None] = {}
+    student_subject_avgs: dict[int, dict[int, Decimal]] = {}
+
+    for student in students:
+        sid = student.id
+        subj_grades = student_subject_grades.get(sid, {})
+        if not subj_grades:
+            student_averages[sid] = None
+            continue
+
+        weighted_sum = Decimal("0")
+        total_coeff = 0
+        subj_avgs: dict[int, Decimal] = {}
+
+        for subject_id, grade_pairs in subj_grades.items():
+            # Subject average = sum(grade * eval_coeff) / sum(eval_coeff)
+            numerator = sum(Decimal(str(v)) * c for v, c in grade_pairs)
+            denominator = sum(c for _, c in grade_pairs)
+            if denominator == 0:
+                continue
+            subject_avg = _quantize(numerator / denominator)
+            subj_avgs[subject_id] = subject_avg
+
+            # Weighted by subject coefficient for trimester average
+            s_coeff = subject_coeff_map.get(subject_id, 1)
+            weighted_sum += subject_avg * s_coeff
+            total_coeff += s_coeff
+
+        student_subject_avgs[sid] = subj_avgs
+
+        if total_coeff > 0:
+            student_averages[sid] = _quantize(weighted_sum / total_coeff)
+        else:
+            student_averages[sid] = None
+
+    # 6. Ranking (competition ranking: ex-aequo share same rank)
+    ranked = sorted(
+        [(sid, avg) for sid, avg in student_averages.items() if avg is not None],
+        key=lambda x: x[1],
+        reverse=True,
+    )
+    student_ranks: dict[int, int | None] = {s.id: None for s in students}
+    rank = 1
+    for i, (sid, avg) in enumerate(ranked):
+        if i > 0 and avg == ranked[i - 1][1]:
+            student_ranks[sid] = student_ranks[ranked[i - 1][0]]
+        else:
+            student_ranks[sid] = rank
+        rank = i + 2
+
+    total_students = len(students)
+
+    # 7. For trimester 3: compute MGA and council decision
+    # MGA = (T1*1 + T2*2 + T3*2) / 5
+    mga_map: dict[int, Decimal | None] = {}
+    council_decisions: dict[int, str | None] = {}
+    if trimester == 3:
+        for student in students:
+            sid = student.id
+            t3_avg = student_averages.get(sid)
+            if t3_avg is None:
+                mga_map[sid] = None
+                council_decisions[sid] = None
+                continue
+
+            # Fetch T1 and T2 bulletins
+            t1_bulletin = await repo.get_bulletin(db, sid, class_id, academic_year_id, 1)
+            t2_bulletin = await repo.get_bulletin(db, sid, class_id, academic_year_id, 2)
+
+            t1_avg = t1_bulletin.average if t1_bulletin and t1_bulletin.average is not None else None
+            t2_avg = t2_bulletin.average if t2_bulletin and t2_bulletin.average is not None else None
+
+            if t1_avg is not None and t2_avg is not None:
+                mga = _quantize(
+                    (t1_avg * 1 + t2_avg * 2 + t3_avg * 2) / 5
+                )
+                mga_map[sid] = mga
+                council_decisions[sid] = _compute_council_decision(mga)
+            else:
+                mga_map[sid] = None
+                council_decisions[sid] = None
+
+    # 8. Create/update bulletins and subject averages in a transaction
+    async with db.begin_nested():
+        bulletin_ids: list[int] = []
+        for student in students:
+            sid = student.id
+            avg = student_averages.get(sid)
+            mention = _compute_mention(avg)
+            decision = council_decisions.get(sid) if trimester == 3 else None
+
+            bulletin = await repo.upsert_bulletin(
+                db,
+                student_id=sid,
+                class_id=class_id,
+                academic_year_id=academic_year_id,
+                trimester=trimester,
+                average=avg,
+                rank=student_ranks.get(sid),
+                mention=mention,
+                council_decision=decision,
+            )
+            bulletin.generated_at = datetime.utcnow()
+            bulletin_ids.append(bulletin.id)
+
+            # Delete existing subject averages and recreate
+            await repo.delete_subject_averages_for_bulletin(db, bulletin.id)
+
+            subj_avgs = student_subject_avgs.get(sid, {})
+            for subject_id, subject_avg in subj_avgs.items():
+                await repo.create_subject_average(
+                    db,
+                    bulletin_id=bulletin.id,
+                    subject_id=subject_id,
+                    student_id=sid,
+                    trimester=trimester,
+                    average=subject_avg,
+                    coefficient=subject_coeff_map.get(subject_id, 1),
+                )
+
+        await audit_log(
+            db,
+            entity_type="bulletin",
+            action=AuditAction.CREATE,
+            user_id=generated_by,
+            notes=f"Generated {len(bulletin_ids)} bulletins for class {class_id} T{trimester}",
+            new_values={"class_id": class_id, "trimester": trimester, "count": len(bulletin_ids)},
+        )
+
+    await db.commit()
+
+    # 9. Reload bulletins with relations for response
+    bulletins = await repo.list_bulletins_for_class(db, class_id, trimester, academic_year_id)
+    return BulletinGenerateResponse(
+        message=f"Generated {len(bulletins)} bulletins for trimester {trimester}",
+        generated=len(bulletins),
+        bulletins=[_bulletin_to_response(b, total_students) for b in bulletins],
+    )
+
+
+# ---------------------------------------------------------------------------
+# List bulletins
+# ---------------------------------------------------------------------------
+
+
+async def list_bulletins(
+    db: AsyncSession,
+    class_id: int,
+    trimester: int,
+    academic_year_id: int,
+) -> BulletinListResponse:
+    """Liste les bulletins generes pour une classe/trimestre."""
+    bulletins = await repo.list_bulletins_for_class(db, class_id, trimester, academic_year_id)
+    total_students = await repo.count_enrolled_students(db, class_id, academic_year_id)
+    return BulletinListResponse(
+        items=[_bulletin_to_response(b, total_students) for b in bulletins],
+        total=len(bulletins),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Get bulletin PDF (placeholder)
+# ---------------------------------------------------------------------------
+
+
+async def get_bulletin_pdf(db: AsyncSession, bulletin_id: int) -> dict[str, Any]:
+    """Retourne l'URL du PDF d'un bulletin (placeholder)."""
+    bulletin = await repo.get_bulletin_by_id(db, bulletin_id)
+    if bulletin is None:
+        raise NotFoundError("Bulletin", bulletin_id)
+
+    # Placeholder: return existing file_url or a generated one
+    pdf_url = bulletin.file_url or f"/reports/bulletins/{bulletin_id}/download"
+    return {
+        "bulletin_id": bulletin_id,
+        "student_id": bulletin.student_id,
+        "pdf_url": pdf_url,
+    }

--- a/tests/routers/test_reports.py
+++ b/tests/routers/test_reports.py
@@ -1,0 +1,224 @@
+"""Tests des endpoints /reports/bulletins."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db
+from app.core.redis import get_redis
+from app.main import app
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+NOW = datetime.now(UTC)
+
+MOCK_USER = TokenData(user_id=1, tenant_id="local", email="admin@college.ci")
+
+SAMPLE_SUBJECT_AVG = {
+    "subject_id": 2,
+    "subject_name": "Mathématiques",
+    "average": Decimal("14.50"),
+    "coefficient": 4,
+}
+
+SAMPLE_BULLETIN = {
+    "id": 1,
+    "student_id": 42,
+    "student_name": "Koffi Aya",
+    "class_id": 3,
+    "class_name": "Terminale C",
+    "academic_year_id": 1,
+    "trimester": 1,
+    "average": Decimal("14.25"),
+    "rank": 1,
+    "total_students": 35,
+    "mention": "B",
+    "teacher_comment": None,
+    "council_decision": None,
+    "file_url": None,
+    "generated_at": NOW,
+    "is_published": False,
+    "subject_averages": [SAMPLE_SUBJECT_AVG],
+    "created_at": NOW,
+    "updated_at": NOW,
+}
+
+SAMPLE_GENERATE_RESPONSE = {
+    "message": "Generated 2 bulletins for trimester 1",
+    "generated": 2,
+    "bulletins": [SAMPLE_BULLETIN],
+}
+
+SAMPLE_LIST_RESPONSE = {
+    "items": [SAMPLE_BULLETIN],
+    "total": 1,
+}
+
+SAMPLE_PDF_RESPONSE = {
+    "bulletin_id": 1,
+    "student_id": 42,
+    "pdf_url": "/reports/bulletins/1/download",
+}
+
+
+def _override_deps() -> None:
+    app.dependency_overrides[get_current_user] = lambda: MOCK_USER
+    app.dependency_overrides[get_tenant_db] = lambda: AsyncMock()
+    app.dependency_overrides[get_redis] = lambda: AsyncMock()
+
+
+def _clear_deps() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# POST /reports/bulletins/generate
+# ---------------------------------------------------------------------------
+
+
+def test_generate_bulletins_success() -> None:
+    """POST /reports/bulletins/generate → 201 + bulletins generes."""
+    _override_deps()
+    try:
+        with patch(
+            "app.services.reports_service.generate_bulletins",
+            new=AsyncMock(return_value=SAMPLE_GENERATE_RESPONSE),
+        ):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/reports/bulletins/generate",
+                    json={"class_id": 3, "trimester": 1, "academic_year_id": 1},
+                )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["generated"] == 2
+        assert len(data["bulletins"]) == 1
+        assert data["bulletins"][0]["student_name"] == "Koffi Aya"
+    finally:
+        _clear_deps()
+
+
+def test_generate_bulletins_invalid_trimester() -> None:
+    """POST /reports/bulletins/generate avec trimester=4 → 422."""
+    _override_deps()
+    try:
+        with TestClient(app) as client:
+            resp = client.post(
+                "/reports/bulletins/generate",
+                json={"class_id": 3, "trimester": 4, "academic_year_id": 1},
+            )
+        assert resp.status_code == 422
+    finally:
+        _clear_deps()
+
+
+def test_generate_bulletins_no_auth() -> None:
+    """POST /reports/bulletins/generate sans token → 401/403."""
+    _clear_deps()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/reports/bulletins/generate",
+            json={"class_id": 3, "trimester": 1, "academic_year_id": 1},
+        )
+    assert resp.status_code in (401, 403)
+
+
+def test_generate_bulletins_no_students() -> None:
+    """POST /reports/bulletins/generate sans eleves → 422."""
+    _override_deps()
+    try:
+        from app.core.exceptions import BusinessValidationError
+
+        with patch(
+            "app.services.reports_service.generate_bulletins",
+            new=AsyncMock(
+                side_effect=BusinessValidationError("No enrolled students found for class 3 / year 1")
+            ),
+        ):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/reports/bulletins/generate",
+                    json={"class_id": 3, "trimester": 1, "academic_year_id": 1},
+                )
+        assert resp.status_code == 422
+        assert "No enrolled students" in resp.json()["detail"]
+    finally:
+        _clear_deps()
+
+
+# ---------------------------------------------------------------------------
+# GET /reports/bulletins/{class_id}/{trimester}
+# ---------------------------------------------------------------------------
+
+
+def test_list_bulletins_success() -> None:
+    """GET /reports/bulletins/3/1 → 200 + liste des bulletins."""
+    _override_deps()
+    try:
+        with patch(
+            "app.services.reports_service.list_bulletins",
+            new=AsyncMock(return_value=SAMPLE_LIST_RESPONSE),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/reports/bulletins/3/1?academic_year_id=1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert len(data["items"]) == 1
+        assert data["items"][0]["rank"] == 1
+    finally:
+        _clear_deps()
+
+
+def test_list_bulletins_no_auth() -> None:
+    """GET /reports/bulletins/3/1 sans token → 401/403."""
+    _clear_deps()
+    with TestClient(app) as client:
+        resp = client.get("/reports/bulletins/3/1?academic_year_id=1")
+    assert resp.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# GET /reports/bulletins/{bulletin_id}/pdf
+# ---------------------------------------------------------------------------
+
+
+def test_get_bulletin_pdf_success() -> None:
+    """GET /reports/bulletins/1/pdf → 200 + URL PDF."""
+    _override_deps()
+    try:
+        with patch(
+            "app.services.reports_service.get_bulletin_pdf",
+            new=AsyncMock(return_value=SAMPLE_PDF_RESPONSE),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/reports/bulletins/1/pdf")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["bulletin_id"] == 1
+        assert "pdf_url" in data
+    finally:
+        _clear_deps()
+
+
+def test_get_bulletin_pdf_not_found() -> None:
+    """GET /reports/bulletins/999/pdf → 404."""
+    _override_deps()
+    try:
+        from app.core.exceptions import NotFoundError
+
+        with patch(
+            "app.services.reports_service.get_bulletin_pdf",
+            new=AsyncMock(side_effect=NotFoundError("Bulletin", 999)),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/reports/bulletins/999/pdf")
+        assert resp.status_code == 404
+    finally:
+        _clear_deps()


### PR DESCRIPTION
## Summary
Closes #20

Génération de bulletins scolaires trimestriels conformes aux normes MENA/DREN ivoiriennes.

### Endpoints
- `POST /reports/bulletins/generate` — génère les bulletins pour une classe/trimestre
- `GET /reports/bulletins/{class_id}/{trimester}` — liste les bulletins générés
- `GET /reports/bulletins/{bulletin_id}/pdf` — télécharge le PDF (placeholder URL)

### Modifications DB
- Ajout `teacher_comment` (TEXT) et `council_decision` (ENUM) au modèle Bulletin
- Nouveau modèle `SubjectAverage` (bulletin_id, subject_id, average, coefficient)
- Migration Alembic réversible

### Calculs conformes CI
- **Moyenne par matière** : `sum(note × coeff_eval) / sum(coeff_eval)`
- **Moyenne trimestrielle** : `sum(moy_matière × coeff_matière) / sum(coeff_matière)`
- **MGA (T3)** : `(T1×1 + T2×2 + T3×2) / 5`
- **Mentions** : TB (≥16), B (≥14), AB (≥12), P (≥10), M (<10)
- **Décision conseil** : passage (≥10), repêchage (9.5-9.99), redoublement (8.5-9.49), exclusion (<8.5)
- Classement avec ex-aequo, `Decimal` + `ROUND_HALF_UP`

### Architecture
- 9 fichiers, ~1019 lignes ajoutées
- Audit log, transactions multi-write

## Test plan
- [ ] `pytest tests/routers/test_reports.py -v`
- [ ] Verify MGA formula correctness
- [ ] Verify mention thresholds
- [ ] Verify ranking with ex-aequo