### PR TITLE
fix(grades): use mode=json for audit payload (fixes 500 on eval create)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Création d'évaluation qui échouait silencieusement avec « Erreur serveur » : l'audit serveur sait désormais sérialiser correctement la date *(admin, enseignant)* (#76).
 - Permissions de gestion des rôles, des salles et des séries désormais seedées par défaut. Auparavant, les pages correspondantes côté portail étaient inaccessibles en silence (#73).
 - Démontage propre de la migration ajoutant la traçabilité de saisie des notes (l'ordre de suppression de l'index et de la contrainte cassait la rétrogradation sur MySQL).
 - Tableau de bord enseignant et tableau de bord élève qui renvoyaient « Connexion impossible » en boucle : les chemins et formats de réponse sont désormais alignés avec ce que les portails attendent *(enseignant, élève)* (#75).

--- a/app/services/grades_service.py
+++ b/app/services/grades_service.py
@@ -84,11 +84,17 @@ async def create_evaluation(
 
     students = await repo.get_students_for_class(db, data.class_id, data.academic_year_id)
 
+    # Repo : types Python (date.date, Enum) attendus par SQLAlchemy.
     eval_data = data.model_dump()
     eval_data["teacher_id"] = teacher_id
 
     evaluation = await repo.create_evaluation(db, data=eval_data, students=students)
 
+    # Audit : la colonne JSON ne sait pas sérialiser un `date` Python ; on
+    # utilise `mode="json"` comme tous les autres services (admin, fees,
+    # attendance) — sinon `audit_log` lève TypeError et le POST échoue en 500.
+    audit_payload = data.model_dump(mode="json")
+    audit_payload["teacher_id"] = teacher_id
     await audit_log(
         db,
         user_id=current_user_id,
@@ -96,7 +102,7 @@ async def create_evaluation(
         entity_id=evaluation.id,
         action=AuditAction.CREATE,
         old_values=None,
-        new_values=eval_data,
+        new_values=audit_payload,
     )
 
     await db.commit()


### PR DESCRIPTION
## Bug

POST /evaluations renvoyait systématiquement \`500 Internal Server Error\` (body texte brut, pas JSON) — ce qui se traduisait par \"Erreur serveur\" dans la modal Nouvelle évaluation côté admin.

Découvert pendant le test prod du cascade Subject Select (#76).

## Root cause

\`audit_log\` écrit dans une colonne JSON. \`data.model_dump()\` (Pydantic v2) retourne des objets Python natifs : \`datetime.date\`, \`Enum\`. \`json.dumps\` ne sait pas sérialiser \`datetime.date\` → \`TypeError\`.

\`audit_log\` capture explicitement \`TypeError\` puis le **re-raise** (par design — état session indéfini). L'exception remonte au router puis fall-through au handler par défaut Starlette → \"Internal Server Error\" plain text (pas JSON, donc le FE affiche son fallback générique).

## Why this is pre-existing

Les autres services (\`admin_service\`, \`fee_service\`, \`attendance_service\`, \`enrollment_service\`) suivent déjà le pattern correct :
- \`model_dump()\` pour le repo (SQLAlchemy ORM attend les types Python)
- \`model_dump(mode=\"json\")\` pour l'audit (colonne JSON attend des chaînes ISO)

Seul \`grades_service.create_evaluation\` ne le faisait pas. Bug latent depuis le merge initial de la feature \`feat(grades): notes, évaluations et génération bulletins PDF via Celery\`.

## Fix

\`grades_service.create_evaluation\` utilise désormais \`mode=\"json\"\` pour le payload d'audit, en gardant le dump Python pour le repo (la signature \`Evaluation(**data)\` côté SQLAlchemy reste inchangée).

## Test plan

- [x] \`ruff check\` PASS sur le fichier modifié.
- [ ] CI verte (Lint, Tests, etc.) avant merge.
- [ ] Post-deploy : POST /evaluations avec une paire valide retourne 201 + objet créé.
- [ ] Modal Nouvelle évaluation côté admin crée une éval sans \"Erreur serveur\".

## Refs

- BE #76 (cascade — la feature qui a permis de découvrir le bug)
- Correction d'un bug latent, pas de régression du cascade.