### PR TITLE
feat: enrollment redesign backend — composite endpoints + fees by level + global year

### DIFF
--- a/alembic/versions/20260407_0005_fee_variants_level_series.py
+++ b/alembic/versions/20260407_0005_fee_variants_level_series.py
@@ -1,0 +1,48 @@
+"""add level_id and series_id to fee_variants.
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-04-07
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers
+revision: str = "0005"
+down_revision: str = "0004"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column("fee_variants", sa.Column("level_id", sa.BigInteger(), nullable=True))
+    op.add_column("fee_variants", sa.Column("series_id", sa.BigInteger(), nullable=True))
+    op.create_foreign_key(
+        "fk_fee_variants_level",
+        "fee_variants",
+        "levels",
+        ["level_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_foreign_key(
+        "fk_fee_variants_series",
+        "fee_variants",
+        "series",
+        ["series_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_index("idx_fee_variants_level_id", "fee_variants", ["level_id"])
+    op.create_index("idx_fee_variants_series_id", "fee_variants", ["series_id"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_fee_variants_series", "fee_variants", type_="foreignkey")
+    op.drop_constraint("fk_fee_variants_level", "fee_variants", type_="foreignkey")
+    op.drop_index("idx_fee_variants_series_id", "fee_variants")
+    op.drop_index("idx_fee_variants_level_id", "fee_variants")
+    op.drop_column("fee_variants", "series_id")
+    op.drop_column("fee_variants", "level_id")

--- a/app/models/fee.py
+++ b/app/models/fee.py
@@ -13,7 +13,7 @@ from app.core.database import Base
 from app.models.base import TimestampMixin, ValueEnum
 
 if TYPE_CHECKING:
-    from app.models.academic import AcademicYear, Class
+    from app.models.academic import AcademicYear, Class, Level, Series
     from app.models.enrollment import Enrollment, StudentOption
 
 
@@ -77,10 +77,18 @@ class FeeVariant(Base, TimestampMixin):
     )
     amount: Mapped[Decimal] = mapped_column(Numeric(15, 2), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    level_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("levels.id", ondelete="RESTRICT"), nullable=True, index=True
+    )
+    series_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("series.id", ondelete="RESTRICT"), nullable=True, index=True
+    )
 
     category: Mapped[FeeCategory] = relationship(back_populates="variants")
     class_: Mapped[Class | None] = relationship()
     academic_year: Mapped[AcademicYear] = relationship()
+    level: Mapped[Level | None] = relationship()
+    series: Mapped[Series | None] = relationship()
     enrollment_fees: Mapped[list[EnrollmentFee]] = relationship(back_populates="fee_variant")
 
 

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -412,6 +412,31 @@ async def update_academic_year(
     )
 
 
+@router.get("/academic-years/current", response_model=AcademicYearResponse)
+async def get_current_academic_year(
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> AcademicYearResponse:
+    """Retourne l'annee academique courante (is_current=True) ou 404."""
+    return await admin_service.get_current_academic_year(db)
+
+
+@router.patch(
+    "/academic-years/{year_id}/set-current",
+    response_model=AcademicYearResponse,
+)
+async def set_current_academic_year(
+    year_id: int,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:academic-years:update"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> AcademicYearResponse:
+    """Definit une annee academique comme courante (desactive les autres)."""
+    return await admin_service.set_current_academic_year(
+        db, year_id, updated_by=current_user.user_id
+    )
+
+
 @router.delete("/academic-years/{year_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_academic_year(
     year_id: int,

--- a/app/routers/enrollments.py
+++ b/app/routers/enrollments.py
@@ -9,6 +9,9 @@ from app.schemas.enrollment import (
     EnrollmentListResponse,
     EnrollmentResponse,
     EnrollmentUpdate,
+    EnrollmentWithStudentCreate,
+    FeeVariantResponse,
+    ReEnrollmentCreate,
 )
 from app.services import enrollment_service
 
@@ -45,6 +48,50 @@ async def create_enrollment(
 ) -> EnrollmentResponse:
     """Crée une nouvelle inscription."""
     return await enrollment_service.create_enrollment(db, data, created_by=current_user.user_id)
+
+
+@router.post(
+    "/with-student",
+    response_model=EnrollmentResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_enrollment_with_student(
+    data: EnrollmentWithStudentCreate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("enrollments:create"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> EnrollmentResponse:
+    """Cree un eleve + parent optionnel + inscription en une seule operation."""
+    return await enrollment_service.create_enrollment_with_student(
+        db, data, created_by=current_user.user_id
+    )
+
+
+@router.post(
+    "/re-enroll",
+    response_model=EnrollmentResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def re_enroll_student(
+    data: ReEnrollmentCreate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("enrollments:create"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> EnrollmentResponse:
+    """Re-inscrit un eleve existant dans une nouvelle classe/annee."""
+    return await enrollment_service.re_enroll_student(
+        db, data, created_by=current_user.user_id
+    )
+
+
+@router.get("/fee-variants", response_model=list[FeeVariantResponse])
+async def get_applicable_fee_variants(
+    class_id: int = Query(..., description="ID de la classe pour la resolution des frais"),
+    _: None = require_permission("enrollments:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> list[FeeVariantResponse]:
+    """Retourne les fee variants applicables pour une classe donnee."""
+    return await enrollment_service.get_applicable_fee_variants(db, class_id)
 
 
 @router.get("/{enrollment_id}", response_model=EnrollmentResponse)

--- a/app/schemas/enrollment.py
+++ b/app/schemas/enrollment.py
@@ -1,6 +1,7 @@
 """Schémas Pydantic pour les inscriptions."""
 
-from datetime import datetime
+from datetime import date, datetime
+from decimal import Decimal
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
@@ -56,3 +57,92 @@ class EnrollmentListResponse(BaseModel):
     total: int
     page: int
     size: int
+
+
+# ---------------------------------------------------------------------------
+# Composite enrollment (student + parent + enrollment in one call)
+# ---------------------------------------------------------------------------
+
+
+class ParentInput(BaseModel):
+    first_name: str
+    last_name: str
+    phone: str | None = None
+    email: str | None = None
+    relationship_type: str = "guardian"
+
+    @field_validator("relationship_type")
+    @classmethod
+    def valid_relationship(cls, v: str) -> str:
+        allowed = {"father", "mother", "guardian", "other"}
+        if v not in allowed:
+            raise ValueError(f"relationship_type must be one of {sorted(allowed)}")
+        return v
+
+
+class EnrollmentWithStudentCreate(BaseModel):
+    """Creates a Student + optional Parent + Enrollment in one transaction."""
+
+    # Student info
+    first_name: str
+    last_name: str
+    birth_date: date | None = None
+    genre: str | None = None
+    enrollment_number: str | None = None
+    # Optional parent
+    parent: ParentInput | None = None
+    # Enrollment info
+    class_id: int
+    academic_year_id: int | None = None  # if None, use current year
+    fee_variant_id: int | None = None
+    notes: str | None = None
+
+    @field_validator("genre")
+    @classmethod
+    def valid_genre(cls, v: str | None) -> str | None:
+        if v is not None and v not in {"M", "F"}:
+            raise ValueError("genre must be 'M' or 'F'")
+        return v
+
+    @field_validator("class_id")
+    @classmethod
+    def positive_class_id(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("must be a positive integer")
+        return v
+
+
+class ReEnrollmentCreate(BaseModel):
+    """Re-enrolls an existing student for a new year/class."""
+
+    student_id: int
+    class_id: int
+    academic_year_id: int | None = None  # if None, use current year
+    fee_variant_id: int | None = None
+    notes: str | None = None
+
+    @field_validator("student_id", "class_id")
+    @classmethod
+    def must_be_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("must be a positive integer")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Fee variant resolution
+# ---------------------------------------------------------------------------
+
+
+class FeeVariantResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    fee_category_id: int
+    category_name: str
+    class_id: int | None
+    level_id: int | None
+    series_id: int | None
+    academic_year_id: int
+    amount: Decimal
+    description: str | None

--- a/app/services/admin_service.py
+++ b/app/services/admin_service.py
@@ -2,10 +2,12 @@
 
 import logging
 
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.audit import AuditAction, audit_log
-from app.core.exceptions import NotFoundError
+from app.core.exceptions import BusinessValidationError, NotFoundError
+from app.models.academic import AcademicYear
 from app.repositories import admin_repository as repo
 from app.schemas.admin import (
     AcademicYearCreate,
@@ -617,6 +619,54 @@ async def delete_academic_year(
             entity_id=year_id,
         )
     await db.commit()
+
+
+async def get_current_academic_year(db: AsyncSession) -> AcademicYearResponse:
+    """Retourne l'annee scolaire courante ou leve 404."""
+    stmt = select(AcademicYear).where(AcademicYear.is_current == True)  # noqa: E712
+    result = await db.execute(stmt)
+    year = result.scalar_one_or_none()
+    if year is None:
+        raise BusinessValidationError(
+            "Aucune annee academique courante definie. "
+            "Veuillez configurer l'annee courante dans les parametres."
+        )
+    return _academic_year_to_response(year)
+
+
+async def set_current_academic_year(
+    db: AsyncSession, year_id: int, *, updated_by: int
+) -> AcademicYearResponse:
+    """Definit une annee scolaire comme courante, desactive toutes les autres."""
+    year = await repo.get_academic_year_by_id(db, year_id)
+    if year is None:
+        raise NotFoundError("AcademicYear", year_id)
+
+    async with db.begin_nested():
+        # Reset all years to not current
+        stmt = update(AcademicYear).values(is_current=False)
+        await db.execute(stmt)
+        # Set this year as current
+        stmt = (
+            update(AcademicYear)
+            .where(AcademicYear.id == year_id)
+            .values(is_current=True)
+        )
+        await db.execute(stmt)
+        await audit_log(
+            db,
+            entity_type="academic_year",
+            action=AuditAction.UPDATE,
+            user_id=updated_by,
+            entity_id=year_id,
+            new_values={"is_current": True},
+        )
+    await db.commit()
+
+    refreshed = await repo.get_academic_year_by_id(db, year_id)
+    if refreshed is None:
+        raise NotFoundError("AcademicYear", year_id)
+    return _academic_year_to_response(refreshed)
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/enrollment_service.py
+++ b/app/services/enrollment_service.py
@@ -1,18 +1,27 @@
 """Service inscriptions — logique métier CRUD + frais automatiques."""
 
 import logging
+from decimal import Decimal
 
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.core.audit import AuditAction, audit_log
 from app.core.exceptions import BusinessValidationError, NotFoundError
+from app.models.academic import AcademicYear, Class
 from app.models.enrollment import Enrollment, EnrollmentStatus
+from app.models.fee import FeeCategory, FeeVariant
+from app.models.user import Parent, ParentStudent, Student
 from app.repositories import enrollment_repository as repo
 from app.schemas.enrollment import (
     EnrollmentCreate,
     EnrollmentListResponse,
     EnrollmentResponse,
     EnrollmentUpdate,
+    EnrollmentWithStudentCreate,
+    FeeVariantResponse,
+    ReEnrollmentCreate,
 )
 
 logger = logging.getLogger(__name__)
@@ -213,3 +222,210 @@ async def delete_enrollment(
         )
 
     await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Current academic year helper
+# ---------------------------------------------------------------------------
+
+
+async def _get_current_academic_year(db: AsyncSession) -> AcademicYear:
+    """Retourne l'annee scolaire courante ou leve une erreur metier."""
+    stmt = select(AcademicYear).where(AcademicYear.is_current == True)  # noqa: E712
+    result = await db.execute(stmt)
+    year = result.scalar_one_or_none()
+    if not year:
+        raise BusinessValidationError(
+            "Aucune annee academique courante definie. "
+            "Veuillez configurer l'annee courante dans les parametres."
+        )
+    return year
+
+
+# ---------------------------------------------------------------------------
+# Composite enrollment: student + parent + enrollment in one transaction
+# ---------------------------------------------------------------------------
+
+
+async def create_enrollment_with_student(
+    db: AsyncSession,
+    data: EnrollmentWithStudentCreate,
+    created_by: int,
+) -> EnrollmentResponse:
+    """Cree un eleve, un parent optionnel, et une inscription en une transaction."""
+    # Resolve academic year
+    academic_year_id = data.academic_year_id
+    if academic_year_id is None:
+        current = await _get_current_academic_year(db)
+        academic_year_id = current.id
+    else:
+        ay = await repo.get_academic_year_by_id(db, academic_year_id)
+        if ay is None:
+            raise BusinessValidationError(f"AcademicYear {academic_year_id} not found")
+
+    async with db.begin_nested():
+        # Capacity guard
+        class_ = await repo.get_class_by_id_for_update(db, data.class_id)
+        if class_ is None:
+            raise BusinessValidationError(f"Class {data.class_id} not found")
+        enrolled_count = await repo.count_active_enrollments_for_class(db, data.class_id)
+        if enrolled_count >= class_.max_students:
+            raise BusinessValidationError(
+                f"Class {data.class_id} is full ({class_.max_students} students max)"
+            )
+
+        # 1. Create student
+        student = Student(
+            first_name=data.first_name,
+            last_name=data.last_name,
+            birth_date=data.birth_date,
+            genre=data.genre,
+            enrollment_number=data.enrollment_number,
+        )
+        db.add(student)
+        await db.flush()
+
+        # 2. Create parent if provided
+        if data.parent:
+            parent = Parent(
+                first_name=data.parent.first_name,
+                last_name=data.parent.last_name,
+                phone=data.parent.phone,
+                email=data.parent.email,
+            )
+            db.add(parent)
+            await db.flush()
+            link = ParentStudent(
+                parent_id=parent.id,
+                student_id=student.id,
+                relationship_type=data.parent.relationship_type,
+            )
+            db.add(link)
+            await db.flush()
+
+        # 3. Create enrollment (reuses capacity check done above)
+        enrollment = await repo.create_enrollment(
+            db,
+            student_id=student.id,
+            class_id=data.class_id,
+            academic_year_id=academic_year_id,
+            created_by=created_by,
+            notes=data.notes,
+        )
+
+        # 4. Create enrollment fee if variant provided
+        if data.fee_variant_id is not None:
+            await repo.create_enrollment_fee(
+                db,
+                enrollment_id=enrollment.id,
+                fee_variant_id=data.fee_variant_id,
+            )
+
+        await audit_log(
+            db,
+            entity_type="enrollment",
+            action=AuditAction.CREATE,
+            user_id=created_by,
+            entity_id=enrollment.id,
+            new_values={
+                "student_name": f"{data.first_name} {data.last_name}",
+                "with_student": True,
+                "class_id": data.class_id,
+                "academic_year_id": academic_year_id,
+            },
+        )
+
+    await db.commit()
+
+    refreshed = await repo.get_enrollment_by_id(db, enrollment.id)
+    if refreshed is None:
+        raise NotFoundError("Enrollment", enrollment.id)
+    return _to_response(refreshed)
+
+
+async def re_enroll_student(
+    db: AsyncSession,
+    data: ReEnrollmentCreate,
+    created_by: int,
+) -> EnrollmentResponse:
+    """Re-inscrit un eleve existant dans une nouvelle classe/annee."""
+    # Resolve academic year
+    academic_year_id = data.academic_year_id
+    if academic_year_id is None:
+        current = await _get_current_academic_year(db)
+        academic_year_id = current.id
+    else:
+        ay = await repo.get_academic_year_by_id(db, academic_year_id)
+        if ay is None:
+            raise BusinessValidationError(f"AcademicYear {academic_year_id} not found")
+
+    # Use existing create_enrollment logic (handles capacity + duplicate guard)
+    enrollment_data = EnrollmentCreate(
+        student_id=data.student_id,
+        class_id=data.class_id,
+        academic_year_id=academic_year_id,
+        fee_variant_id=data.fee_variant_id,
+        notes=data.notes,
+    )
+    return await create_enrollment(db, enrollment_data, created_by=created_by)
+
+
+# ---------------------------------------------------------------------------
+# Fee variant resolution by class
+# ---------------------------------------------------------------------------
+
+
+async def get_applicable_fee_variants(
+    db: AsyncSession,
+    class_id: int,
+) -> list[FeeVariantResponse]:
+    """Retourne les fee variants applicables pour une classe donnee.
+
+    Resout par class_id exact, par level_id, par series_id, ou globaux
+    (class_id/level_id/series_id tous NULL). Filtre par annee courante.
+    """
+    # Get class to find level_id and series_id
+    stmt = select(Class).where(Class.id == class_id)
+    result = await db.execute(stmt)
+    class_ = result.scalar_one_or_none()
+    if class_ is None:
+        raise BusinessValidationError(f"Class {class_id} not found")
+
+    # Build conditions: exact class, or matching level, or matching series, or global
+    conditions = [FeeVariant.class_id == class_id]
+    if class_.level_id:
+        conditions.append(FeeVariant.level_id == class_.level_id)
+    if class_.series_id:
+        conditions.append(FeeVariant.series_id == class_.series_id)
+    # Global variants (no class, level, or series specified)
+    conditions.append(
+        (FeeVariant.class_id.is_(None))
+        & (FeeVariant.level_id.is_(None))
+        & (FeeVariant.series_id.is_(None))
+    )
+
+    stmt = (
+        select(FeeVariant)
+        .options(selectinload(FeeVariant.category))
+        .where(
+            FeeVariant.academic_year_id == class_.academic_year_id,
+            or_(*conditions),
+        )
+        .order_by(FeeVariant.fee_category_id, FeeVariant.id)
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+
+    return [
+        FeeVariantResponse(
+            id=fv.id,
+            fee_category_id=fv.fee_category_id,
+            category_name=fv.category.name if fv.category else str(fv.fee_category_id),
+            class_id=fv.class_id,
+            level_id=fv.level_id,
+            series_id=fv.series_id,
+            academic_year_id=fv.academic_year_id,
+            amount=fv.amount,
+            description=fv.description,
+        )
+        for fv in rows
+    ]


### PR DESCRIPTION
## Summary

Backend changes for enrollment form redesign.

### Migration
- `fee_variants`: added `level_id` + `series_id` columns (FK to levels/series)
- Allows fee configuration by level (6eme, 5eme) or series (A, C, D)

### New endpoints
- `GET /admin/academic-years/current` — returns the current academic year (or 422)
- `PATCH /admin/academic-years/{id}/set-current` — sets one year as current, resets others
- `POST /enrollments/with-student` — composite: creates Student + Parent + Enrollment in one transaction
- `POST /enrollments/re-enroll` — re-enrolls existing student
- `GET /enrollments/fee-variants?class_id=X` — resolves applicable fees (class > level > series > global)

### Fee resolution cascade
1. `class_id` exact match
2. `level_id` match (class's level)
3. `series_id` match (class's series)
4. Global (all null)

## Test plan
- [ ] Set current year via PATCH
- [ ] Create enrollment with new student (composite)
- [ ] Re-enroll existing student
- [ ] Fee variants resolve by level/series