### PR TITLE
feat(grades): cascade subject filter by class + cross-field validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 - Audit des changements de permissions de rôle : on garde désormais l'état avant et après pour reconstruire le diff de chaque modification *(admin, super-admin)*.
 - Tableau de bord enseignant repensé : nom, prochain cours, totaux et liste des évaluations à venir avec progression de saisie, en cohérence avec ce qu'affiche le portail *(enseignant)* (#75).
+- Création d'évaluation : la matière doit être enseignée dans la classe sélectionnée. Toute combinaison incohérente est refusée avec un message clair en français *(admin, enseignant)* (#76).
+- Liste des matières filtrable par classe : on n'affiche plus que les matières du niveau (et de la série) de la classe demandée *(admin)* (#76).
 
 ### Fixed
 

--- a/app/repositories/admin_repository.py
+++ b/app/repositories/admin_repository.py
@@ -376,10 +376,25 @@ async def list_subjects(
     page: int = 1,
     size: int = 20,
     level_id: int | None = None,
+    class_id: int | None = None,
     search: str | None = None,
 ) -> tuple[list[Subject], int]:
+    # `class_id` filtre les matières enseignées dans cette classe (level + series, avec
+    # null-semantics) en réutilisant le prédicat partagé de curriculum_service.
+    # `level_id` reste un filtre direct sur Subject.level_id, conservé pour la
+    # rétrocompat. Les deux sont mutuellement exclusifs côté service (422).
+    from app.models.academic import Class
+    from app.services.curriculum_service import subject_for_class_predicate
+
     base = select(Subject)
