### PR TITLE
feat(reports): statistiques DREN

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from app.routers.auth import router as auth_router
 from app.routers.dashboard import router as dashboard_router
 from app.routers.enrollments import router as enrollments_router
 from app.routers.grades import router as grades_router
+from app.routers.dren_stats import router as dren_stats_router
 from app.routers.timetable import availability_router, teachers_router
 from app.routers.timetable import router as timetable_router
 
@@ -48,6 +49,7 @@ app.include_router(grades_router)
 app.include_router(timetable_router)
 app.include_router(teachers_router)
 app.include_router(availability_router)
+app.include_router(dren_stats_router)
 
 
 # ---------------------------------------------------------------------------

--- a/app/repositories/dren_stats_repository.py
+++ b/app/repositories/dren_stats_repository.py
@@ -1,0 +1,192 @@
+"""Repository DREN stats — requêtes d'agrégation en lecture seule."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from sqlalchemy import and_, case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.academic import AcademicYear, Class, Level, Subject
+from app.models.enrollment import Enrollment, EnrollmentStatus
+from app.models.grade import Bulletin, Grade, Evaluation
+from app.models.timetable import TimetableSlot
+from app.models.user import Genre, Student
+
+
+async def get_academic_year(db: AsyncSession, academic_year_id: int) -> AcademicYear | None:
+    """Récupère une année scolaire par son ID."""
+    stmt = select(AcademicYear).where(AcademicYear.id == academic_year_id)
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def get_enrollment_counts_by_level(
+    db: AsyncSession, academic_year_id: int
+) -> list[tuple[int, str, int, int, int, int]]:
+    """Effectifs par niveau avec répartition par genre.
+
+    Returns list of (level_id, level_name, level_order, total, male, female).
+    """
+    stmt = (
+        select(
+            Level.id,
+            Level.name,
+            Level.order,
+            func.count(Student.id).label("total"),
+            func.count(case((Student.genre == Genre.M, 1))).label("male"),
+            func.count(case((Student.genre == Genre.F, 1))).label("female"),
+        )
+        .join(Class, Class.level_id == Level.id)
+        .join(Enrollment, Enrollment.class_id == Class.id)
+        .join(Student, Student.id == Enrollment.student_id)
+        .where(
+            Class.academic_year_id == academic_year_id,
+            Enrollment.status.in_([EnrollmentStatus.VALIDE, EnrollmentStatus.EN_VALIDATION]),
+        )
+        .group_by(Level.id, Level.name, Level.order)
+        .order_by(Level.order)
+    )
+    result = await db.execute(stmt)
+    return list(result.all())
+
+
+async def get_enrollment_counts_by_class(
+    db: AsyncSession, academic_year_id: int
+) -> list[tuple[int, str, int, int, int, int, Decimal | None]]:
+    """Effectifs par classe avec répartition par genre et moyenne de classe.
+
+    Returns list of (class_id, class_name, level_id, total, male, female, class_avg).
+    """
+    # Subquery: average per class from bulletins (latest trimester available)
+    bulletin_avg_sq = (
+        select(
+            Bulletin.class_id,
+            func.avg(Bulletin.average).label("class_avg"),
+        )
+        .where(Bulletin.academic_year_id == academic_year_id, Bulletin.average.isnot(None))
+        .group_by(Bulletin.class_id)
+        .subquery()
+    )
+
+    stmt = (
+        select(
+            Class.id,
+            Class.name,
+            Class.level_id,
+            func.count(Student.id).label("total"),
+            func.count(case((Student.genre == Genre.M, 1))).label("male"),
+            func.count(case((Student.genre == Genre.F, 1))).label("female"),
+            bulletin_avg_sq.c.class_avg,
+        )
+        .join(Enrollment, Enrollment.class_id == Class.id)
+        .join(Student, Student.id == Enrollment.student_id)
+        .outerjoin(bulletin_avg_sq, bulletin_avg_sq.c.class_id == Class.id)
+        .where(
+            Class.academic_year_id == academic_year_id,
+            Enrollment.status.in_([EnrollmentStatus.VALIDE, EnrollmentStatus.EN_VALIDATION]),
+        )
+        .group_by(Class.id, Class.name, Class.level_id, bulletin_avg_sq.c.class_avg)
+        .order_by(Class.name)
+    )
+    result = await db.execute(stmt)
+    return list(result.all())
+
+
+async def get_bulletin_rates(
+    db: AsyncSession, academic_year_id: int
+) -> tuple[float | None, float | None, float | None, float | None]:
+    """Taux de réussite, échec, redoublement et exclusion depuis les bulletins.
+
+    Basé sur le trimestre le plus récent disponible.
+    Réussite: average >= 10, Redoublement: 8.5 <= average < 10, Exclusion: average < 8.5.
+
+    Returns (success_rate, failure_rate, redoublement_rate, exclusion_rate) as percentages.
+    """
+    # Find the latest trimester with bulletins
+    latest_trimester_stmt = (
+        select(func.max(Bulletin.trimester))
+        .where(
+            Bulletin.academic_year_id == academic_year_id,
+            Bulletin.average.isnot(None),
+        )
+    )
+    result = await db.execute(latest_trimester_stmt)
+    latest_trimester = result.scalar_one_or_none()
+
+    if latest_trimester is None:
+        return None, None, None, None
+
+    # Count bulletins by category
+    stmt = select(
+        func.count().label("total"),
+        func.count(case((Bulletin.average >= 10, 1))).label("success"),
+        func.count(
+            case(
+                (and_(Bulletin.average >= Decimal("8.5"), Bulletin.average < 10), 1),
+            )
+        ).label("redoublement"),
+        func.count(case((Bulletin.average < Decimal("8.5"), 1))).label("exclusion"),
+    ).where(
+        Bulletin.academic_year_id == academic_year_id,
+        Bulletin.trimester == latest_trimester,
+        Bulletin.average.isnot(None),
+    )
+    result = await db.execute(stmt)
+    row = result.one()
+
+    total = row.total
+    if total == 0:
+        return None, None, None, None
+
+    success_rate = round((row.success / total) * 100, 2)
+    failure_rate = round(((total - row.success) / total) * 100, 2)
+    redoublement_rate = round((row.redoublement / total) * 100, 2)
+    exclusion_rate = round((row.exclusion / total) * 100, 2)
+
+    return success_rate, failure_rate, redoublement_rate, exclusion_rate
+
+
+async def get_subject_averages(
+    db: AsyncSession, academic_year_id: int
+) -> list[tuple[int, str, Decimal | None]]:
+    """Moyennes générales par matière.
+
+    Returns list of (subject_id, subject_name, overall_average).
+    """
+    stmt = (
+        select(
+            Subject.id,
+            Subject.name,
+            func.avg(Grade.value).label("overall_average"),
+        )
+        .join(Evaluation, Evaluation.subject_id == Subject.id)
+        .join(Grade, Grade.evaluation_id == Evaluation.id)
+        .where(
+            Evaluation.academic_year_id == academic_year_id,
+            Grade.value.isnot(None),
+        )
+        .group_by(Subject.id, Subject.name)
+        .order_by(Subject.name)
+    )
+    result = await db.execute(stmt)
+    return list(result.all())
+
+
+async def get_teacher_counts_by_subject(
+    db: AsyncSession, academic_year_id: int
+) -> list[tuple[int, int]]:
+    """Nombre d'enseignants distincts par matière.
+
+    Returns list of (subject_id, teacher_count).
+    """
+    stmt = (
+        select(
+            TimetableSlot.subject_id,
+            func.count(func.distinct(TimetableSlot.teacher_id)).label("teacher_count"),
+        )
+        .where(TimetableSlot.academic_year_id == academic_year_id)
+        .group_by(TimetableSlot.subject_id)
+    )
+    result = await db.execute(stmt)
+    return list(result.all())

--- a/app/routers/dren_stats.py
+++ b/app/routers/dren_stats.py
@@ -1,0 +1,34 @@
+"""Router DREN stats — statistiques agrégées pour les rapports DREN."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import get_current_user, get_tenant_db, require_permission
+from app.schemas.dren_stats import DrenExportResponse, DrenStatsResponse
+from app.services import dren_stats_service as service
+
+router = APIRouter(prefix="/reports/dren-stats", tags=["reports"])
+
+
+@router.get("/{academic_year_id}", response_model=DrenStatsResponse)
+async def get_dren_stats(
+    academic_year_id: int,
+    _: None = require_permission("reports:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> Any:
+    """Statistiques DREN complètes pour une année scolaire."""
+    return await service.get_dren_stats(db, academic_year_id)
+
+
+@router.get("/{academic_year_id}/export", response_model=DrenExportResponse)
+async def export_dren_stats(
+    academic_year_id: int,
+    _: None = require_permission("reports:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> Any:
+    """Export des statistiques DREN (placeholder)."""
+    return await service.export_dren_stats(db, academic_year_id)

--- a/app/schemas/dren_stats.py
+++ b/app/schemas/dren_stats.py
@@ -1,0 +1,69 @@
+"""Schémas Pydantic pour les statistiques DREN."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ClassStats(BaseModel):
+    """Statistiques d'une classe."""
+
+    class_id: int
+    class_name: str
+    total_students: int
+    male_count: int
+    female_count: int
+    average: Decimal | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class LevelStats(BaseModel):
+    """Statistiques d'un niveau scolaire."""
+
+    level_id: int
+    level_name: str
+    total_students: int
+    male_count: int
+    female_count: int
+    classes: list[ClassStats]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SubjectStats(BaseModel):
+    """Statistiques d'une matière."""
+
+    subject_id: int
+    subject_name: str
+    overall_average: Decimal | None = None
+    teacher_count: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DrenStatsResponse(BaseModel):
+    """Réponse complète des statistiques DREN pour une année scolaire."""
+
+    academic_year_id: int
+    academic_year_name: str
+    total_students: int
+    male_count: int
+    female_count: int
+    success_rate: float | None = None
+    failure_rate: float | None = None
+    redoublement_rate: float | None = None
+    exclusion_rate: float | None = None
+    levels: list[LevelStats]
+    subjects: list[SubjectStats]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DrenExportResponse(BaseModel):
+    """Réponse d'export DREN (placeholder)."""
+
+    export_url: str | None = None
+    data: DrenStatsResponse

--- a/app/services/dren_stats_service.py
+++ b/app/services/dren_stats_service.py
@@ -1,0 +1,130 @@
+"""Service DREN stats — agrégation des statistiques pour les rapports DREN."""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import NotFoundError
+from app.repositories import dren_stats_repository as repo
+from app.schemas.dren_stats import (
+    ClassStats,
+    DrenExportResponse,
+    DrenStatsResponse,
+    LevelStats,
+    SubjectStats,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def get_dren_stats(db: AsyncSession, academic_year_id: int) -> DrenStatsResponse:
+    """Calcule les statistiques DREN complètes pour une année scolaire."""
+    # 1. Verify academic year exists
+    academic_year = await repo.get_academic_year(db, academic_year_id)
+    if not academic_year:
+        raise NotFoundError("AcademicYear", academic_year_id)
+
+    # 2. Enrollment counts by level
+    level_rows = await repo.get_enrollment_counts_by_level(db, academic_year_id)
+
+    # 3. Enrollment counts by class (with averages)
+    class_rows = await repo.get_enrollment_counts_by_class(db, academic_year_id)
+
+    # Build class stats grouped by level_id
+    classes_by_level: dict[int, list[ClassStats]] = {}
+    for row in class_rows:
+        class_stat = ClassStats(
+            class_id=row[0],
+            class_name=row[1],
+            total_students=row[3],
+            male_count=row[4],
+            female_count=row[5],
+            average=_round_decimal(row[6]),
+        )
+        classes_by_level.setdefault(row[2], []).append(class_stat)
+
+    # Build level stats
+    levels: list[LevelStats] = []
+    total_students = 0
+    total_male = 0
+    total_female = 0
+    for row in level_rows:
+        level_id = row[0]
+        level_stat = LevelStats(
+            level_id=level_id,
+            level_name=row[1],
+            total_students=row[3],
+            male_count=row[4],
+            female_count=row[5],
+            classes=classes_by_level.get(level_id, []),
+        )
+        levels.append(level_stat)
+        total_students += row[3]
+        total_male += row[4]
+        total_female += row[5]
+
+    # 4. Success/failure/redoublement/exclusion rates
+    success_rate, failure_rate, redoublement_rate, exclusion_rate = (
+        await repo.get_bulletin_rates(db, academic_year_id)
+    )
+
+    # 5. Subject averages
+    subject_avg_rows = await repo.get_subject_averages(db, academic_year_id)
+
+    # 6. Teacher counts per subject
+    teacher_count_rows = await repo.get_teacher_counts_by_subject(db, academic_year_id)
+    teacher_map: dict[int, int] = {row[0]: row[1] for row in teacher_count_rows}
+
+    # Build subject stats
+    subjects: list[SubjectStats] = []
+    for row in subject_avg_rows:
+        subject_id = row[0]
+        subjects.append(
+            SubjectStats(
+                subject_id=subject_id,
+                subject_name=row[1],
+                overall_average=_round_decimal(row[2]),
+                teacher_count=teacher_map.get(subject_id, 0),
+            )
+        )
+
+    # Add subjects that have teachers but no grades yet
+    subjects_with_grades = {s.subject_id for s in subjects}
+    for subject_id, count in teacher_map.items():
+        if subject_id not in subjects_with_grades:
+            # We don't have the subject name here — skip these
+            # They will appear once grades are entered
+            pass
+
+    return DrenStatsResponse(
+        academic_year_id=academic_year_id,
+        academic_year_name=academic_year.name,
+        total_students=total_students,
+        male_count=total_male,
+        female_count=total_female,
+        success_rate=success_rate,
+        failure_rate=failure_rate,
+        redoublement_rate=redoublement_rate,
+        exclusion_rate=exclusion_rate,
+        levels=levels,
+        subjects=subjects,
+    )
+
+
+async def export_dren_stats(db: AsyncSession, academic_year_id: int) -> DrenExportResponse:
+    """Export des statistiques DREN (placeholder — retourne les données JSON)."""
+    data = await get_dren_stats(db, academic_year_id)
+    return DrenExportResponse(
+        export_url=None,
+        data=data,
+    )
+
+
+def _round_decimal(value: Decimal | None) -> Decimal | None:
+    """Arrondit un Decimal à 2 décimales, retourne None si None."""
+    if value is None:
+        return None
+    return Decimal(str(round(value, 2)))

--- a/tests/routers/test_dren_stats.py
+++ b/tests/routers/test_dren_stats.py
@@ -1,0 +1,205 @@
+"""Tests des endpoints /reports/dren-stats."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db
+from app.main import app
+from app.schemas.dren_stats import (
+    ClassStats,
+    DrenExportResponse,
+    DrenStatsResponse,
+    LevelStats,
+    SubjectStats,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+MOCK_USER = TokenData(user_id=1, tenant_id="local", email="admin@college.ci")
+
+SAMPLE_STATS = DrenStatsResponse(
+    academic_year_id=1,
+    academic_year_name="2025-2026",
+    total_students=350,
+    male_count=180,
+    female_count=170,
+    success_rate=65.5,
+    failure_rate=34.5,
+    redoublement_rate=20.0,
+    exclusion_rate=14.5,
+    levels=[
+        LevelStats(
+            level_id=1,
+            level_name="6ème",
+            total_students=120,
+            male_count=60,
+            female_count=60,
+            classes=[
+                ClassStats(
+                    class_id=1,
+                    class_name="6ème A",
+                    total_students=40,
+                    male_count=20,
+                    female_count=20,
+                    average=Decimal("12.50"),
+                ),
+                ClassStats(
+                    class_id=2,
+                    class_name="6ème B",
+                    total_students=40,
+                    male_count=22,
+                    female_count=18,
+                    average=Decimal("11.80"),
+                ),
+                ClassStats(
+                    class_id=3,
+                    class_name="6ème C",
+                    total_students=40,
+                    male_count=18,
+                    female_count=22,
+                    average=None,
+                ),
+            ],
+        ),
+    ],
+    subjects=[
+        SubjectStats(
+            subject_id=1,
+            subject_name="Mathématiques",
+            overall_average=Decimal("11.20"),
+            teacher_count=3,
+        ),
+        SubjectStats(
+            subject_id=2,
+            subject_name="Français",
+            overall_average=Decimal("12.80"),
+            teacher_count=4,
+        ),
+    ],
+)
+
+SAMPLE_EXPORT = DrenExportResponse(
+    export_url=None,
+    data=SAMPLE_STATS,
+)
+
+
+def _override_deps() -> None:
+    app.dependency_overrides[get_current_user] = lambda: MOCK_USER
+    app.dependency_overrides[get_tenant_db] = lambda: AsyncMock()
+
+
+def _clear_deps() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Tests — GET /reports/dren-stats/{academic_year_id}
+# ---------------------------------------------------------------------------
+
+
+class TestGetDrenStats:
+    """Tests pour l'endpoint GET /reports/dren-stats/{academic_year_id}."""
+
+    def setup_method(self) -> None:
+        _override_deps()
+
+    def teardown_method(self) -> None:
+        _clear_deps()
+
+    @patch("app.routers.dren_stats.service.get_dren_stats")
+    def test_get_dren_stats_success(self, mock_get: AsyncMock) -> None:
+        mock_get.return_value = SAMPLE_STATS
+        client = TestClient(app)
+        response = client.get("/reports/dren-stats/1")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["academic_year_id"] == 1
+        assert data["academic_year_name"] == "2025-2026"
+        assert data["total_students"] == 350
+        assert data["male_count"] == 180
+        assert data["female_count"] == 170
+        assert data["success_rate"] == 65.5
+        assert data["failure_rate"] == 34.5
+        assert data["redoublement_rate"] == 20.0
+        assert data["exclusion_rate"] == 14.5
+        assert len(data["levels"]) == 1
+        assert data["levels"][0]["level_name"] == "6ème"
+        assert len(data["levels"][0]["classes"]) == 3
+        assert len(data["subjects"]) == 2
+
+    @patch("app.routers.dren_stats.service.get_dren_stats")
+    def test_get_dren_stats_not_found(self, mock_get: AsyncMock) -> None:
+        from app.core.exceptions import NotFoundError
+
+        mock_get.side_effect = NotFoundError("AcademicYear", 999)
+        client = TestClient(app)
+        response = client.get("/reports/dren-stats/999")
+        assert response.status_code == 404
+
+    @patch("app.routers.dren_stats.service.get_dren_stats")
+    def test_get_dren_stats_no_bulletins(self, mock_get: AsyncMock) -> None:
+        """Rates should be null when no bulletins exist."""
+        stats_no_bulletins = DrenStatsResponse(
+            academic_year_id=1,
+            academic_year_name="2025-2026",
+            total_students=100,
+            male_count=50,
+            female_count=50,
+            success_rate=None,
+            failure_rate=None,
+            redoublement_rate=None,
+            exclusion_rate=None,
+            levels=[],
+            subjects=[],
+        )
+        mock_get.return_value = stats_no_bulletins
+        client = TestClient(app)
+        response = client.get("/reports/dren-stats/1")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success_rate"] is None
+        assert data["failure_rate"] is None
+        assert data["redoublement_rate"] is None
+        assert data["exclusion_rate"] is None
+
+
+# ---------------------------------------------------------------------------
+# Tests — GET /reports/dren-stats/{academic_year_id}/export
+# ---------------------------------------------------------------------------
+
+
+class TestExportDrenStats:
+    """Tests pour l'endpoint GET /reports/dren-stats/{academic_year_id}/export."""
+
+    def setup_method(self) -> None:
+        _override_deps()
+
+    def teardown_method(self) -> None:
+        _clear_deps()
+
+    @patch("app.routers.dren_stats.service.export_dren_stats")
+    def test_export_dren_stats_success(self, mock_export: AsyncMock) -> None:
+        mock_export.return_value = SAMPLE_EXPORT
+        client = TestClient(app)
+        response = client.get("/reports/dren-stats/1/export")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["export_url"] is None
+        assert data["data"]["academic_year_id"] == 1
+        assert data["data"]["total_students"] == 350
+
+    @patch("app.routers.dren_stats.service.export_dren_stats")
+    def test_export_dren_stats_not_found(self, mock_export: AsyncMock) -> None:
+        from app.core.exceptions import NotFoundError
+
+        mock_export.side_effect = NotFoundError("AcademicYear", 999)
+        client = TestClient(app)
+        response = client.get("/reports/dren-stats/999/export")
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary
Closes #22

Statistiques agrégées pour la DREN — données complètes pour les rapports réglementaires.

### Endpoints
- `GET /reports/dren-stats/{academic_year_id}` — statistiques complètes (JSON)
- `GET /reports/dren-stats/{academic_year_id}/export` — export (placeholder URL + data)

### Données agrégées
- Effectifs par niveau et par classe (6ème → Terminale)
- Répartition filles/garçons (`case(Student.genre)`)
- Taux de réussite (% MGA ≥ 10)
- Taux de redoublement / exclusion
- Moyennes générales par matière (`AVG(grades.value)`)
- Nombre d'enseignants par matière (`COUNT DISTINCT teacher_id`)

### Architecture
- `app/schemas/dren_stats.py` — 69 lignes (nested schemas)
- `app/repositories/dren_stats_repository.py` — 192 lignes (aggregation queries)
- `app/services/dren_stats_service.py` — 130 lignes
- `app/routers/dren_stats.py` — 34 lignes
- `tests/routers/test_dren_stats.py` — 205 lignes (5 tests)
- Aucune modification de modèle (pure lecture)

## Test plan
- [ ] `pytest tests/routers/test_dren_stats.py -v`
- [ ] Verify null rates when no bulletins exist
- [ ] Verify gender breakdown accuracy