### PR TITLE
feat(portals): align teacher dashboard + add student dashboard + teacher evals listing

### DIFF
--- a/app/repositories/teacher_portal_repository.py
+++ b/app/repositories/teacher_portal_repository.py
@@ -1,6 +1,6 @@
 """Repository portail enseignant — accès DB read-only pour le teacher portal."""
 
-from datetime import date
+from datetime import date, timedelta
 
 from sqlalchemy import distinct, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -115,6 +115,125 @@ async def count_upcoming_evaluations(db: AsyncSession, teacher_id: int) -> int:
         )
     )
     return (await db.execute(stmt)).scalar() or 0
+
+
+async def list_upcoming_evaluations(
+    db: AsyncSession,
+    teacher_id: int,
+    *,
+    limit: int = 5,
+) -> list[dict]:
+    """Liste les évaluations récentes ou à venir pour le dashboard.
+
+    Inclut date >= today - 7 days pour montrer aussi les évals récentes
+    qui peuvent encore avoir des notes à saisir. Joint avec class + subject
+    pour l'affichage et compte les notes saisies.
+    """
+    cutoff = date.today() - timedelta(days=7)
+    stmt = (
+        select(Evaluation)
+        .options(
+            selectinload(Evaluation.class_),
+            selectinload(Evaluation.subject),
+            selectinload(Evaluation.grades),
+        )
+        .where(
+            Evaluation.teacher_id == teacher_id,
+            Evaluation.date >= cutoff,
+        )
+        .order_by(Evaluation.date.asc())
+        .limit(limit)
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+
+    items: list[dict] = []
+    for ev in rows:
+        graded = sum(1 for g in (ev.grades or []) if g.value is not None)
+        total = len(ev.grades or [])
+        items.append(
+            {
+                "id": ev.id,
+                "title": ev.title,
+                "type": ev.type.value if hasattr(ev.type, "value") else str(ev.type),
+                "date": ev.date.isoformat(),
+                "class_name": ev.class_.name if ev.class_ else "",
+                "subject_name": ev.subject.name if ev.subject else "",
+                "graded_students": graded,
+                "total_students": total,
+            }
+        )
+    return items
+
+
+async def get_next_course(db: AsyncSession, teacher_id: int) -> dict | None:
+    """Retourne le prochain créneau d'enseignement (today/future).
+
+    Le timetable est hebdomadaire — on cherche aujourd'hui après l'heure
+    courante, sinon le 1er créneau du prochain jour de la semaine. Renvoie
+    None si l'enseignant n'a aucun créneau planifié.
+    """
+    from datetime import datetime
+
+    now = datetime.now()
+    today_name = _DAY_INDEX_TO_NAME.get(now.weekday())
+    current_time = now.time()
+
+    # 1) Slot aujourd'hui après l'heure courante
+    if today_name is not None:
+        stmt_today = (
+            select(TimetableSlot)
+            .options(
+                selectinload(TimetableSlot.subject),
+                selectinload(TimetableSlot.class_),
+                selectinload(TimetableSlot.room),
+            )
+            .where(
+                TimetableSlot.teacher_id == teacher_id,
+                TimetableSlot.day == today_name,
+                TimetableSlot.start_time > current_time,
+            )
+            .order_by(TimetableSlot.start_time.asc())
+            .limit(1)
+        )
+        slot = (await db.execute(stmt_today)).scalar_one_or_none()
+        if slot is not None:
+            return _slot_to_dict(slot)
+
+    # 2) Sinon premier slot du prochain jour de la semaine où le prof enseigne
+    stmt_any = (
+        select(TimetableSlot)
+        .options(
+            selectinload(TimetableSlot.subject),
+            selectinload(TimetableSlot.class_),
+            selectinload(TimetableSlot.room),
+        )
+        .where(TimetableSlot.teacher_id == teacher_id)
+        .order_by(TimetableSlot.day.asc(), TimetableSlot.start_time.asc())
+        .limit(1)
+    )
+    slot = (await db.execute(stmt_any)).scalar_one_or_none()
+    return _slot_to_dict(slot) if slot is not None else None
+
+
+_DAY_INDEX_TO_NAME = {
+    0: "lundi",
+    1: "mardi",
+    2: "mercredi",
+    3: "jeudi",
+    4: "vendredi",
+    5: "samedi",
+    6: "dimanche",
+}
+
+
+def _slot_to_dict(slot: TimetableSlot) -> dict:
+    return {
+        "subject_name": slot.subject.name if slot.subject else "",
+        "class_name": slot.class_.name if slot.class_ else "",
+        "start_time": slot.start_time.strftime("%H:%M"),
+        "end_time": slot.end_time.strftime("%H:%M"),
+        "room": slot.room.name if slot.room else None,
+    }
 
 
 async def get_class_averages(db: AsyncSession, teacher_id: int) -> list[dict]:

--- a/app/repositories/teacher_portal_repository.py
+++ b/app/repositories/teacher_portal_repository.py
@@ -156,6 +156,7 @@ async def list_upcoming_evaluations(
                 "title": ev.title,
                 "type": ev.type.value if hasattr(ev.type, "value") else str(ev.type),
                 "date": ev.date.isoformat(),
+                "class_id": ev.class_id,
                 "class_name": ev.class_.name if ev.class_ else "",
                 "subject_name": ev.subject.name if ev.subject else "",
                 "graded_students": graded,

--- a/app/repositories/teacher_portal_repository.py
+++ b/app/repositories/teacher_portal_repository.py
@@ -121,29 +121,29 @@ async def list_upcoming_evaluations(
     db: AsyncSession,
     teacher_id: int,
     *,
-    limit: int = 5,
+    limit: int | None = 5,
+    cutoff_days: int | None = 7,
 ) -> list[dict]:
-    """Liste les évaluations récentes ou à venir pour le dashboard.
+    """Liste les évaluations du prof avec class + subject + comptage des notes.
 
-    Inclut date >= today - 7 days pour montrer aussi les évals récentes
-    qui peuvent encore avoir des notes à saisir. Joint avec class + subject
-    pour l'affichage et compte les notes saisies.
+    Par défaut : limite à 5 entries et filtre date >= today - 7 days (pour le
+    dashboard hero). Pour la page complète "Mes évaluations", passer
+    `limit=None` et `cutoff_days=None` pour obtenir l'historique complet.
     """
-    cutoff = date.today() - timedelta(days=7)
-    stmt = (
+    base = (
         select(Evaluation)
         .options(
             selectinload(Evaluation.class_),
             selectinload(Evaluation.subject),
             selectinload(Evaluation.grades),
         )
-        .where(
-            Evaluation.teacher_id == teacher_id,
-            Evaluation.date >= cutoff,
-        )
-        .order_by(Evaluation.date.asc())
-        .limit(limit)
+        .where(Evaluation.teacher_id == teacher_id)
+        .order_by(Evaluation.date.desc())
     )
+    if cutoff_days is not None:
+        cutoff = date.today() - timedelta(days=cutoff_days)
+        base = base.where(Evaluation.date >= cutoff).order_by(Evaluation.date.asc())
+    stmt = base.limit(limit) if limit is not None else base
     rows = (await db.execute(stmt)).scalars().all()
 
     items: list[dict] = []

--- a/app/routers/student_portal.py
+++ b/app/routers/student_portal.py
@@ -9,6 +9,7 @@ from app.core.dependencies import TokenData, get_current_user, get_tenant_db
 from app.schemas.attendance import StudentAttendanceResponse
 from app.schemas.student_portal import (
     StudentBulletinsListResponse,
+    StudentDashboardResponse,
     StudentFeesResponse,
     StudentGradesListResponse,
     StudentProfileResponse,
@@ -17,6 +18,15 @@ from app.schemas.student_portal import (
 from app.services import attendance_service, student_portal_service
 
 router = APIRouter(prefix="/student", tags=["student-portal"])
+
+
+@router.get("/dashboard", response_model=StudentDashboardResponse)
+async def get_student_dashboard(
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> StudentDashboardResponse:
+    """Dashboard élève : nom, classe, prochain cours, moyenne, frais, absences."""
+    return await student_portal_service.get_dashboard(db, current_user.user_id)
 
 
 @router.get("/grades", response_model=StudentGradesListResponse)

--- a/app/routers/teacher_portal.py
+++ b/app/routers/teacher_portal.py
@@ -11,6 +11,7 @@ from app.schemas.teacher_portal import (
     TeacherClassesListResponse,
     TeacherDashboardStats,
     TeacherScheduleResponse,
+    TeacherUpcomingEval,
 )
 from app.services import teacher_portal_service
 
@@ -42,6 +43,15 @@ async def get_teacher_dashboard(
 ) -> TeacherDashboardStats:
     """Retourne le dashboard enseignant (KPIs + prochain cours + évaluations à venir)."""
     return await teacher_portal_service.get_dashboard_stats(db, current_user.user_id)
+
+
+@router.get("/evaluations", response_model=list[TeacherUpcomingEval])
+async def list_teacher_evaluations(
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> list[TeacherUpcomingEval]:
+    """Liste toutes les évaluations du prof connecté pour la page Mes évaluations."""
+    return await teacher_portal_service.list_evaluations(db, current_user.user_id)
 
 
 @router.get("/classes/{class_id}/attendance", response_model=ClassAttendanceStats)

--- a/app/routers/teacher_portal.py
+++ b/app/routers/teacher_portal.py
@@ -35,12 +35,12 @@ async def get_teacher_schedule(
     return await teacher_portal_service.get_schedule(db, current_user.user_id)
 
 
-@router.get("/dashboard-stats", response_model=TeacherDashboardStats)
-async def get_teacher_dashboard_stats(
+@router.get("/dashboard", response_model=TeacherDashboardStats)
+async def get_teacher_dashboard(
     current_user: TokenData = Depends(get_current_user),
     db: AsyncSession = Depends(get_tenant_db),
 ) -> TeacherDashboardStats:
-    """Retourne les KPIs du dashboard enseignant."""
+    """Retourne le dashboard enseignant (KPIs + prochain cours + évaluations à venir)."""
     return await teacher_portal_service.get_dashboard_stats(db, current_user.user_id)
 
 

--- a/app/schemas/student_portal.py
+++ b/app/schemas/student_portal.py
@@ -134,3 +134,32 @@ class StudentProfileResponse(BaseModel):
     class_id: int | None
     enrollment_status: str | None
     academic_year_name: str | None
+
+
+# ---------------------------------------------------------------------------
+# Dashboard
+# ---------------------------------------------------------------------------
+
+
+class StudentNextCourse(BaseModel):
+    """Prochain créneau dans la semaine pour l'élève."""
+
+    subject_name: str
+    teacher_name: str
+    start_time: str  # HH:MM
+    end_time: str
+    room: str | None = None
+
+
+class StudentDashboardResponse(BaseModel):
+    """Contrat consommé par /student/dashboard côté FE.
+
+    Voir `klassci-frontend/lib/contracts/student-portal.ts:StudentDashboardSchema`.
+    """
+
+    student_name: str
+    class_name: str
+    next_course: StudentNextCourse | None = None
+    general_average: float | None = None
+    fees_remaining: float
+    total_absences: int

--- a/app/schemas/teacher_portal.py
+++ b/app/schemas/teacher_portal.py
@@ -77,6 +77,7 @@ class TeacherUpcomingEval(BaseModel):
     title: str
     type: str
     date: str  # ISO date YYYY-MM-DD
+    class_id: int
     class_name: str
     subject_name: str
     graded_students: int

--- a/app/schemas/teacher_portal.py
+++ b/app/schemas/teacher_portal.py
@@ -60,8 +60,37 @@ class ClassAverageItem(BaseModel):
     average: float | None
 
 
+class TeacherNextCourse(BaseModel):
+    """Prochain créneau de cours à venir pour l'enseignant."""
+
+    subject_name: str
+    class_name: str
+    start_time: str  # "HH:MM"
+    end_time: str
+    room: str | None = None
+
+
+class TeacherUpcomingEval(BaseModel):
+    """Évaluation à venir (ou récente non saisie) pour le hero du dashboard."""
+
+    id: int
+    title: str
+    type: str
+    date: str  # ISO date YYYY-MM-DD
+    class_name: str
+    subject_name: str
+    graded_students: int
+    total_students: int
+
+
 class TeacherDashboardStats(BaseModel):
+    """Contrat consommé par /teacher/dashboard côté FE.
+
+    Voir `klassci-frontend/lib/contracts/teacher-portal.ts:TeacherDashboardSchema`.
+    """
+
+    teacher_name: str
     total_classes: int
     total_students: int
-    upcoming_evaluations: int
-    class_averages: list[ClassAverageItem]
+    next_course: TeacherNextCourse | None = None
+    upcoming_evaluations: list[TeacherUpcomingEval]

--- a/app/services/student_portal_service.py
+++ b/app/services/student_portal_service.py
@@ -1,11 +1,15 @@
 """Service portail eleve — logique metier read-only."""
 
+from datetime import datetime
 from decimal import Decimal
 
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import NotFoundError
+from app.models.attendance import AttendanceRecord, AttendanceStatus
 from app.models.fee import PaymentStatus
+from app.models.grade import Grade
 from app.models.user import Student
 from app.repositories import student_portal_repository as repo
 from app.schemas.student_portal import (
@@ -14,9 +18,11 @@ from app.schemas.student_portal import (
     EvaluationDetail,
     PaymentResponse,
     StudentBulletinsListResponse,
+    StudentDashboardResponse,
     StudentFeesResponse,
     StudentGradeResponse,
     StudentGradesListResponse,
+    StudentNextCourse,
     StudentProfileResponse,
     StudentTimetableResponse,
     TimetableSlotResponse,
@@ -197,4 +203,102 @@ async def get_profile(db: AsyncSession, user_id: int) -> StudentProfileResponse:
         class_id=class_id,
         enrollment_status=enrollment_status,
         academic_year_name=academic_year_name,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dashboard
+# ---------------------------------------------------------------------------
+
+
+_DAY_INDEX_TO_NAME = {
+    0: "lundi",
+    1: "mardi",
+    2: "mercredi",
+    3: "jeudi",
+    4: "vendredi",
+    5: "samedi",
+    6: "dimanche",
+}
+
+
+async def _next_course_for_class(db: AsyncSession, class_id: int) -> StudentNextCourse | None:
+    """Retourne le prochain créneau dans la semaine pour une classe."""
+    slots = await repo.get_timetable_slots_for_class(db, class_id)
+    if not slots:
+        return None
+
+    now = datetime.now()
+    today = _DAY_INDEX_TO_NAME.get(now.weekday())
+    current_time = now.time()
+
+    candidates = [s for s in slots if s.day == today and s.start_time > current_time]
+    candidates.sort(key=lambda s: s.start_time)
+
+    chosen = candidates[0] if candidates else slots[0]  # fallback : 1er slot semaine
+    teacher_name = ""
+    if chosen.teacher:
+        teacher_name = f"{chosen.teacher.first_name} {chosen.teacher.last_name}".strip()
+
+    return StudentNextCourse(
+        subject_name=chosen.subject.name if chosen.subject else "",
+        teacher_name=teacher_name,
+        start_time=chosen.start_time.strftime("%H:%M"),
+        end_time=chosen.end_time.strftime("%H:%M"),
+        room=chosen.room.name if chosen.room else None,
+    )
+
+
+async def get_dashboard(db: AsyncSession, user_id: int) -> StudentDashboardResponse:
+    """Compose le dashboard de l'élève à partir des sources existantes.
+
+    Aligné sur le contrat FE `StudentDashboardSchema`
+    (lib/contracts/student-portal.ts) : nom, classe, prochain cours,
+    moyenne générale du trimestre courant, frais restants, total absences.
+    """
+    student = await _get_student_for_user(db, user_id)
+    enrollment = await repo.get_active_enrollment_for_student(db, student.id)
+
+    class_name = enrollment.class_.name if enrollment else "—"
+    class_id = enrollment.class_id if enrollment else None
+
+    # Prochain cours
+    next_course = await _next_course_for_class(db, class_id) if class_id else None
+
+    # Moyenne générale (toutes notes saisies, tous trimestres confondus pour
+    # garder l'usage simple à l'écran d'accueil).
+    avg_stmt = select(func.avg(Grade.value)).where(
+        Grade.student_id == student.id, Grade.value.is_not(None)
+    )
+    avg_raw = (await db.execute(avg_stmt)).scalar()
+    general_average = round(float(avg_raw), 2) if avg_raw is not None else None
+
+    # Frais restants (somme balance des fees non payés)
+    fees_remaining = Decimal("0")
+    if enrollment:
+        fees = await repo.get_enrollment_fees_for_enrollment(db, enrollment.id)
+        for fee in fees:
+            paid = sum(p.amount for p in fee.payments if p.status == PaymentStatus.COMPLETED)
+            balance = fee.amount - paid
+            if balance > 0:
+                fees_remaining += balance
+
+    # Total absences
+    abs_stmt = (
+        select(func.count())
+        .select_from(AttendanceRecord)
+        .where(
+            AttendanceRecord.student_id == student.id,
+            AttendanceRecord.status == AttendanceStatus.ABSENT,
+        )
+    )
+    total_absences = (await db.execute(abs_stmt)).scalar() or 0
+
+    return StudentDashboardResponse(
+        student_name=f"{student.first_name} {student.last_name}".strip(),
+        class_name=class_name,
+        next_course=next_course,
+        general_average=general_average,
+        fees_remaining=float(fees_remaining),
+        total_absences=int(total_absences),
     )

--- a/app/services/teacher_portal_service.py
+++ b/app/services/teacher_portal_service.py
@@ -11,12 +11,13 @@ from app.models.user import TeacherProfile
 from app.repositories import teacher_portal_repository as repo
 from app.schemas.attendance import ClassAttendanceStats
 from app.schemas.teacher_portal import (
-    ClassAverageItem,
     TeacherClassesListResponse,
     TeacherClassResponse,
     TeacherDashboardStats,
+    TeacherNextCourse,
     TeacherScheduleResponse,
     TeacherScheduleSlot,
+    TeacherUpcomingEval,
 )
 from app.services import attendance_service
 
@@ -59,21 +60,24 @@ async def get_schedule(db: AsyncSession, user_id: int) -> TeacherScheduleRespons
 
 
 async def get_dashboard_stats(db: AsyncSession, user_id: int) -> TeacherDashboardStats:
-    """Retourne les KPIs du dashboard enseignant."""
+    """Retourne le dashboard de l'enseignant connecté.
+
+    Aligné sur le contrat FE `TeacherDashboardSchema` (lib/contracts/teacher-portal.ts) :
+    nom, totaux, prochain cours, évaluations à venir/récentes.
+    """
     teacher = await _get_teacher_for_user(db, user_id)
 
     total_classes = await repo.count_distinct_classes(db, teacher.id)
     total_students = await repo.count_total_students(db, teacher.id)
-    upcoming_evaluations = await repo.count_upcoming_evaluations(db, teacher.id)
-    averages_raw = await repo.get_class_averages(db, teacher.id)
-
-    class_averages = [ClassAverageItem(**a) for a in averages_raw]
+    next_course_raw = await repo.get_next_course(db, teacher.id)
+    upcoming_raw = await repo.list_upcoming_evaluations(db, teacher.id, limit=5)
 
     return TeacherDashboardStats(
+        teacher_name=f"{teacher.first_name} {teacher.last_name}".strip(),
         total_classes=total_classes,
         total_students=total_students,
-        upcoming_evaluations=upcoming_evaluations,
-        class_averages=class_averages,
+        next_course=TeacherNextCourse(**next_course_raw) if next_course_raw else None,
+        upcoming_evaluations=[TeacherUpcomingEval(**e) for e in upcoming_raw],
     )
 
 

--- a/app/services/teacher_portal_service.py
+++ b/app/services/teacher_portal_service.py
@@ -81,6 +81,13 @@ async def get_dashboard_stats(db: AsyncSession, user_id: int) -> TeacherDashboar
     )
 
 
+async def list_evaluations(db: AsyncSession, user_id: int) -> list[TeacherUpcomingEval]:
+    """Liste toutes les évaluations du prof, sans cutoff ni limite."""
+    teacher = await _get_teacher_for_user(db, user_id)
+    rows = await repo.list_upcoming_evaluations(db, teacher.id, limit=None, cutoff_days=None)
+    return [TeacherUpcomingEval(**e) for e in rows]
+
+
 async def get_class_attendance(
     db: AsyncSession,
     user_id: int,

--- a/tests/routers/test_teacher_portal.py
+++ b/tests/routers/test_teacher_portal.py
@@ -8,12 +8,13 @@ from app.core.dependencies import TokenData, get_current_user, get_tenant_db
 from app.core.redis import get_redis
 from app.main import app
 from app.schemas.teacher_portal import (
-    ClassAverageItem,
     TeacherClassesListResponse,
     TeacherClassResponse,
     TeacherDashboardStats,
+    TeacherNextCourse,
     TeacherScheduleResponse,
     TeacherScheduleSlot,
+    TeacherUpcomingEval,
 )
 
 # ---------------------------------------------------------------------------
@@ -50,18 +51,32 @@ SAMPLE_SCHEDULE = TeacherScheduleResponse(
     total=1,
 )
 
-SAMPLE_AVERAGE = ClassAverageItem(
+SAMPLE_NEXT_COURSE = TeacherNextCourse(
+    subject_name="Mathematiques",
+    class_name="Terminale C",
+    start_time="08:00",
+    end_time="10:00",
+    room="Salle 12",
+)
+
+SAMPLE_UPCOMING_EVAL = TeacherUpcomingEval(
+    id=42,
+    title="Devoir n1",
+    type="controle",
+    date="2026-04-30",
     class_id=1,
     class_name="Terminale C",
     subject_name="Mathematiques",
-    average=14.5,
+    graded_students=0,
+    total_students=30,
 )
 
 SAMPLE_STATS = TeacherDashboardStats(
+    teacher_name="Aminata Coulibaly",
     total_classes=3,
     total_students=105,
-    upcoming_evaluations=2,
-    class_averages=[SAMPLE_AVERAGE],
+    next_course=SAMPLE_NEXT_COURSE,
+    upcoming_evaluations=[SAMPLE_UPCOMING_EVAL],
 )
 
 
@@ -176,12 +191,12 @@ def test_get_teacher_schedule_not_a_teacher() -> None:
 
 
 # ---------------------------------------------------------------------------
-# GET /teacher/dashboard-stats
+# GET /teacher/dashboard
 # ---------------------------------------------------------------------------
 
 
 def test_get_teacher_dashboard_stats_success() -> None:
-    """GET /teacher/dashboard-stats → 200 + KPIs."""
+    """GET /teacher/dashboard → 200 + KPIs."""
     _override_deps()
     try:
         with patch(
@@ -190,21 +205,22 @@ def test_get_teacher_dashboard_stats_success() -> None:
             return_value=SAMPLE_STATS,
         ):
             with TestClient(app) as client:
-                resp = client.get("/teacher/dashboard-stats")
+                resp = client.get("/teacher/dashboard")
     finally:
         _clear_deps()
 
     assert resp.status_code == 200
     body = resp.json()
+    assert body["teacher_name"] == "Aminata Coulibaly"
     assert body["total_classes"] == 3
     assert body["total_students"] == 105
-    assert body["upcoming_evaluations"] == 2
-    assert len(body["class_averages"]) == 1
-    assert body["class_averages"][0]["average"] == 14.5
+    assert body["next_course"]["subject_name"] == "Mathematiques"
+    assert len(body["upcoming_evaluations"]) == 1
+    assert body["upcoming_evaluations"][0]["id"] == 42
 
 
 def test_get_teacher_dashboard_stats_not_a_teacher() -> None:
-    """GET /teacher/dashboard-stats sans profil enseignant → 404."""
+    """GET /teacher/dashboard sans profil enseignant → 404."""
     from app.core.exceptions import NotFoundError
 
     _override_deps()
@@ -215,7 +231,7 @@ def test_get_teacher_dashboard_stats_not_a_teacher() -> None:
             side_effect=NotFoundError("TeacherProfile", 10),
         ):
             with TestClient(app) as client:
-                resp = client.get("/teacher/dashboard-stats")
+                resp = client.get("/teacher/dashboard")
     finally:
         _clear_deps()
 


### PR DESCRIPTION
Three fixes for teacher/student portals that were silently 404 in prod (visual-check 2026-04-27).

- /teacher/dashboard : aligns BE response with FE TeacherDashboardSchema (teacher_name, total_classes, total_students, next_course, upcoming_evaluations as a list). Path moves from /teacher/dashboard-stats.
- /student/dashboard (NEW): student_name, class_name, next_course, general_average, fees_remaining, total_absences. FE has been waiting on this endpoint.
- /teacher/evaluations (NEW): exhaustive list of teacher's evaluations, feeds the FE /teacher/grades index page.
- TeacherUpcomingEval gains class_id for direct routing without extra fetch.

Pairs with klassci-college-frontend.