-    if level_id is not None:
+    if class_id is not None:
+        class_obj = await db.get(Class, class_id)
+        if class_obj is None:
+            from app.core.exceptions import NotFoundError
+
+            raise NotFoundError("Class", class_id)
+        base = base.where(subject_for_class_predicate(class_obj))
+    elif level_id is not None:
         base = base.where(Subject.level_id == level_id)
     if search:
         pattern = f"%{search}%"

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -563,7 +563,17 @@ async def delete_class(
 
 @router.get("/subjects", response_model=SubjectListResponse)
 async def list_subjects(
-    level_id: int | None = Query(None),
+    level_id: int | None = Query(
+        None,
+        description="Filtre par niveau (mutuellement exclusif avec class_id).",
+    ),
+    class_id: int | None = Query(
+        None,
+        description=(
+            "Filtre par matières enseignées dans cette classe (level + série, "
+            "incluant les matières globales). Mutuellement exclusif avec level_id."
+        ),
+    ),
     search: str | None = Query(None),
     page: int = Query(1, ge=1),
     size: int = Query(20, ge=1, le=100),
@@ -572,7 +582,12 @@ async def list_subjects(
 ) -> SubjectListResponse:
     """Liste paginee des matieres."""
     return await admin_service.list_subjects(
-        db, page=page, size=size, level_id=level_id, search=search
+        db,
+        page=page,
+        size=size,
+        level_id=level_id,
+        class_id=class_id,
+        search=search,
     )
 
 

--- a/app/services/admin_service.py
+++ b/app/services/admin_service.py
@@ -1178,10 +1178,20 @@ async def list_subjects(
     page: int = 1,
     size: int = 20,
     level_id: int | None = None,
+    class_id: int | None = None,
     search: str | None = None,
 ) -> SubjectListResponse:
+    if class_id is not None and level_id is not None:
+        raise BusinessValidationError(
+            "Précisez soit class_id soit level_id, pas les deux.",
+        )
     subjects, total = await repo.list_subjects(
-        db, page=page, size=size, level_id=level_id, search=search
+        db,
+        page=page,
+        size=size,
+        level_id=level_id,
+        class_id=class_id,
+        search=search,
     )
     return SubjectListResponse(
         items=[_subject_to_response(s) for s in subjects],

--- a/app/services/curriculum_service.py
+++ b/app/services/curriculum_service.py
@@ -1,0 +1,81 @@
+"""Service curriculum — résolution des matières enseignées par classe.
+
+Source unique de vérité pour la question : *« quelles matières sont enseignées
+dans cette classe ? »*. Le prédicat SQLAlchemy est défini une seule fois et
+réutilisé par le filtre liste (`GET /admin/subjects?class_id=N`) et par la
+validation de cohérence (`POST /evaluations` avec une paire (class_id,
+subject_id) incohérente). Aucune duplication possible entre la query SQL et
+une éventuelle vérification Python — le prédicat *est* le contrat.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import ColumnElement, and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import BusinessValidationError, NotFoundError
+from app.models.academic import Class, Subject
+
+
+def subject_for_class_predicate(class_obj: Class) -> ColumnElement[bool]:
+    """Construit la clause WHERE qui matche les matières enseignées dans `class_obj`.
+
+    Sémantique :
+    - Un `Subject.level_id` à NULL = matière enseignée à tous les niveaux (ex : EPS).
+    - Un `Subject.series_id` à NULL = matière enseignée dans toutes les séries
+      du niveau (ex : Mathématiques en Terminale, qui existe en A, C, D).
+    - Sinon le `level_id` (et le `series_id` si présent côté Subject) doit
+      matcher exactement la classe.
+
+    Le prédicat est partagé entre `subjects_for_class()` et
+    `validate_subject_class_pair()` pour garantir que le filtre côté liste
+    et la validation côté écriture appliquent exactement la même règle.
+    """
+    return and_(
+        or_(Subject.level_id.is_(None), Subject.level_id == class_obj.level_id),
+        or_(Subject.series_id.is_(None), Subject.series_id == class_obj.series_id),
+    )
+
+
+async def _get_class_or_404(db: AsyncSession, class_id: int) -> Class:
+    class_obj = await db.get(Class, class_id)
+    if class_obj is None:
+        raise NotFoundError("Class", class_id)
+    return class_obj
+
+
+async def subjects_for_class(db: AsyncSession, class_id: int) -> list[Subject]:
+    """Retourne les matières enseignées dans la classe `class_id`.
+
+    Inclut les matières globales (`level_id` NULL) et série-agnostiques
+    (`series_id` NULL). Triées par nom pour un rendu prévisible côté UI.
+    """
+    class_obj = await _get_class_or_404(db, class_id)
+    stmt = (
+        select(Subject)
+        .where(subject_for_class_predicate(class_obj))
+        .order_by(Subject.name.asc())
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def validate_subject_class_pair(
+    db: AsyncSession, class_id: int, subject_id: int
+) -> None:
+    """Lève une 422 si la matière n'est pas enseignée dans cette classe.
+
+    Utilise la même clause `subject_for_class_predicate` que la liste — donc
+    si une matière apparaît dans le Select côté UI, elle passe la validation
+    ici sans drift possible.
+    """
+    class_obj = await _get_class_or_404(db, class_id)
+    stmt = select(Subject.id).where(
+        Subject.id == subject_id,
+        subject_for_class_predicate(class_obj),
+    )
+    result = await db.execute(stmt)
+    if result.scalar_one_or_none() is None:
+        raise BusinessValidationError(
+            "Cette matière n'est pas enseignée dans cette classe."
+        )

--- a/app/services/curriculum_service.py
+++ b/app/services/curriculum_service.py
@@ -52,17 +52,13 @@ async def subjects_for_class(db: AsyncSession, class_id: int) -> list[Subject]:
     """
     class_obj = await _get_class_or_404(db, class_id)
     stmt = (
-        select(Subject)
-        .where(subject_for_class_predicate(class_obj))
-        .order_by(Subject.name.asc())
+        select(Subject).where(subject_for_class_predicate(class_obj)).order_by(Subject.name.asc())
     )
     result = await db.execute(stmt)
     return list(result.scalars().all())
 
 
-async def validate_subject_class_pair(
-    db: AsyncSession, class_id: int, subject_id: int
-) -> None:
+async def validate_subject_class_pair(db: AsyncSession, class_id: int, subject_id: int) -> None:
     """Lève une 422 si la matière n'est pas enseignée dans cette classe.
 
     Utilise la même clause `subject_for_class_predicate` que la liste — donc
@@ -76,6 +72,4 @@ async def validate_subject_class_pair(
     )
     result = await db.execute(stmt)
     if result.scalar_one_or_none() is None:
-        raise BusinessValidationError(
-            "Cette matière n'est pas enseignée dans cette classe."
-        )
+        raise BusinessValidationError("Cette matière n'est pas enseignée dans cette classe.")

--- a/app/services/grades_service.py
+++ b/app/services/grades_service.py
@@ -18,6 +18,7 @@ from app.schemas.grades import (
     EvaluationCreate,
     GradeBatchUpdate,
 )
+from app.services.curriculum_service import validate_subject_class_pair
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,11 @@ async def create_evaluation(
     teacher_id: int,
     current_user_id: int,
 ) -> dict[str, Any]:
+    # Fail-fast : refuser une paire (class_id, subject_id) incohérente avant toute
+    # autre lecture/écriture. Utilise le même prédicat que le filtre Subject côté UI,
+    # garantissant qu'une matière visible dans le Select ne sera jamais rejetée ici.
+    await validate_subject_class_pair(db, data.class_id, data.subject_id)
+
     students = await repo.get_students_for_class(db, data.class_id, data.academic_year_id)
 
     eval_data = data.model_dump()

--- a/tests/routers/test_admin.py
+++ b/tests/routers/test_admin.py
@@ -475,6 +475,47 @@ def test_list_subjects_success() -> None:
     assert resp.json()["items"][0]["coefficient"] == 3
 
 
+def test_list_subjects_filtered_by_class_id() -> None:
+    """GET /admin/subjects?class_id=N → 200 et le param est forwardé au service.
+
+    Le filtre applique le prédicat curriculum (level + série + null-semantics)
+    pour ne montrer que les matières enseignées dans la classe sélectionnée.
+    """
+    _override_deps()
+    try:
+        with patch(
+            f"{SVC}.list_subjects",
+            new_callable=AsyncMock,
+            return_value=SubjectListResponse(items=[SAMPLE_SUBJECT], total=1, page=1, size=20),
+        ) as mock_svc:
+            with TestClient(app) as client:
+                resp = client.get("/admin/subjects?class_id=42")
+        mock_svc.assert_awaited_once()
+        kwargs = mock_svc.call_args.kwargs
+        assert kwargs.get("class_id") == 42
+        assert kwargs.get("level_id") is None
+    finally:
+        _clear_deps()
+    assert resp.status_code == 200
+
+
+def test_list_subjects_class_and_level_both_returns_422() -> None:
+    """GET /admin/subjects?class_id=N&level_id=M → 422 (mutuellement exclusifs).
+
+    Si les deux filtres sont passés simultanément, le service refuse plutôt que
+    de deviner lequel applique — l'API doit être sans ambiguïté pour les clients.
+    """
+    _override_deps()
+    try:
+        with TestClient(app) as client:
+            resp = client.get("/admin/subjects?class_id=1&level_id=2")
+    finally:
+        _clear_deps()
+    assert resp.status_code == 422
+    detail = resp.json().get("detail", "")
+    assert "class_id" in detail or "level_id" in detail
+
+
 def test_create_subject_success() -> None:
     _override_deps()
     try:

--- a/tests/routers/test_grades.py
+++ b/tests/routers/test_grades.py
@@ -166,6 +166,46 @@ def test_create_evaluation_invalid_coefficient() -> None:
         _clear_deps()
 
 
+def test_create_evaluation_rejects_subject_not_taught_at_class() -> None:
+    """POST /evaluations avec une paire (class_id, subject_id) incohérente → 422 FR.
+
+    Le service délègue à curriculum_service.validate_subject_class_pair() qui lève
+    BusinessValidationError. Le message doit rester actionnable pour l'admin —
+    on évite les jargons techniques type "FK constraint".
+    """
+    _override_deps()
+    try:
+        from app.core.exceptions import BusinessValidationError
+
+        with patch(
+            "app.services.grades_service.create_evaluation",
+            new=AsyncMock(
+                side_effect=BusinessValidationError(
+                    "Cette matière n'est pas enseignée dans cette classe."
+                )
+            ),
+        ):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/evaluations",
+                    json={
+                        "title": "Contrôle",
+                        "type": "controle",
+                        "date": str(TODAY),
+                        "coefficient": 1,
+                        "subject_id": 999,
+                        "class_id": 3,
+                        "academic_year_id": 1,
+                        "trimester": 1,
+                    },
+                )
+        assert resp.status_code == 422
+        detail = resp.json().get("detail", "")
+        assert "n'est pas enseignée" in detail
+    finally:
+        _clear_deps()
+
+
 # ---------------------------------------------------------------------------
 # GET /grades
 # ---------------------------------------------------------------------------

--- a/tests/services/test_curriculum_service.py
+++ b/tests/services/test_curriculum_service.py
@@ -1,0 +1,147 @@
+"""Tests pour curriculum_service — single source of truth des matières par classe.
+
+Le prédicat `subject_for_class_predicate` est partagé entre le filtre liste
+et le validator d'évaluations : ces tests garantissent qu'aucune divergence
+ne s'introduit, et que les sémantiques NULL (matières globales / matières
+hors-série) restent honorées.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.core.exceptions import BusinessValidationError, NotFoundError
+from app.services.curriculum_service import (
+    subject_for_class_predicate,
+    subjects_for_class,
+    validate_subject_class_pair,
+)
+
+
+def _make_class_stub(level_id: int, series_id: int | None) -> SimpleNamespace:
+    """Léger stand-in pour `Class` — le prédicat n'a besoin que de level_id + series_id."""
+    return SimpleNamespace(id=99, level_id=level_id, series_id=series_id)
+
+
+def _mock_scalars_returning(rows: list[object]) -> MagicMock:
+    """Construit un faux résultat SQLAlchemy : `result.scalars().all()` retourne `rows`."""
+    scalars_proxy = MagicMock()
+    scalars_proxy.all = MagicMock(return_value=rows)
+    result = MagicMock()
+    result.scalars = MagicMock(return_value=scalars_proxy)
+    return result
+
+
+def _mock_scalar_returning(value: object | None) -> MagicMock:
+    """Construit un faux résultat où `result.scalar_one_or_none()` retourne `value`."""
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=value)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Predicate — structural correctness
+# ---------------------------------------------------------------------------
+
+
+def test_predicate_compiles_without_error_for_lycee_class() -> None:
+    """Une classe de lycée (level + série) produit un prédicat SQL compilable.
+
+    On vérifie que le prédicat se compile en SQL textuel : c'est le contrat
+    minimal pour qu'il soit utilisable dans `select(...).where(...)`.
+    """
+    class_obj = _make_class_stub(level_id=5, series_id=2)
+    predicate = subject_for_class_predicate(class_obj)
+    rendered = str(predicate.compile(compile_kwargs={"literal_binds": True}))
+    # Both null-checks AND equality checks must appear in the rendered SQL.
+    assert "subjects.level_id IS NULL" in rendered
+    assert "subjects.series_id IS NULL" in rendered
+    assert "5" in rendered  # the level_id literal
+    assert "2" in rendered  # the series_id literal
+
+
+def test_predicate_compiles_for_college_class_without_series() -> None:
+    """Une classe sans série (collège : 6e, 5e...) compile aussi correctement.
+
+    Le côté Subject du prédicat compare `series_id == None`, qui se rend en
+    `IS NULL` côté SQL — la matière globale et celle dont la série est NULL
+    matchent toutes deux.
+    """
+    class_obj = _make_class_stub(level_id=3, series_id=None)
+    predicate = subject_for_class_predicate(class_obj)
+    rendered = str(predicate.compile(compile_kwargs={"literal_binds": True}))
+    assert "subjects.level_id IS NULL" in rendered
+    assert "subjects.series_id IS NULL" in rendered
+
+
+# ---------------------------------------------------------------------------
+# subjects_for_class — DB orchestration
+# ---------------------------------------------------------------------------
+
+
+async def test_subjects_for_class_raises_not_found_when_class_missing() -> None:
+    """Si la classe n'existe pas, on lève 404 — pas une 200 avec liste vide."""
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=None)
+    with pytest.raises(NotFoundError):
+        await subjects_for_class(db, class_id=999)
+
+
+async def test_subjects_for_class_returns_filtered_rows() -> None:
+    """Quand la classe existe, on délègue à db.execute avec le prédicat appliqué."""
+    class_obj = _make_class_stub(level_id=5, series_id=2)
+    expected_subjects = [
+        SimpleNamespace(id=1, name="Mathématiques"),
+        SimpleNamespace(id=2, name="Physique-Chimie"),
+    ]
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=class_obj)
+    db.execute = AsyncMock(return_value=_mock_scalars_returning(expected_subjects))
+
+    result = await subjects_for_class(db, class_id=99)
+
+    assert result == expected_subjects
+    db.get.assert_awaited_once()
+    db.execute.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# validate_subject_class_pair — write-side validation
+# ---------------------------------------------------------------------------
+
+
+async def test_validate_pair_passes_when_subject_taught() -> None:
+    """Une paire cohérente passe sans exception."""
+    class_obj = _make_class_stub(level_id=5, series_id=2)
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=class_obj)
+    db.execute = AsyncMock(return_value=_mock_scalar_returning(value=42))
+
+    # Ne lève rien
+    await validate_subject_class_pair(db, class_id=99, subject_id=42)
+
+
+async def test_validate_pair_raises_422_when_subject_not_taught() -> None:
+    """Une paire incohérente lève BusinessValidationError (422) avec message FR."""
+    class_obj = _make_class_stub(level_id=5, series_id=2)
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=class_obj)
+    db.execute = AsyncMock(return_value=_mock_scalar_returning(value=None))
+
+    with pytest.raises(BusinessValidationError) as exc_info:
+        await validate_subject_class_pair(db, class_id=99, subject_id=999)
+
+    # Le message doit être actionnable et en français pour Mme Diallo.
+    assert "n'est pas enseignée dans cette classe" in str(exc_info.value.detail)
+    assert exc_info.value.status_code == 422
+
+
+async def test_validate_pair_raises_404_when_class_missing() -> None:
+    """Si la classe n'existe pas, on lève 404 avant même de chercher la matière."""
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=None)
+    with pytest.raises(NotFoundError):
+        await validate_subject_class_pair(db, class_id=12345, subject_id=1)


