### PR TITLE
feat(tenant): multi-tenant provisioning system

### DIFF
--- a/app/cli/migrate_all.py
+++ b/app/cli/migrate_all.py
@@ -1,0 +1,86 @@
+"""CLI — Migrer toutes les bases de données tenant.
+
+Usage:
+    python -m app.cli.migrate_all [revision]
+    python -m app.cli.migrate_all head
+"""
+
+import argparse
+import asyncio
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+async def list_tenant_databases() -> list[str]:
+    """List all tenant databases (convention: exclude system DBs)."""
+    from app.core.config import settings
+
+    base_url = settings.DATABASE_URL.replace("/{tenant}", "/")
+    engine = create_async_engine(base_url, isolation_level="AUTOCOMMIT")
+    try:
+        async with engine.begin() as conn:
+            result = await conn.execute(text("SHOW DATABASES"))
+            all_dbs = [row[0] for row in result.fetchall()]
+    finally:
+        await engine.dispose()
+
+    # Exclude MySQL system databases
+    system_dbs = {"information_schema", "mysql", "performance_schema", "sys", "alembic_migration"}
+    return [db for db in all_dbs if db not in system_dbs]
+
+
+async def migrate_all(revision: str = "head") -> None:
+    """Run Alembic migrations on all tenant databases."""
+    tenants = await list_tenant_databases()
+    logger.info("Found %d tenant databases", len(tenants))
+
+    project_root = str(Path(__file__).resolve().parents[2])
+    failed: list[tuple[str, str]] = []
+
+    for tenant in tenants:
+        logger.info("Migrating '%s'...", tenant)
+        env = os.environ.copy()
+        env["TENANT_ID"] = tenant
+        result = subprocess.run(
+            ["alembic", "upgrade", revision],
+            cwd=project_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            failed.append((tenant, result.stderr[:200]))
+            logger.error("  Failed: %s", result.stderr[:200])
+        else:
+            logger.info("  OK")
+
+    if failed:
+        logger.error("%d tenants failed:", len(failed))
+        for name, err in failed:
+            logger.error("  - %s: %s", name, err)
+        sys.exit(1)
+    else:
+        logger.info("All %d tenants migrated successfully", len(tenants))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Migrer toutes les bases tenant")
+    parser.add_argument(
+        "revision", nargs="?", default="head", help="Revision Alembic (default: head)"
+    )
+    args = parser.parse_args()
+    asyncio.run(migrate_all(args.revision))
+
+
+if __name__ == "__main__":
+    main()

--- a/app/cli/provision_tenant.py
+++ b/app/cli/provision_tenant.py
@@ -1,0 +1,56 @@
+"""CLI — Provisionner un nouveau tenant.
+
+Usage:
+    python -m app.cli.provision_tenant \
+        --slug lycee-moderne \
+        --school "Lycée Moderne d'Abidjan" \
+        --admin-email admin@lycee-moderne.ci \
+        --admin-password "SecureP@ss123"
+"""
+
+import argparse
+import asyncio
+import logging
+import sys
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Provisionner un nouveau tenant KLASSCI")
+    parser.add_argument("--slug", required=True, help="Identifiant unique du tenant (sous-domaine)")
+    parser.add_argument("--school", required=True, help="Nom de l'établissement")
+    parser.add_argument("--admin-email", required=True, help="Email du compte admin")
+    parser.add_argument("--admin-password", required=True, help="Mot de passe admin initial")
+    parser.add_argument("--address", default=None, help="Adresse de l'établissement")
+    parser.add_argument("--phone", default=None, help="Téléphone")
+    parser.add_argument("--school-email", default=None, help="Email de l'établissement")
+    parser.add_argument("--ministry-code", default=None, help="Code ministère / DREN")
+    args = parser.parse_args()
+
+    from app.services.tenant_service import provision_tenant
+
+    try:
+        result = asyncio.run(
+            provision_tenant(
+                tenant_slug=args.slug,
+                school_name=args.school,
+                admin_email=args.admin_email,
+                admin_password=args.admin_password,
+                school_address=args.address,
+                school_phone=args.phone,
+                school_email=args.school_email,
+                ministry_code=args.ministry_code,
+            )
+        )
+        print(f"\nTenant '{result['tenant_slug']}' provisionned successfully!")
+        print(f"   Database     : {result['database']}")
+        print(f"   Admin email  : {result['admin_email']}")
+        print(f"   URL          : https://{result['tenant_slug']}.klassci.com")
+    except Exception as e:
+        print(f"\nError: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/main.py
+++ b/app/main.py
@@ -23,6 +23,7 @@ from app.routers.teacher_portal import router as teacher_portal_router
 from app.routers.reports import router as reports_router
 from app.routers.council import router as council_router
 from app.routers.dren_stats import router as dren_stats_router
+from app.routers.super_admin import router as super_admin_router
 from app.routers.timetable import availability_router, teachers_router
 from app.routers.timetable import router as timetable_router
 
@@ -65,6 +66,7 @@ app.include_router(teacher_portal_router)
 app.include_router(reports_router)
 app.include_router(council_router)
 app.include_router(dren_stats_router)
+app.include_router(super_admin_router)
 app.include_router(timetable_router)
 app.include_router(teachers_router)
 app.include_router(availability_router)

--- a/app/routers/super_admin.py
+++ b/app/routers/super_admin.py
@@ -1,0 +1,35 @@
+"""Router Super Admin — provisioning de tenants via API."""
+
+from fastapi import APIRouter, Depends
+
+from app.core.dependencies import TokenData, get_current_user, require_permission
+from app.schemas.tenant import TenantProvisionRequest, TenantProvisionResponse
+from app.services import tenant_service
+
+router = APIRouter(prefix="/super-admin", tags=["super-admin"])
+
+
+@router.post("/tenants", response_model=TenantProvisionResponse, status_code=201)
+async def provision_tenant(
+    data: TenantProvisionRequest,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("super-admin:tenants:create"),
+) -> TenantProvisionResponse:
+    """Provisionne un nouveau tenant : crée la DB, migre, et seed les données initiales."""
+    result = await tenant_service.provision_tenant(
+        tenant_slug=data.tenant_slug,
+        school_name=data.school_name,
+        admin_email=data.admin_email,
+        admin_password=data.admin_password,
+        school_address=data.school_address,
+        school_phone=data.school_phone,
+        school_email=data.school_email,
+        ministry_code=data.ministry_code,
+    )
+    return TenantProvisionResponse(
+        tenant_slug=result["tenant_slug"],
+        database=result["database"],
+        admin_email=result["admin_email"],
+        status=result["status"],
+        url=f"https://{result['tenant_slug']}.klassci.com",
+    )

--- a/app/schemas/tenant.py
+++ b/app/schemas/tenant.py
@@ -1,0 +1,38 @@
+"""Schémas Pydantic pour le provisioning de tenants."""
+
+import re
+
+from pydantic import BaseModel, EmailStr, field_validator
+
+
+class TenantProvisionRequest(BaseModel):
+    tenant_slug: str
+    school_name: str
+    admin_email: EmailStr
+    admin_password: str
+    school_address: str | None = None
+    school_phone: str | None = None
+    school_email: EmailStr | None = None
+    ministry_code: str | None = None
+
+    @field_validator("tenant_slug")
+    @classmethod
+    def validate_slug(cls, v: str) -> str:
+        if not re.match(r"^[a-z0-9][a-z0-9\-]{0,61}[a-z0-9]$", v):
+            raise ValueError("Must be 2-63 chars, lowercase alphanumeric + hyphens")
+        return v
+
+    @field_validator("admin_password")
+    @classmethod
+    def validate_password(cls, v: str) -> str:
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters")
+        return v
+
+
+class TenantProvisionResponse(BaseModel):
+    tenant_slug: str
+    database: str
+    admin_email: str
+    status: str
+    url: str

--- a/app/services/tenant_service.py
+++ b/app/services/tenant_service.py
@@ -1,0 +1,327 @@
+"""Service de provisioning multi-tenant — crée une DB, migre, et seed les données initiales."""
+
+import logging
+import os
+import re
+import subprocess
+from pathlib import Path
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import settings
+from app.core.security import hash_password
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# 46 permission slugs (extracted from all routers)
+# ---------------------------------------------------------------------------
+
+ALL_PERMISSIONS: list[dict[str, str]] = [
+    # Admin module (28)
+    {"slug": "admin:students:read", "name": "View students"},
+    {"slug": "admin:students:create", "name": "Create students"},
+    {"slug": "admin:students:update", "name": "Update students"},
+    {"slug": "admin:students:delete", "name": "Delete students"},
+    {"slug": "admin:teachers:read", "name": "View teachers"},
+    {"slug": "admin:teachers:create", "name": "Create teachers"},
+    {"slug": "admin:teachers:update", "name": "Update teachers"},
+    {"slug": "admin:teachers:delete", "name": "Delete teachers"},
+    {"slug": "admin:staff:read", "name": "View staff"},
+    {"slug": "admin:staff:create", "name": "Create staff"},
+    {"slug": "admin:staff:update", "name": "Update staff"},
+    {"slug": "admin:staff:delete", "name": "Delete staff"},
+    {"slug": "admin:classes:read", "name": "View classes"},
+    {"slug": "admin:classes:create", "name": "Create classes"},
+    {"slug": "admin:classes:update", "name": "Update classes"},
+    {"slug": "admin:classes:delete", "name": "Delete classes"},
+    {"slug": "admin:subjects:read", "name": "View subjects"},
+    {"slug": "admin:subjects:create", "name": "Create subjects"},
+    {"slug": "admin:subjects:update", "name": "Update subjects"},
+    {"slug": "admin:subjects:delete", "name": "Delete subjects"},
+    {"slug": "admin:academic-years:read", "name": "View academic years"},
+    {"slug": "admin:academic-years:create", "name": "Create academic years"},
+    {"slug": "admin:academic-years:update", "name": "Update academic years"},
+    {"slug": "admin:academic-years:delete", "name": "Delete academic years"},
+    {"slug": "admin:levels:read", "name": "View levels"},
+    {"slug": "admin:levels:create", "name": "Create levels"},
+    {"slug": "admin:levels:update", "name": "Update levels"},
+    {"slug": "admin:levels:delete", "name": "Delete levels"},
+    # Academic (7)
+    {"slug": "enrollments:read", "name": "View enrollments"},
+    {"slug": "enrollments:create", "name": "Create enrollments"},
+    {"slug": "enrollments:update", "name": "Update enrollments"},
+    {"slug": "enrollments:delete", "name": "Delete enrollments"},
+    {"slug": "grades:read", "name": "View grades"},
+    {"slug": "grades:write", "name": "Write grades"},
+    {"slug": "bulletins:generate", "name": "Generate bulletins"},
+    # Timetable (3)
+    {"slug": "timetable:read", "name": "View timetable"},
+    {"slug": "timetable:write", "name": "Edit timetable"},
+    {"slug": "timetable:generate", "name": "Generate timetable"},
+    # Operations (5)
+    {"slug": "payments:read", "name": "View payments"},
+    {"slug": "payments:create", "name": "Create payments"},
+    {"slug": "attendance:read", "name": "View attendance"},
+    {"slug": "attendance:create", "name": "Create attendance"},
+    {"slug": "attendance:update", "name": "Update attendance"},
+    # Reports (3)
+    {"slug": "reports:read", "name": "View reports"},
+    {"slug": "reports:generate", "name": "Generate reports"},
+    {"slug": "reports:override", "name": "Override council decisions"},
+    # Super Admin (1)
+    {"slug": "super-admin:tenants:create", "name": "Provision new tenants"},
+]
+
+# ---------------------------------------------------------------------------
+# Role definitions with their permission slugs
+# ---------------------------------------------------------------------------
+
+ROLE_DEFINITIONS: dict[str, dict] = {
+    "admin": {
+        "description": "Administrateur — accès complet",
+        "permissions": [p["slug"] for p in ALL_PERMISSIONS],
+    },
+    "director": {
+        "description": "Directeur d'établissement",
+        "permissions": [p["slug"] for p in ALL_PERMISSIONS],
+    },
+    "teacher": {
+        "description": "Enseignant",
+        "permissions": [
+            "grades:read",
+            "grades:write",
+            "bulletins:generate",
+            "attendance:read",
+            "attendance:create",
+            "attendance:update",
+            "timetable:read",
+            "reports:read",
+        ],
+    },
+    "staff": {
+        "description": "Personnel administratif",
+        "permissions": [
+            "enrollments:read",
+            "enrollments:create",
+            "enrollments:update",
+            "payments:read",
+            "payments:create",
+            "admin:students:read",
+            "admin:students:create",
+            "admin:students:update",
+            "admin:classes:read",
+            "attendance:read",
+            "reports:read",
+        ],
+    },
+    "accountant": {
+        "description": "Comptable / Trésorier",
+        "permissions": [
+            "payments:read",
+            "payments:create",
+            "enrollments:read",
+            "reports:read",
+        ],
+    },
+}
+# Note: student and parent roles have NO permissions (portal is user-scoped via JWT)
+
+
+async def create_tenant_database(tenant_slug: str) -> None:
+    """Step 1: Create the MySQL database for the tenant."""
+    base_url = settings.DATABASE_URL.replace("/{tenant}", "/")
+
+    mgmt_engine = create_async_engine(base_url, isolation_level="AUTOCOMMIT")
+    try:
+        async with mgmt_engine.begin() as conn:
+            await conn.execute(
+                text(
+                    f"CREATE DATABASE IF NOT EXISTS `{tenant_slug}` "
+                    "CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+                )
+            )
+            logger.info("Database '%s' created", tenant_slug)
+    finally:
+        await mgmt_engine.dispose()
+
+
+async def run_migrations(tenant_slug: str) -> None:
+    """Step 2: Run all Alembic migrations on the tenant database."""
+    env = os.environ.copy()
+    env["TENANT_ID"] = tenant_slug
+
+    result = subprocess.run(
+        ["alembic", "upgrade", "head"],
+        cwd=str(Path(__file__).resolve().parents[2]),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Alembic migration failed for tenant '{tenant_slug}': {result.stderr}"
+        )
+    logger.info("Migrations applied for tenant '%s'", tenant_slug)
+
+
+async def seed_tenant_data(
+    tenant_slug: str,
+    *,
+    school_name: str,
+    admin_email: str,
+    admin_password: str,
+    school_address: str | None = None,
+    school_phone: str | None = None,
+    school_email: str | None = None,
+    ministry_code: str | None = None,
+) -> dict:
+    """Step 3: Seed permissions, roles, admin user, and school settings."""
+    tenant_url = settings.DATABASE_URL.format(tenant=tenant_slug)
+    engine = create_async_engine(tenant_url, pool_pre_ping=True)
+    factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    try:
+        async with factory() as db:
+            async with db.begin():
+                # 3a. Seed permissions
+                for perm in ALL_PERMISSIONS:
+                    await db.execute(
+                        text(
+                            "INSERT IGNORE INTO permissions (slug, name) "
+                            "VALUES (:slug, :name)"
+                        ),
+                        perm,
+                    )
+
+                # 3b. Seed roles and link permissions
+                for role_name, role_def in ROLE_DEFINITIONS.items():
+                    await db.execute(
+                        text(
+                            "INSERT IGNORE INTO roles (name, description) "
+                            "VALUES (:name, :desc)"
+                        ),
+                        {"name": role_name, "desc": role_def["description"]},
+                    )
+                    result = await db.execute(
+                        text("SELECT id FROM roles WHERE name = :name"),
+                        {"name": role_name},
+                    )
+                    role_id = result.scalar_one()
+
+                    for slug in role_def["permissions"]:
+                        await db.execute(
+                            text(
+                                "INSERT IGNORE INTO role_permissions (role_id, permission_id) "
+                                "SELECT :role_id, id FROM permissions WHERE slug = :slug"
+                            ),
+                            {"role_id": role_id, "slug": slug},
+                        )
+
+                # 3c. Create admin user
+                hashed = hash_password(admin_password)
+                await db.execute(
+                    text(
+                        "INSERT INTO users (email, hashed_password, role, is_active) "
+                        "VALUES (:email, :hashed, 'admin', 1)"
+                    ),
+                    {"email": admin_email, "hashed": hashed},
+                )
+                admin_result = await db.execute(
+                    text("SELECT id FROM users WHERE email = :email"),
+                    {"email": admin_email},
+                )
+                admin_user_id = admin_result.scalar_one()
+
+                # 3d. Assign admin role to admin user
+                admin_role_result = await db.execute(
+                    text("SELECT id FROM roles WHERE name = 'admin'"),
+                )
+                admin_role_id = admin_role_result.scalar_one()
+                await db.execute(
+                    text(
+                        "INSERT INTO user_roles (user_id, role_id) "
+                        "VALUES (:user_id, :role_id)"
+                    ),
+                    {"user_id": admin_user_id, "role_id": admin_role_id},
+                )
+
+                # 3e. Create StaffProfile for admin
+                await db.execute(
+                    text(
+                        "INSERT INTO staff_profiles (user_id, first_name, last_name, position) "
+                        "VALUES (:user_id, 'Admin', :school_name, 'Administrateur')"
+                    ),
+                    {"user_id": admin_user_id, "school_name": school_name},
+                )
+
+                # 3f. Seed school settings
+                await db.execute(
+                    text(
+                        "INSERT INTO school_settings "
+                        "(school_name, address, phone, email, ministry_code) "
+                        "VALUES (:name, :address, :phone, :email, :code)"
+                    ),
+                    {
+                        "name": school_name,
+                        "address": school_address,
+                        "phone": school_phone,
+                        "email": school_email,
+                        "code": ministry_code,
+                    },
+                )
+
+            logger.info("Seed data inserted for tenant '%s'", tenant_slug)
+            return {"admin_user_id": admin_user_id, "admin_email": admin_email}
+    finally:
+        await engine.dispose()
+
+
+async def provision_tenant(
+    *,
+    tenant_slug: str,
+    school_name: str,
+    admin_email: str,
+    admin_password: str,
+    school_address: str | None = None,
+    school_phone: str | None = None,
+    school_email: str | None = None,
+    ministry_code: str | None = None,
+) -> dict:
+    """Full provisioning workflow: create DB -> migrate -> seed."""
+    if not re.match(r"^[a-z0-9][a-z0-9\-]{0,61}[a-z0-9]$", tenant_slug):
+        raise ValueError(
+            f"Invalid tenant_slug '{tenant_slug}': "
+            "must be 2-63 chars, lowercase alphanumeric + hyphens"
+        )
+
+    logger.info("=== Provisioning tenant '%s' ===", tenant_slug)
+
+    # Step 1: Create database
+    await create_tenant_database(tenant_slug)
+
+    # Step 2: Run migrations
+    await run_migrations(tenant_slug)
+
+    # Step 3: Seed data
+    result = await seed_tenant_data(
+        tenant_slug,
+        school_name=school_name,
+        admin_email=admin_email,
+        admin_password=admin_password,
+        school_address=school_address,
+        school_phone=school_phone,
+        school_email=school_email,
+        ministry_code=ministry_code,
+    )
+
+    logger.info("=== Tenant '%s' provisioned successfully ===", tenant_slug)
+    return {
+        "tenant_slug": tenant_slug,
+        "database": tenant_slug,
+        "admin_email": result["admin_email"],
+        "status": "provisioned",
+    }

--- a/tests/routers/test_super_admin.py
+++ b/tests/routers/test_super_admin.py
@@ -1,0 +1,131 @@
+"""Tests des endpoints /super-admin."""
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db
+from app.core.redis import get_redis
+from app.main import app
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MOCK_USER = TokenData(user_id=1, tenant_id="local", email="superadmin@klassci.com")
+
+PROVISION_RESULT = {
+    "tenant_slug": "lycee-moderne",
+    "database": "lycee-moderne",
+    "admin_email": "admin@lycee-moderne.ci",
+    "status": "provisioned",
+}
+
+VALID_PAYLOAD = {
+    "tenant_slug": "lycee-moderne",
+    "school_name": "Lycée Moderne d'Abidjan",
+    "admin_email": "admin@lycee-moderne.ci",
+    "admin_password": "SecureP@ss123",
+    "school_address": "Abidjan, Cocody",
+    "school_phone": "+2250700000000",
+}
+
+
+def _override_deps() -> None:
+    """Surcharge les dépendances d'auth et DB pour les tests."""
+    app.dependency_overrides[get_current_user] = lambda: MOCK_USER
+    app.dependency_overrides[get_tenant_db] = lambda: AsyncMock()
+    app.dependency_overrides[get_redis] = lambda: AsyncMock()
+
+
+def _clear_deps() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# POST /super-admin/tenants
+# ---------------------------------------------------------------------------
+
+
+def test_provision_tenant_success() -> None:
+    """POST /super-admin/tenants -> 201 + tenant provisionné."""
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.super_admin.tenant_service.provision_tenant",
+            new_callable=AsyncMock,
+            return_value=PROVISION_RESULT,
+        ):
+            with TestClient(app) as client:
+                resp = client.post("/super-admin/tenants", json=VALID_PAYLOAD)
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["tenant_slug"] == "lycee-moderne"
+    assert body["database"] == "lycee-moderne"
+    assert body["admin_email"] == "admin@lycee-moderne.ci"
+    assert body["status"] == "provisioned"
+    assert body["url"] == "https://lycee-moderne.klassci.com"
+
+
+def test_provision_tenant_invalid_slug() -> None:
+    """POST /super-admin/tenants avec slug invalide -> 422."""
+    _override_deps()
+    try:
+        payload = VALID_PAYLOAD.copy()
+        payload["tenant_slug"] = "INVALID SLUG"
+        with TestClient(app) as client:
+            resp = client.post("/super-admin/tenants", json=payload)
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 422
+
+
+def test_provision_tenant_short_password() -> None:
+    """POST /super-admin/tenants avec mot de passe court -> 422."""
+    _override_deps()
+    try:
+        payload = VALID_PAYLOAD.copy()
+        payload["admin_password"] = "short"
+        with TestClient(app) as client:
+            resp = client.post("/super-admin/tenants", json=payload)
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 422
+
+
+def test_provision_tenant_invalid_email() -> None:
+    """POST /super-admin/tenants avec email invalide -> 422."""
+    _override_deps()
+    try:
+        payload = VALID_PAYLOAD.copy()
+        payload["admin_email"] = "not-an-email"
+        with TestClient(app) as client:
+            resp = client.post("/super-admin/tenants", json=payload)
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 422
+
+
+def test_provision_tenant_unauthenticated() -> None:
+    """POST /super-admin/tenants sans token -> 401."""
+    with TestClient(app) as client:
+        resp = client.post("/super-admin/tenants", json=VALID_PAYLOAD)
+    assert resp.status_code == 401
+
+
+def test_provision_tenant_missing_required_fields() -> None:
+    """POST /super-admin/tenants sans champs requis -> 422."""
+    _override_deps()
+    try:
+        with TestClient(app) as client:
+            resp = client.post("/super-admin/tenants", json={"tenant_slug": "ab"})
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 422

--- a/tests/test_tenant_service.py
+++ b/tests/test_tenant_service.py
@@ -1,0 +1,159 @@
+"""Tests du service de provisioning tenant."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.tenant_service import (
+    ALL_PERMISSIONS,
+    ROLE_DEFINITIONS,
+    provision_tenant,
+)
+
+
+# ---------------------------------------------------------------------------
+# Validation du slug
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "slug",
+    [
+        "A",  # too short + uppercase
+        "a",  # too short (1 char)
+        "UPPERCASE",
+        "with spaces",
+        "-starts-with-dash",
+        "ends-with-dash-",
+        "has_underscore",
+        "a" * 64,  # too long (64 chars)
+    ],
+)
+def test_provision_tenant_invalid_slug(slug: str) -> None:
+    """Les slugs invalides doivent lever ValueError."""
+    with pytest.raises(ValueError, match="Invalid tenant_slug"):
+        import asyncio
+
+        asyncio.run(
+            provision_tenant(
+                tenant_slug=slug,
+                school_name="Test",
+                admin_email="admin@test.ci",
+                admin_password="SecureP@ss123",
+            )
+        )
+
+
+def test_provision_tenant_valid_slugs() -> None:
+    """Les slugs valides ne doivent pas lever ValueError sur la validation."""
+    valid_slugs = ["ab", "lycee-moderne", "college-01", "a" * 63]
+    for slug in valid_slugs:
+        # We only test the slug validation — the actual provisioning is mocked
+        import re
+
+        assert re.match(r"^[a-z0-9][a-z0-9\-]{0,61}[a-z0-9]$", slug), f"'{slug}' should be valid"
+
+
+# ---------------------------------------------------------------------------
+# Full provisioning (mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provision_tenant_success() -> None:
+    """Le workflow complet doit appeler create DB, migrate, seed dans l'ordre."""
+    with (
+        patch(
+            "app.services.tenant_service.create_tenant_database",
+            new_callable=AsyncMock,
+        ) as mock_create_db,
+        patch(
+            "app.services.tenant_service.run_migrations",
+            new_callable=AsyncMock,
+        ) as mock_migrate,
+        patch(
+            "app.services.tenant_service.seed_tenant_data",
+            new_callable=AsyncMock,
+            return_value={"admin_user_id": 1, "admin_email": "admin@test.ci"},
+        ) as mock_seed,
+    ):
+        result = await provision_tenant(
+            tenant_slug="lycee-test",
+            school_name="Lycee Test",
+            admin_email="admin@test.ci",
+            admin_password="SecureP@ss123",
+        )
+
+    mock_create_db.assert_called_once_with("lycee-test")
+    mock_migrate.assert_called_once_with("lycee-test")
+    mock_seed.assert_called_once()
+
+    assert result["tenant_slug"] == "lycee-test"
+    assert result["database"] == "lycee-test"
+    assert result["admin_email"] == "admin@test.ci"
+    assert result["status"] == "provisioned"
+
+
+# ---------------------------------------------------------------------------
+# list_tenant_databases (mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_tenant_databases() -> None:
+    """SHOW DATABASES doit filtrer les bases système."""
+    from app.cli.migrate_all import list_tenant_databases
+
+    mock_result = MagicMock()
+    mock_result.fetchall.return_value = [
+        ("information_schema",),
+        ("mysql",),
+        ("performance_schema",),
+        ("sys",),
+        ("alembic_migration",),
+        ("lycee-moderne",),
+        ("college-01",),
+    ]
+
+    mock_conn = AsyncMock()
+    mock_conn.execute = AsyncMock(return_value=mock_result)
+    mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+    mock_engine = AsyncMock()
+    mock_engine.begin = MagicMock(return_value=mock_conn)
+    mock_engine.dispose = AsyncMock()
+
+    with patch(
+        "app.cli.migrate_all.create_async_engine",
+        return_value=mock_engine,
+    ):
+        tenants = await list_tenant_databases()
+
+    assert "lycee-moderne" in tenants
+    assert "college-01" in tenants
+    assert "mysql" not in tenants
+    assert "information_schema" not in tenants
+    assert "sys" not in tenants
+    assert len(tenants) == 2
+
+
+# ---------------------------------------------------------------------------
+# Permission & role data integrity
+# ---------------------------------------------------------------------------
+
+
+def test_all_permissions_unique_slugs() -> None:
+    """Toutes les permissions doivent avoir des slugs uniques."""
+    slugs = [p["slug"] for p in ALL_PERMISSIONS]
+    assert len(slugs) == len(set(slugs)), "Duplicate slugs found"
+
+
+def test_role_permissions_reference_valid_slugs() -> None:
+    """Toutes les permissions des rôles doivent exister dans ALL_PERMISSIONS."""
+    valid_slugs = {p["slug"] for p in ALL_PERMISSIONS}
+    for role_name, role_def in ROLE_DEFINITIONS.items():
+        for slug in role_def["permissions"]:
+            assert slug in valid_slugs, (
+                f"Role '{role_name}' references unknown permission '{slug}'"
+            )


### PR DESCRIPTION
## Summary

Système complet de provisioning multi-tenant — crée une DB MySQL, migre le schéma, et seed les données initiales pour un nouvel établissement.

### CLI

```bash
# Provisionner un nouveau tenant
python -m app.cli.provision_tenant \
    --slug lycee-moderne \
    --school "Lycée Moderne d'Abidjan" \
    --admin-email admin@lycee-moderne.ci \
    --admin-password "SecureP@ss123"

# Migrer toutes les bases tenant
python -m app.cli.migrate_all head
```

### API

```
POST /super-admin/tenants
{
    "tenant_slug": "lycee-moderne",
    "school_name": "Lycée Moderne d'Abidjan",
    "admin_email": "admin@lycee-moderne.ci",
    "admin_password": "SecureP@ss123"
}
```

### Flow de provisioning

1. `CREATE DATABASE` (AUTOCOMMIT, utf8mb4)
2. `alembic upgrade head` (4 migrations)
3. Seed 46 permissions
4. Seed 5 rôles (admin, director, teacher, staff, accountant)
5. Matrice rôle→permissions (admin = toutes, teacher = grades/attendance, etc.)
6. Créer user admin + staff profile + user_role
7. Seed school_settings (singleton)

### Fichiers créés
- `app/services/tenant_service.py` — 327 lignes, core logic
- `app/cli/provision_tenant.py` — CLI avec argparse
- `app/cli/migrate_all.py` — batch migration (SHOW DATABASES + loop)
- `app/schemas/tenant.py` — Pydantic v2 validation (slug RFC 1123, password ≥ 8)
- `app/routers/super_admin.py` — endpoint protégé par `super-admin:tenants:create`
- `tests/` — 2 fichiers, service + router tests

## Test plan
- [ ] `pytest tests/test_tenant_service.py tests/routers/test_super_admin.py -v`
- [ ] Verify slug validation rejects uppercase/spaces
- [ ] Verify all 46 permissions are seeded
- [ ] Verify role-permission matrix integrity