### PR TITLE
fix(admin): eager-load enrollments in get_student_by_id (hotfix P0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Fiche élève, création, modification et upload de photo qui renvoyaient « Connexion au serveur impossible » depuis l'enrichissement de la liste : restaurés en eager-loadant l'inscription année courante au chargement d'un élève *(admin)*.
 - Création d'évaluation qui échouait silencieusement avec « Erreur serveur » : l'audit serveur sait désormais sérialiser correctement la date *(admin, enseignant)* (#76).
 - Permissions de gestion des rôles, des salles et des séries désormais seedées par défaut. Auparavant, les pages correspondantes côté portail étaient inaccessibles en silence (#73).
 - Démontage propre de la migration ajoutant la traçabilité de saisie des notes (l'ordre de suppression de l'index et de la contrainte cassait la rétrogradation sur MySQL).

--- a/app/repositories/admin_repository.py
+++ b/app/repositories/admin_repository.py
@@ -16,14 +16,46 @@ from app.utils.fuzzy_search import fuzzy_filter_by_name
 # ---------------------------------------------------------------------------
 
 
-async def get_student_by_id(db: AsyncSession, student_id: int) -> Student | None:
-    stmt = select(Student).where(Student.id == student_id)
-    return (await db.execute(stmt)).scalar_one_or_none()
-
-
 async def get_current_academic_year_id(db: AsyncSession) -> int | None:
     """Retourne l'id de l'année scolaire courante (`is_current = true`) ou None."""
     stmt = select(AcademicYear.id).where(AcademicYear.is_current.is_(True)).limit(1)
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+def _student_with_current_enrollment_options(current_ay_id: int | None) -> list:
+    """Loader options bornant `Student.enrollments` à l'année courante + status valide.
+
+    Single source of truth partagée entre `list_students` et `get_student_by_id` :
+    sans ce eager-load, `_student_to_response` plante avec `MissingGreenlet` quand
+    il lit `s.enrollments` (lazy-load implicite hors greenlet async).
+    """
+    options: list = [selectinload(Student.enrollments).options(selectinload(Enrollment.class_))]
+    if current_ay_id is not None:
+        options.append(
+            with_loader_criteria(
+                Enrollment,
+                and_(
+                    Enrollment.academic_year_id == current_ay_id,
+                    Enrollment.status == EnrollmentStatus.VALIDE,
+                ),
+                include_aliases=True,
+            )
+        )
+    return options
+
+
+async def get_student_by_id(db: AsyncSession, student_id: int) -> Student | None:
+    """Charge un Student avec son inscription année courante eager-loaded.
+
+    Eager-load obligatoire : tous les callers passent par `_student_to_response`
+    qui lit `s.enrollments` — sans options, MissingGreenlet → 500.
+    """
+    current_ay_id = await get_current_academic_year_id(db)
+    stmt = (
+        select(Student)
+        .where(Student.id == student_id)
+        .options(*_student_with_current_enrollment_options(current_ay_id))
+    )
     return (await db.execute(stmt)).scalar_one_or_none()
 
 
@@ -91,21 +123,7 @@ async def list_students(
     count_stmt = select(func.count()).select_from(base.subquery())
     total: int = (await db.execute(count_stmt)).scalar() or 0
 
-    # `with_loader_criteria` borne le selectinload de Student.enrollments aux
-    # enrollments valide de l'année courante. Single source of truth pour
-    # "current_enrollment" partagée par list_students et tout futur consumer.
-    options: list = [selectinload(Student.enrollments).options(selectinload(Enrollment.class_))]
-    if current_ay_id is not None:
-        options.append(
-            with_loader_criteria(
-                Enrollment,
-                and_(
-                    Enrollment.academic_year_id == current_ay_id,
-                    Enrollment.status == EnrollmentStatus.VALIDE,
-                ),
-                include_aliases=True,
-            )
-        )
+    options = _student_with_current_enrollment_options(current_ay_id)
 
     stmt = (
         base.options(*options)

--- a/tests/services/test_students_filters.py
+++ b/tests/services/test_students_filters.py
@@ -181,3 +181,49 @@ async def test_filters_returns_counts_per_class() -> None:
     assert result.current_academic_year_id == 7
     # Sanity check : 12 + 8 + 3 = 23, donc 27 élèves sont en non-valide ou multi-tenant
     # (le total est indépendant des cohortes — un élève peut n'être nulle part).
+
+
+# ---------------------------------------------------------------------------
+# get_student_by_id — eager-load obligatoire (regression PR #83 → hotfix)
+# ---------------------------------------------------------------------------
+
+
+async def test_get_student_by_id_eager_loads_enrollments() -> None:
+    """Régression : sans selectinload, _student_to_response déclenche MissingGreenlet en prod.
+
+    PR #83 a ajouté la lecture de `s.enrollments` dans `_student_to_response`,
+    mais `repo.get_student_by_id` n'avait pas été mis à jour pour eager-loader
+    cette relation. Résultat : 4 endpoints cassés en cascade (GET / POST / PATCH /
+    photo upload) — l'admin en prod voyait "Connexion au serveur impossible".
+
+    Ce test garantit que la fonction emit bien un select(Student) AVEC loader
+    options. On l'inspecte via _with_options (interne SQLAlchemy 2.0 mais stable).
+    """
+    from app.repositories.admin_repository import get_student_by_id
+
+    captured: dict = {"stmts": []}
+
+    async def fake_execute(stmt: object) -> MagicMock:
+        captured["stmts"].append(stmt)
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=None)
+        result.scalar = MagicMock(return_value=None)
+        return result
+
+    db = AsyncMock()
+    db.execute = fake_execute
+
+    await get_student_by_id(db, 1)
+
+    # 2 executes attendus : (1) get_current_academic_year_id, (2) le select Student
+    stmts = captured["stmts"]
+    assert len(stmts) == 2, (
+        f"Expected 2 db.execute calls (year + student), got {len(stmts)}"
+    )
+
+    student_stmt = stmts[1]
+    options = getattr(student_stmt, "_with_options", ())
+    assert options, (
+        "get_student_by_id doit appliquer selectinload sur Student.enrollments — "
+        "sans, _student_to_response trigger MissingGreenlet en prod async session"
+    )


### PR DESCRIPTION
## Bug

Production : `https://college.klassci.com/admin/students/4` affichait **« Connexion au serveur impossible — Impossible de charger la fiche élève »**.

Root cause : la PR #82 a ajouté `_student_to_response()` qui lit `s.enrollments` via `getattr` pour attacher `current_enrollment`, mais `repo.get_student_by_id()` n'a pas été mis à jour pour eager-loader cette relation. Résultat : `MissingGreenlet` exception sur SQLAlchemy 2.0 async → **500 silencieux** côté BE.

## Cascade — 4 endpoints cassés (pas seulement la fiche)

| Endpoint | État avant fix | État après fix |
|---|---|---|
| `GET /admin/students/{id}` | 500 | 200 |
| `POST /admin/students` (create) | 500 | 200 |
| `PATCH /admin/students/{id}` (update) | 500 | 200 |
| `POST /admin/students/{id}/photo` | 500 | 200 |

Tous passent par `_student_to_response` après `repo.get_student_by_id`, donc tous étaient affectés en silence.

## Fix

1. Extraire `_student_with_current_enrollment_options()` helper — single source of truth partagée entre `list_students` (déjà OK) et `get_student_by_id` (à fixer). Pattern « single source of truth predicate » de la rule `redesign-premium.md`.
2. `get_student_by_id` charge désormais avec les mêmes loader options que `list_students` : `selectinload(Student.enrollments)` + `with_loader_criteria` borné à l'année courante + status `valide`.
3. DRY `list_students` : utilise le nouveau helper au lieu d'un copy-paste inline.

## Test

Ajout d'un test de régression `test_get_student_by_id_eager_loads_enrollments` qui :
- Capture les `stmt` passés à `db.execute`.
- Vérifie que 2 selects sont émis (`get_current_academic_year_id` + le student select).
- Vérifie que le student select porte bien des `_with_options` (loader options présentes).

## Pourquoi le test n'avait pas attrapé le bug avant

Les tests router de PR #82 mockaient le service entier (`patch(f"{SVC}.get_student", ...)`) — donc la fonction repo n'était jamais exercée. Le bug ne manifeste qu'avec une **vraie** session async (lazy-load + greenlet). Mockée, elle ne plante pas.

À cycle 1 (redesign enrollments), on devra introduire une fixture de test avec un vrai session SQLAlchemy in-memory pour couvrir ce niveau de bug en intégration.

## Test plan

- [x] Lint `ruff check` passe
- [x] Test unitaire ajouté + vérifié localement (mockable hors weasyprint Windows)
- [ ] CI passe sur cette PR
- [ ] Après merge develop : deploy EC2 + curl `https://college.klassci.com/api/admin/students/4` → 200
- [ ] Visual-check `https://college.klassci.com/admin/students/4` charge la fiche
- [ ] Cherry-pick / merge dans `main` lors du prochain cycle

## Severity

**P0** — la fiche élève + create + update + photo upload sont cassés pour tous les admins en prod.