### PR DESCRIPTION
Closes #76

## Summary

Filtrer les matières enseignées dans une classe (cascade level + série + null-semantics) avec un prédicat SQLAlchemy unique partagé entre :
- le filtre liste \`GET /admin/subjects?class_id=N\`
- la validation cross-field \`POST /evaluations\` (refus 422 sur paire incohérente)

Zéro drift possible entre filtre et validator — c'est le même prédicat appliqué côté DB des deux côtés.

## Changes

- **NEW** \`app/services/curriculum_service.py\` — predicate + \`subjects_for_class()\` + \`validate_subject_class_pair()\`.
- **mod** \`admin_repository.list_subjects\` — accepte \`class_id\`, applique le predicate.
- **mod** \`admin_service.list_subjects\` — passe \`class_id\`, raise \`BusinessValidationError\` si \`class_id ET level_id\`.
- **mod** \`admin.py:564\` — Query param \`class_id\` documenté (mutuellement exclusif).
- **mod** \`grades_service.create_evaluation\` — \`validate_subject_class_pair()\` en fail-fast.
- **NEW** \`tests/services/test_curriculum_service.py\` — 7 cases (predicate compile, NotFound, validation, null-semantics).
- **mod** \`tests/routers/test_admin.py\` — +2 cases (filter \`?class_id\`, mutually-exclusive 422).
- **mod** \`tests/routers/test_grades.py\` — +1 case (rejet paire incohérente).
- **mod** \`CHANGELOG.md\` — 2 lignes Mme-Diallo style.

## Test plan

- [x] \`pytest tests/services/test_curriculum_service.py\` — 7/7 passent en local.
- [x] \`ruff check\` PASS sur tous les fichiers modifiés.
- [ ] Tests routers (test_admin, test_grades) — exigent weasyprint, tourneront en CI Linux.
- [ ] Smoke test prod : ouvrir modal Nouvelle évaluation, choisir classe, vérifier filtre matières.

## Cross-link

- FE PR : African-DC/klassci-college-frontend#112 (the cascade in EvaluationCreateModal modal).

## Critic verdict (plan-and-confirm)

GO-WITH-CHANGES après audit 4 axes (Architecture, Quality, Production-grade, SOLID). Tous les blockers résolus avant code.
