### PR TITLE
fix(models): add CouncilMinutes models + fix migration chain

### DIFF
--- a/alembic/versions/20260406_0004_council_minutes.py
+++ b/alembic/versions/20260406_0004_council_minutes.py
@@ -1,7 +1,7 @@
 """Add council_minutes and council_student_decisions tables.
 
-Revision ID: 0003
-Revises: 0002
+Revision ID: 0004
+Revises: 0003
 Create Date: 2026-04-06
 """
 
@@ -9,8 +9,8 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision: str = "0003"
-down_revision: str | None = "0002"
+revision: str = "0004"
+down_revision: str | None = "0003"
 branch_labels: str | None = None
 depends_on: str | None = None
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -51,6 +51,8 @@ from app.models.fee import (  # noqa: F401
 from app.models.grade import (  # noqa: F401
     Bulletin,
     CouncilDecision,
+    CouncilMinutes,
+    CouncilStudentDecision,
     Evaluation,
     EvaluationType,
     Grade,

--- a/app/models/grade.py
+++ b/app/models/grade.py
@@ -173,3 +173,51 @@ class SubjectAverage(Base, TimestampMixin):
     bulletin: Mapped[Bulletin] = relationship(back_populates="subject_averages")
     subject: Mapped[Subject] = relationship()
     student: Mapped[Student] = relationship()
+
+
+class CouncilMinutes(Base, TimestampMixin):
+    """Procès-verbal du conseil de classe."""
+
+    __tablename__ = "council_minutes"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    class_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("classes.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    academic_year_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("academic_years.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    trimester: Mapped[int] = mapped_column(Integer, nullable=False)
+    main_teacher_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    director_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    dren_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    generated_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    is_published: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    class_: Mapped[Class] = relationship()
+    academic_year: Mapped[AcademicYear] = relationship()
+    decisions: Mapped[list[CouncilStudentDecision]] = relationship(back_populates="council_minutes")
+
+
+class CouncilStudentDecision(Base, TimestampMixin):
+    """Décision du conseil pour un élève."""
+
+    __tablename__ = "council_student_decisions"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    council_minutes_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("council_minutes.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    student_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("students.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    average: Mapped[Decimal | None] = mapped_column(Numeric(4, 2), nullable=True)
+    rank: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    absence_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    auto_decision: Mapped[str] = mapped_column(String(50), nullable=False)
+    final_decision: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    override_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    council_minutes: Mapped[CouncilMinutes] = relationship(back_populates="decisions")
+    student: Mapped[Student] = relationship()


### PR DESCRIPTION
Adds missing CouncilMinutes and CouncilStudentDecision models to grade.py. Fixes duplicate revision 0003 by renaming council migration to 0004.