### PR TITLE
release: fix eval create 500 (audit JSON mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Création d'évaluation qui échouait silencieusement avec « Erreur serveur » : l'audit serveur sait désormais sérialiser correctement la date *(admin, enseignant)* (#76).
 - Permissions de gestion des rôles, des salles et des séries désormais seedées par défaut. Auparavant, les pages correspondantes côté portail étaient inaccessibles en silence (#73).
 - Démontage propre de la migration ajoutant la traçabilité de saisie des notes (l'ordre de suppression de l'index et de la contrainte cassait la rétrogradation sur MySQL).
 - Tableau de bord enseignant et tableau de bord élève qui renvoyaient « Connexion impossible » en boucle : les chemins et formats de réponse sont désormais alignés avec ce que les portails attendent *(enseignant, élève)* (#75).

--- a/app/services/grades_service.py
+++ b/app/services/grades_service.py
@@ -84,11 +84,17 @@ async def create_evaluation(
 
     students = await repo.get_students_for_class(db, data.class_id, data.academic_year_id)
 
+    # Repo : types Python (date.date, Enum) attendus par SQLAlchemy.
     eval_data = data.model_dump()
     eval_data["teacher_id"] = teacher_id
 
     evaluation = await repo.create_evaluation(db, data=eval_data, students=students)
 
+    # Audit : la colonne JSON ne sait pas sérialiser un `date` Python ; on
+    # utilise `mode="json"` comme tous les autres services (admin, fees,
+    # attendance) — sinon `audit_log` lève TypeError et le POST échoue en 500.
+    audit_payload = data.model_dump(mode="json")
+    audit_payload["teacher_id"] = teacher_id
     await audit_log(
         db,
         user_id=current_user_id,
@@ -96,7 +102,7 @@ async def create_evaluation(
         entity_id=evaluation.id,
         action=AuditAction.CREATE,
         old_values=None,
-        new_values=eval_data,
+        new_values=audit_payload,
     )
 
     await db.commit()


### PR DESCRIPTION
Hotfix release : déploie le fix audit JSON mode pour débloquer la création d'évaluation côté prod (cassée silencieusement depuis le merge initial de feat(grades), surfaced par le test du cascade #76).

## Inclus

- fix(grades): use mode=json for audit payload (#80)

## Deploy

Le merge déclenche \`deploy-be.yml\` → wheels → ship EC2 → restart.

## Test plan post-deploy

- [ ] Modal Nouvelle évaluation côté admin → création d'éval réussie (201, plus d'\"Erreur serveur\").