### PR TITLE
docs+devops: CHANGELOG, rule, and E2E seed script

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -101,3 +101,4 @@ mypy app/
 @rules/auth-architecture.md
 @rules/deploy.md
 @rules/git.md
+@rules/changelog.md

--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -1,0 +1,118 @@
+# Règle Changelog — KLASSCI College Backend
+
+Le fichier `CHANGELOG.md` à la racine documente les évolutions de la
+plateforme du **point de vue de l'utilisateur final** (admin, enseignant,
+parent, élève, devops). Il suit
+[Keep a Changelog 1.1.0](https://keepachangelog.com/fr/1.1.0/) et
+[Semantic Versioning](https://semver.org/lang/fr/).
+
+## Quand alimenter
+
+| Type de commit                | Action sur le changelog |
+|-------------------------------|--------------------------|
+| `feat:` qui change l'API ou le comportement perceptible | **Oui** → `Added` ou `Changed` |
+| `fix:` d'un bug que l'utilisateur a vu               | **Oui** → `Fixed`              |
+| `perf:` ressenti côté usage                          | **Oui** → `Changed`            |
+| `refactor:` qui modifie un endpoint ou un contrat    | **Oui** → `Changed`            |
+| Faille corrigée, dépendance bumpée pour un CVE       | **Oui** → `Security`           |
+| `chore:` / `docs:` / `test:` / `ci:` / `style:`      | **Non** — n'a rien à faire dans le changelog |
+
+> **Règle d'or** : si la ligne ne dit pas *« ce que l'utilisateur peut
+> faire de plus, mieux, ou différemment »*, elle ne devrait pas être là.
+
+## Comment écrire une entrée
+
+1. **Perspective utilisateur, pas développeur.**
+   - ❌ « Added `EnrollmentService` class with `create()` method »
+   - ✅ « Inscription multi-étape avec validation automatique des frais
+     selon le niveau et la série *(admin)* »
+
+2. **Français propre, accents corrects.** Cohérence avec le reste du
+   projet : voir `marcel-global-preferences.md`.
+
+3. **Persona en italique** à la fin de la ligne :
+   `*(admin)*`, `*(enseignant)*`, `*(parent)*`, `*(élève)*`,
+   `*(super-admin)*`, `*(devops)*`. Plusieurs si pertinent : `*(admin,
+   enseignant)*`. **Pas de persona** si vraiment transverse.
+
+4. **Lien PR** quand identifiable : `(#42)` à la fin.
+
+5. **Une ligne, ≤ 25 mots.** Si le sujet déborde, c'est qu'il devrait
+   être deux entrées séparées.
+
+6. **Pas de jargon technique** : aucune mention de classes Python, de
+   modules `app/...`, de noms de migrations, de libs (FastAPI, SQLAlchemy,
+   Alembic). On décrit *ce que ça fait*, pas *avec quoi*.
+
+## Où l'ajouter
+
+Toujours sous `## [Unreleased]` au sommet du fichier, dans la section
+appropriée. Si la section n'existe pas encore dans `Unreleased`, la
+créer dans cet ordre canonique (sauter celles vides) :
+
+```
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+```
+
+## Quand bumper la version
+
+| De            | À             | Critère                                                 |
+|---------------|---------------|---------------------------------------------------------|
+| `0.1.0-alpha` | `0.1.0`       | Première école pilote tournée 30 jours sans incident P0 |
+| `0.1.x`       | `0.2.0`       | Nouvelle capacité majeure (ex : Wave/Orange Money live) |
+| `0.x.y`       | `1.0.0`       | 5 écoles en production payante, SLA tenu 60 jours       |
+| `X.Y.Z`       | `X.Y.(Z+1)`   | Patch — fix bugs sans nouvelle capacité                 |
+| `X.Y.Z`       | `X.(Y+1).0`   | Minor — nouvelle capacité, rétrocompatible              |
+| `X.Y.Z`       | `(X+1).0.0`   | Major — breaking change (migration manuelle requise)    |
+
+À chaque release :
+
+1. Renommer `## [Unreleased]` en `## [X.Y.Z] - YYYY-MM-DD` (date du tag).
+2. Recréer un bloc `## [Unreleased]` vide au sommet.
+3. Ajouter / mettre à jour les liens compare en bas du fichier :
+   ```
+   [unreleased]: https://github.com/African-DC/klassci-college-backend/compare/vX.Y.Z...HEAD
+   [X.Y.Z]: https://github.com/African-DC/klassci-college-backend/compare/vX.Y.W...vX.Y.Z
+   ```
+4. Tagger : `git tag vX.Y.Z` puis `git push --tags`.
+
+## Anti-patterns à bloquer en revue
+
+1. Entrée qui décrit l'implémentation : `Added EnrollmentRepository.create_batch`
+2. Entrée qui mentionne un fichier ou un module : `routers/grades.py`
+3. Entrée qui ne dit pas *quoi*, juste *pourquoi internal* : `Refactor for cleaner code`
+4. Section `## [Unreleased]` absente ou vide bloquée à plusieurs commits feat
+5. Version sans date, ou date au format autre qu'ISO 8601 (`YYYY-MM-DD`)
+6. Sections vides laissées dans le fichier (les supprimer)
+7. Mélange français / anglais dans les entrées
+8. Lister 5 commits CRUD distincts au lieu de méga-grouper en une feature
+
+## Exemples corrects
+
+```markdown
+### Added
+- Saisie de notes en mode dictée vocale, parfait pour les enseignants qui
+  préfèrent réciter les notes plutôt que taper *(enseignant)* (#40)
+- Provisioning d'un nouvel établissement en une commande CLI : DB, rôles,
+  admin, e-mail de bienvenue *(super-admin)* (#40)
+
+### Fixed
+- Saisie d'absence enregistrait l'élève comme « non saisi » au lieu de
+  « absent » dans certains cas *(enseignant)* (#73)
+
+### Security
+- Token de rafraîchissement déplacé en cookie HttpOnly Secure SameSite,
+  l'access token JWT reste 15 minutes pour limiter l'exposition (#52)
+```
+
+## Voir aussi
+
+- `klassci-college-frontend/.claude/rules/changelog.md` — règle équivalente
+  côté FE (entrées séparées dans le CHANGELOG.md du frontend)
+- `klassci-backend/CHANGELOG.md` — fichier alimenté
+- Rule `rules/git.md` — formats de commit qui alimentent les sections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,83 @@
+# Changelog
+
+Toutes les évolutions notables de KLASSCI College Backend (FastAPI) sont
+documentées dans ce fichier.
+
+Le format suit [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/) et
+le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
+
+## [Unreleased]
+
+### Added
+
+- Création d'évaluation par un admin ou un personnel administratif au nom d'un enseignant, avec contrôle d'identité du titulaire et trace d'audit *(admin, enseignant)*.
+- Endpoint exposant les permissions effectives de l'utilisateur courant, consommé par les portails pour afficher uniquement les actions autorisées *(tous)*.
+- Outils de provisioning : script de seed déterministe pour les comptes admin / enseignant / élève des scénarios E2E *(devops)*.
+
+### Changed
+
+- Audit des changements de permissions de rôle : on garde désormais l'état avant et après pour reconstruire le diff de chaque modification *(admin, super-admin)*.
+
+### Fixed
+
+- Permissions de gestion des rôles, des salles et des séries désormais seedées par défaut. Auparavant, les pages correspondantes côté portail étaient inaccessibles en silence (#73).
+- Démontage propre de la migration ajoutant la traçabilité de saisie des notes (l'ordre de suppression de l'index et de la contrainte cassait la rétrogradation sur MySQL).
+
+## [0.1.0-alpha] - 2026-04-26
+
+### Added
+
+- Authentification par email et mot de passe avec session persistante via cookie sécurisé et endpoint de profil *(admin, enseignant, parent, élève)*.
+- Provisioning d'un nouvel établissement en une commande (CLI ou API) avec création automatique de l'admin, des rôles et des données de démarrage *(super-admin)* (#40).
+- Inscriptions des élèves en plusieurs étapes avec contrôle de capacité de classe, gestion des doublons et réinscription d'une année à l'autre *(admin)* (#16, #44).
+- CRUD complet des élèves, enseignants, personnel, classes, niveaux, séries, salles et matières avec recherche, filtres et pagination *(admin)* (#31).
+- Création automatique d'un compte de connexion lors de l'ajout d'un élève ou d'un enseignant, et endpoint dédié pour générer un compte ultérieurement *(admin)*.
+- Fiche détaillée 360° de l'élève avec compte utilisateur, inscription en cours, présences et résumé des frais en un seul écran *(admin)*.
+- Gestion des parents avec rattachement aux enfants et accès au portail famille *(admin, parent)*.
+- Catégories et variantes de frais paramétrables par niveau et série, avec distinction obligatoire/optionnel et options multiples (cantine, transport, etc.) *(admin)* (#46).
+- Création automatique des frais à payer dès l'inscription, régénération en cas de changement de classe et abonnement aux frais optionnels *(admin)*.
+- Encaissement des paiements en espèces avec workflow validation/annulation, génération d'un reçu PDF et résumé par élève *(admin)* (#32, #55).
+- Saisie des présences cours par cours avec statistiques par élève, par classe et alertes d'absence *(enseignant, admin)* (#33).
+- Saisie des notes et évaluations avec coefficients par matière, classement et historique *(enseignant)* (#18).
+- Génération et publication des bulletins de notes en PDF avec téléchargement individuel ou par lot *(admin, enseignant, parent, élève)* (#38).
+- Procès-verbaux de conseil de classe en PDF avec décisions par élève (admis, redouble, exclu, etc.) *(admin, enseignant)* (#37, #55).
+- Statistiques DREN agrégées (effectifs, taux de présence, résultats) prêtes à exporter *(admin)* (#39).
+- Tableau de bord de l'admin avec compteurs en temps réel (élèves, paiements, présences) et flux d'activité récente *(admin)*.
+- Emploi du temps avec génération automatique intelligente (OR-Tools), durées variables, préservation des créneaux saisis manuellement et détection des conflits salles/profs *(admin)* (#17).
+- Export PDF de l'emploi du temps prêt à imprimer pour affichage *(admin, enseignant, élève)*.
+- Coloration des matières et duplication par glisser-déposer pour configurer rapidement la grille hebdomadaire *(admin)*.
+- Configuration du format des numéros matricule par établissement, avec aperçu en direct avant validation *(admin)* (#52).
+- Téléversement de la photo des élèves, enseignants et personnel, et de documents officiels (carte, justificatifs) *(admin)*.
+- Import en lot des élèves depuis un fichier CSV *(admin)* (#53).
+- Portail élève avec emploi du temps, notes, bulletins, présences et notifications *(élève)* (#34).
+- Portail enseignant avec classes assignées, saisie des notes/présences, emploi du temps et messagerie de notifications *(enseignant)* (#36).
+- Portail parent avec suivi multi-enfants : bulletins, présences, paiements, emploi du temps *(parent)* (#35).
+- Notifications multi-canal (email SMTP, SMS Twilio, in-app) déclenchées sur publication de bulletin, absence et paiement *(admin, enseignant, parent, élève)* (#30, #54).
+- Paramètres établissement éditables : informations école, année scolaire en cours, format matricule *(admin)*.
+- Données de démonstration pré-remplies pour démarrer un établissement test (CI) en une commande *(super-admin)* (#45).
+
+### Changed
+
+- Résolution du tenant unifiée via le token JWT puis l'en-tête `X-Tenant-Slug`, avec repli sur le sous-domaine, pour le déploiement en domaine unique `college.klassci.com` *(devops)* (#72).
+- Réponses des inscriptions, classes, matières et paiements enrichies avec les noms et photos liés (élève, classe, matière, photo) pour éviter des appels supplémentaires *(admin, enseignant)*.
+
+### Fixed
+
+- Recherche multi-mots traitée correctement (chaque mot filtre indépendamment) avec repli flou (RapidFuzz) lorsqu'aucun résultat exact n'est trouvé *(admin)*.
+- Inscriptions filtrées correctement par élève sur la liste *(admin)*.
+- Génération du reçu PDF de paiement et du PV de conseil ne plante plus sur les profils sans prénom *(admin)*.
+- Détection du tenant en local (adresses IP numériques) pour le développement *(devops)*.
+
+### Security
+
+- Permissions dynamiques pilotées par la base de données (rôles × permissions configurables par tenant) avec endpoints d'administration dédiés *(admin)*.
+- Journal d'audit horodaté pour toutes les actions sensibles (création, modification, suppression, login) avec sérialisation sûre des paramètres *(admin)*.
+- Token JWT scopé au tenant : impossible d'utiliser un token d'un établissement sur un autre, contrôle appliqué aussi sur le refresh et le logout *(devops, admin)*.
+- Refresh token stocké en cookie HttpOnly + SameSite + Secure, supprimé proprement au logout *(devops)*.
+- Verrou pessimiste (`SELECT FOR UPDATE`) sur la création d'inscription pour empêcher tout dépassement de capacité de classe en cas d'accès simultané *(admin)*.
+- Mise à jour `PyJWT 2.12.0`, `cryptography 46.0.5` et remplacement de `python-jose` (CVE critiques résolues) *(devops)*.
+- Workflow de sécurité automatisé en CI : Bandit, pip-audit, CodeQL et TruffleHog sur chaque PR *(devops)*.
+- Validation stricte des fichiers téléversés (taille, type MIME réel via `finfo`) sur les photos et documents *(devops)*.
+
+[unreleased]: https://github.com/African-DC/klassci-college-backend/compare/v0.1.0-alpha...HEAD
+[0.1.0-alpha]: https://github.com/African-DC/klassci-college-backend/releases/tag/v0.1.0-alpha

--- a/scripts/seed_test_users.py
+++ b/scripts/seed_test_users.py
@@ -1,0 +1,178 @@
+"""Seed deterministic test users for E2E pipelines and local development.
+
+Idempotent — safe to re-run. Reads `DATABASE_URL` from env (with `{tenant}`
+placeholder substituted to the value of the `TENANT_ID` env var, defaulting
+to `local`). All users get the same password to keep the E2E suite simple.
+
+Users seeded:
+- admin@klassci.com  → role admin, with StaffProfile
+- prof@klassci.com   → role teacher, with TeacherProfile
+- eleve@klassci.com  → role student, with Student profile (enrollment_number=E2E001)
+
+Run locally:
+    TENANT_ID=local python scripts/seed_test_users.py
+
+Run in CI (after alembic upgrade head):
+    DATABASE_URL=mysql+aiomysql://root:root@127.0.0.1:3306/{tenant} \\
+    TENANT_ID=klassci_test \\
+    python scripts/seed_test_users.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# Allow running as `python scripts/seed_test_users.py` from repo root.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy import text  # noqa: E402
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine  # noqa: E402
+
+from app.core.config import settings  # noqa: E402
+from app.core.security import hash_password  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+PASSWORD = "Admin@2026"
+
+USERS: list[dict[str, Any]] = [
+    {
+        "email": "admin@klassci.com",
+        "role": "admin",
+        "profile": {"table": "staff_profiles", "first_name": "Admin", "last_name": "KLASSCI"},
+    },
+    {
+        "email": "prof@klassci.com",
+        "role": "teacher",
+        "profile": {
+            "table": "teacher_profiles",
+            "first_name": "Aïssatou",
+            "last_name": "Diallo",
+        },
+    },
+    {
+        "email": "eleve@klassci.com",
+        "role": "student",
+        "profile": {
+            "table": "students",
+            "first_name": "Aminata",
+            "last_name": "Traoré",
+            "enrollment_number": "E2E001",
+        },
+    },
+]
+
+
+def _resolve_database_url() -> str:
+    """Substitute `{tenant}` in DATABASE_URL with TENANT_ID env or 'local'."""
+    tenant = os.environ.get("TENANT_ID", "local")
+    raw = settings.DATABASE_URL
+    return raw.format(tenant=tenant) if "{tenant}" in raw else raw
+
+
+async def _ensure_user(db: Any, email: str, role: str, profile: dict[str, Any]) -> None:
+    """Insert user + role link + profile (idempotent — skip if email exists)."""
+    existing = await db.execute(
+        text("SELECT id FROM users WHERE email = :email"),
+        {"email": email},
+    )
+    user_id = existing.scalar_one_or_none()
+
+    if user_id is None:
+        await db.execute(
+            text(
+                "INSERT INTO users (email, hashed_password, role, is_active) "
+                "VALUES (:email, :hashed, :role, 1)"
+            ),
+            {"email": email, "hashed": hash_password(PASSWORD), "role": role},
+        )
+        result = await db.execute(
+            text("SELECT id FROM users WHERE email = :email"),
+            {"email": email},
+        )
+        user_id = result.scalar_one()
+        logger.info("Created user %s (id=%s)", email, user_id)
+    else:
+        logger.info("User %s already exists (id=%s) — skipping insert", email, user_id)
+
+    # Link to role row in user_roles (idempotent — INSERT IGNORE on UNIQUE).
+    await db.execute(
+        text(
+            "INSERT IGNORE INTO user_roles (user_id, role_id) "
+            "SELECT :user_id, id FROM roles WHERE name = :role_name"
+        ),
+        {"user_id": user_id, "role_name": role},
+    )
+
+    # Create the persona-specific profile if missing.
+    table = profile["table"]
+    if table == "staff_profiles":
+        await db.execute(
+            text(
+                "INSERT IGNORE INTO staff_profiles (user_id, first_name, last_name, position) "
+                "VALUES (:user_id, :first_name, :last_name, 'Administrateur')"
+            ),
+            {
+                "user_id": user_id,
+                "first_name": profile["first_name"],
+                "last_name": profile["last_name"],
+            },
+        )
+    elif table == "teacher_profiles":
+        await db.execute(
+            text(
+                "INSERT IGNORE INTO teacher_profiles "
+                "(user_id, first_name, last_name, speciality) "
+                "VALUES (:user_id, :first_name, :last_name, 'Mathématiques')"
+            ),
+            {
+                "user_id": user_id,
+                "first_name": profile["first_name"],
+                "last_name": profile["last_name"],
+            },
+        )
+    elif table == "students":
+        await db.execute(
+            text(
+                "INSERT IGNORE INTO students "
+                "(user_id, first_name, last_name, enrollment_number) "
+                "VALUES (:user_id, :first_name, :last_name, :enrollment_number)"
+            ),
+            {
+                "user_id": user_id,
+                "first_name": profile["first_name"],
+                "last_name": profile["last_name"],
+                "enrollment_number": profile["enrollment_number"],
+            },
+        )
+
+
+async def main() -> None:
+    url = _resolve_database_url()
+    logger.info("Seeding test users on %s", url.replace(url.split("@")[0], "***"))
+
+    engine = create_async_engine(url, pool_pre_ping=True)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    try:
+        async with factory() as db, db.begin():
+            for spec in USERS:
+                await _ensure_user(
+                    db,
+                    email=spec["email"],
+                    role=spec["role"],
+                    profile=spec["profile"],
+                )
+        logger.info("Seed complete (%d users guaranteed).", len(USERS))
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- Introduces `CHANGELOG.md` (Keep a Changelog 1.1.0 + SemVer) with `[0.1.0-alpha] - 2026-04-26` history and `[Unreleased]` populated by post-tag features.
- Adds `.claude/rules/changelog.md` to guide Claude on when/how to log entries (user-perspective French, persona italics, version bump policy, anti-patterns).
- Adds `scripts/seed_test_users.py` — idempotent seed for `admin@klassci.com`, `prof@klassci.com`, `eleve@klassci.com` (password `Admin@2026`), used by the new FE E2E pipeline.

## Test plan

- [ ] CHANGELOG.md renders correctly on the GitHub view
- [ ] `python scripts/seed_test_users.py` is idempotent on a fresh tenant DB
- [ ] After merge, the FE E2E workflow can clone the BE main and run the seed against MySQL service