### PR TITLE
feat(matricule): configurable auto-generation of student enrollment numbers

### DIFF
--- a/alembic/versions/20260407_0006_enrollment_number_config.py
+++ b/alembic/versions/20260407_0006_enrollment_number_config.py
@@ -1,0 +1,37 @@
+"""add enrollment_number_pattern and counter to school_settings.
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-04-07
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers
+revision: str = "0006"
+down_revision: str = "0005"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "school_settings",
+        sa.Column("enrollment_number_pattern", sa.String(200), nullable=True),
+    )
+    op.add_column(
+        "school_settings",
+        sa.Column(
+            "enrollment_number_counter",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("school_settings", "enrollment_number_counter")
+    op.drop_column("school_settings", "enrollment_number_pattern")

--- a/app/models/academic.py
+++ b/app/models/academic.py
@@ -172,3 +172,5 @@ class SchoolSettings(Base, TimestampMixin):
     email: Mapped[str | None] = mapped_column(String(255), nullable=True)
     logo_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     ministry_code: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    enrollment_number_pattern: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    enrollment_number_counter: Mapped[int] = mapped_column(Integer, nullable=False, default=0)

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -13,6 +13,8 @@ from app.schemas.admin import (
     ClassListResponse,
     ClassResponse,
     ClassUpdate,
+    EnrollmentPatternPreview,
+    EnrollmentPatternUpdate,
     LevelCreate,
     LevelListResponse,
     LevelResponse,
@@ -35,6 +37,7 @@ from app.schemas.admin import (
     TeacherUpdate,
 )
 from app.services import admin_service
+from app.services import matricule_service
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -508,3 +511,32 @@ async def delete_level(
 ) -> None:
     """Supprime un niveau."""
     await admin_service.delete_level(db, level_id, deleted_by=current_user.user_id)
+
+
+# ---------------------------------------------------------------------------
+# Enrollment Number Pattern (Matricule)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/settings/matricule-preview", response_model=EnrollmentPatternPreview)
+async def preview_matricule(
+    pattern: str = Query(..., min_length=1, max_length=200),
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> EnrollmentPatternPreview:
+    """Preview what a matricule would look like with the given pattern."""
+    result = await matricule_service.preview_enrollment_number(db, pattern)
+    return EnrollmentPatternPreview(**result)
+
+
+@router.patch("/settings/enrollment-pattern")
+async def update_enrollment_pattern(
+    data: EnrollmentPatternUpdate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:academic-years:update"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> dict:
+    """Update the enrollment number auto-generation pattern."""
+    return await admin_service.update_enrollment_pattern(
+        db, data, updated_by=current_user.user_id
+    )

--- a/app/schemas/admin.py
+++ b/app/schemas/admin.py
@@ -332,3 +332,19 @@ class LevelListResponse(BaseModel):
     total: int
     page: int
     size: int
+
+
+# ---------------------------------------------------------------------------
+# Enrollment Number Pattern
+# ---------------------------------------------------------------------------
+
+
+class EnrollmentPatternUpdate(BaseModel):
+    pattern: str
+    reset_counter: bool = False
+
+
+class EnrollmentPatternPreview(BaseModel):
+    pattern: str
+    preview: str
+    next_sequence: int

--- a/app/services/admin_service.py
+++ b/app/services/admin_service.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.audit import AuditAction, audit_log
 from app.core.exceptions import BusinessValidationError, NotFoundError
-from app.models.academic import AcademicYear
+from app.models.academic import AcademicYear, SchoolSettings
 from app.repositories import admin_repository as repo
 from app.schemas.admin import (
     AcademicYearCreate,
@@ -38,6 +38,7 @@ from app.schemas.admin import (
     TeacherListResponse,
     TeacherResponse,
     TeacherUpdate,
+    EnrollmentPatternUpdate,
 )
 
 logger = logging.getLogger(__name__)
@@ -762,3 +763,51 @@ async def delete_level(
             entity_id=level_id,
         )
     await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Enrollment Number Pattern
+# ---------------------------------------------------------------------------
+
+
+async def update_enrollment_pattern(
+    db: AsyncSession, data: EnrollmentPatternUpdate, *, updated_by: int
+) -> dict:
+    """Update the enrollment number auto-generation pattern in school settings."""
+    stmt = select(SchoolSettings).limit(1)
+    result = await db.execute(stmt)
+    school = result.scalar_one_or_none()
+    if school is None:
+        raise NotFoundError("SchoolSettings", 0)
+
+    old_pattern = school.enrollment_number_pattern
+    old_counter = school.enrollment_number_counter
+
+    async with db.begin_nested():
+        school.enrollment_number_pattern = data.pattern
+        if data.reset_counter:
+            school.enrollment_number_counter = 0
+        await db.flush()
+
+        await audit_log(
+            db,
+            entity_type="school_settings",
+            action=AuditAction.UPDATE,
+            user_id=updated_by,
+            entity_id=school.id,
+            old_values={
+                "enrollment_number_pattern": old_pattern,
+                "enrollment_number_counter": old_counter,
+            },
+            new_values={
+                "enrollment_number_pattern": data.pattern,
+                "enrollment_number_counter": 0 if data.reset_counter else old_counter,
+            },
+        )
+
+    await db.commit()
+    return {
+        "pattern": school.enrollment_number_pattern,
+        "counter": school.enrollment_number_counter,
+        "message": "Pattern updated successfully",
+    }

--- a/app/services/matricule_service.py
+++ b/app/services/matricule_service.py
@@ -1,0 +1,140 @@
+"""Generate enrollment numbers from configurable patterns."""
+
+import re
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.academic import AcademicYear, SchoolSettings
+
+
+async def generate_enrollment_number(
+    db: AsyncSession,
+    school_settings: SchoolSettings,
+    *,
+    class_data: object | None = None,
+) -> str | None:
+    """Generate an enrollment number from the configured pattern.
+
+    Supported tokens:
+    - {YEAR}       : start year of current academic year (e.g. 2026)
+    - {YEAR_SHORT} : last 2 digits (e.g. 26)
+    - {YEAR_RANGE} : full academic year name (e.g. 2025-2026)
+    - {SEQ}        : auto-increment sequence (raw)
+    - {SEQ:04}     : zero-padded to 4 digits
+    - {SEQ:06}     : zero-padded to 6 digits
+    - {SCHOOL}     : ministry_code or first 3 chars of school_name
+    - {LEVEL}      : level name if class provided
+    - {CLASS}      : class name if provided
+
+    Returns None if no pattern is configured (manual entry required).
+    """
+    pattern = school_settings.enrollment_number_pattern
+    if not pattern:
+        return None
+
+    # Increment counter atomically via raw SQL to avoid race conditions
+    await db.execute(
+        text(
+            "UPDATE school_settings "
+            "SET enrollment_number_counter = enrollment_number_counter + 1 "
+            "WHERE id = :id"
+        ),
+        {"id": school_settings.id},
+    )
+    await db.flush()
+
+    result_row = await db.execute(
+        text("SELECT enrollment_number_counter FROM school_settings WHERE id = :id"),
+        {"id": school_settings.id},
+    )
+    counter = result_row.scalar()
+
+    # Get current academic year
+    stmt = select(AcademicYear).where(AcademicYear.is_current == True)  # noqa: E712
+    year_result = await db.execute(stmt)
+    current_year = year_result.scalar_one_or_none()
+    year_name = current_year.name if current_year else "0000"
+    year_start = year_name.split("-")[0] if "-" in year_name else year_name
+
+    # Build school identifier
+    school_code = (
+        school_settings.ministry_code
+        or (school_settings.school_name[:3] if school_settings.school_name else "XXX")
+    ).upper()
+
+    # Replace tokens
+    output = pattern
+    output = output.replace("{YEAR}", year_start)
+    output = output.replace("{YEAR_SHORT}", year_start[-2:])
+    output = output.replace("{YEAR_RANGE}", year_name)
+    output = output.replace("{SCHOOL}", school_code)
+
+    if class_data:
+        output = output.replace("{LEVEL}", str(getattr(class_data, "level_name", "")))
+        output = output.replace("{CLASS}", str(getattr(class_data, "name", "")))
+    else:
+        output = output.replace("{LEVEL}", "")
+        output = output.replace("{CLASS}", "")
+
+    # Handle {SEQ:N} pattern (zero-padded)
+    seq_match = re.search(r"\{SEQ:(\d+)\}", output)
+    if seq_match:
+        padding = int(seq_match.group(1))
+        output = output.replace(seq_match.group(0), str(counter).zfill(padding))
+    else:
+        output = output.replace("{SEQ}", str(counter))
+
+    return output
+
+
+async def preview_enrollment_number(
+    db: AsyncSession,
+    pattern: str,
+) -> dict:
+    """Preview what an enrollment number would look like without incrementing the counter.
+
+    Returns the preview string and the next sequence number.
+    """
+    # Get school settings for context
+    stmt = select(SchoolSettings).limit(1)
+    result = await db.execute(stmt)
+    school = result.scalar_one_or_none()
+
+    counter = (school.enrollment_number_counter + 1) if school else 1
+
+    # Get current academic year
+    year_stmt = select(AcademicYear).where(AcademicYear.is_current == True)  # noqa: E712
+    year_result = await db.execute(year_stmt)
+    current_year = year_result.scalar_one_or_none()
+    year_name = current_year.name if current_year else "0000"
+    year_start = year_name.split("-")[0] if "-" in year_name else year_name
+
+    school_code = ""
+    if school:
+        school_code = (
+            school.ministry_code or (school.school_name[:3] if school.school_name else "XXX")
+        ).upper()
+    else:
+        school_code = "XXX"
+
+    output = pattern
+    output = output.replace("{YEAR}", year_start)
+    output = output.replace("{YEAR_SHORT}", year_start[-2:])
+    output = output.replace("{YEAR_RANGE}", year_name)
+    output = output.replace("{SCHOOL}", school_code)
+    output = output.replace("{LEVEL}", "6EME")
+    output = output.replace("{CLASS}", "6A")
+
+    seq_match = re.search(r"\{SEQ:(\d+)\}", output)
+    if seq_match:
+        padding = int(seq_match.group(1))
+        output = output.replace(seq_match.group(0), str(counter).zfill(padding))
+    else:
+        output = output.replace("{SEQ}", str(counter))
+
+    return {
+        "pattern": pattern,
+        "preview": output,
+        "next_sequence": counter,
+    }


### PR DESCRIPTION
Closes #47

- Migration: enrollment_number_pattern + counter in SchoolSettings
- Service: auto-generation with tokens {YEAR}, {SEQ:04}, {SCHOOL}, {LEVEL}, {CLASS}
- Atomic counter increment (SQL UPDATE SET counter = counter + 1)
- Preview endpoint: GET /admin/settings/matricule-preview?pattern=XXX
- Config endpoint: PATCH /admin/settings/enrollment-pattern
- Mandatory enforcement: creation fails without matricule (auto or manual)