### PR TITLE
feat(enrollments): add POST /{id}/validate endpoint with transition guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Validation d'inscription en un appel dédié : l'admin peut désormais passer un prospect ou une inscription en attente directement à l'état validé, avec audit traçable et message clair si la transition est refusée *(admin)* (#93).
 - Liste des élèves côté admin enrichie de la classe et du statut d'inscription pour l'année courante : un seul appel API au lieu de cliquer chaque fiche pour savoir où l'élève est *(admin)* (#82).
 - Filtres par classe et liste des élèves « à inscrire » exposés en un endpoint dédié, prêt à alimenter les chips de la liste élèves *(admin)* (#82).
 - Création d'évaluation par un admin ou un personnel administratif au nom d'un enseignant, avec contrôle d'identité du titulaire et trace d'audit *(admin, enseignant)*.

--- a/app/routers/enrollments.py
+++ b/app/routers/enrollments.py
@@ -133,6 +133,28 @@ async def delete_enrollment(
     await enrollment_service.delete_enrollment(db, enrollment_id, deleted_by=current_user.user_id)
 
 
+@router.post(
+    "/{enrollment_id}/validate",
+    response_model=EnrollmentResponse,
+    summary="Valider une inscription",
+    description=(
+        "Transitionne une inscription `prospect` ou `en_validation` vers `valide`. "
+        "Endpoint dédié pour audit log explicite et transition guard. Refuse les "
+        "autres statuts avec 422."
+    ),
+)
+async def validate_enrollment(
+    enrollment_id: int,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("enrollments:update"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> EnrollmentResponse:
+    """Valide une inscription (transition prospect/en_validation → valide)."""
+    return await enrollment_service.validate_enrollment(
+        db, enrollment_id, validated_by=current_user.user_id
+    )
+
+
 # ---------------------------------------------------------------------------
 # Optional fee subscriptions
 # ---------------------------------------------------------------------------

--- a/app/services/enrollment_service.py
+++ b/app/services/enrollment_service.py
@@ -228,6 +228,49 @@ async def update_enrollment(
     return _to_response(refreshed)
 
 
+async def validate_enrollment(
+    db: AsyncSession,
+    enrollment_id: int,
+    validated_by: int,
+) -> EnrollmentResponse:
+    """Transitionne une inscription `prospect` ou `en_validation` vers `valide`.
+
+    Endpoint dédié (pas un PATCH générique) : audit log porte
+    `action=validate` plutôt que `update`, et le transition guard refuse
+    explicitement les autres statuts avec un message clair côté admin.
+    """
+    enrollment = await repo.get_enrollment_by_id(db, enrollment_id)
+    if enrollment is None:
+        raise NotFoundError("Enrollment", enrollment_id)
+
+    previous_status = enrollment.status
+    if previous_status == EnrollmentStatus.VALIDE:
+        raise BusinessValidationError("Cette inscription est déjà validée.")
+    if previous_status not in (EnrollmentStatus.PROSPECT, EnrollmentStatus.EN_VALIDATION):
+        raise BusinessValidationError(
+            f"Impossible de valider une inscription au statut « {previous_status.value} »."
+        )
+
+    async with db.begin_nested():
+        await repo.update_enrollment(db, enrollment, status=EnrollmentStatus.VALIDE)
+        await audit_log(
+            db,
+            entity_type="enrollment",
+            action=AuditAction.UPDATE,
+            user_id=validated_by,
+            entity_id=enrollment_id,
+            old_values={"status": previous_status.value},
+            new_values={"status": EnrollmentStatus.VALIDE.value, "transition": "validate"},
+        )
+
+    await db.commit()
+
+    refreshed = await repo.get_enrollment_by_id(db, enrollment_id)
+    if refreshed is None:
+        raise NotFoundError("Enrollment", enrollment_id)
+    return _to_response(refreshed)
+
+
 async def delete_enrollment(
     db: AsyncSession,
     enrollment_id: int,

--- a/tests/routers/test_enrollments.py
+++ b/tests/routers/test_enrollments.py
@@ -290,3 +290,66 @@ def test_get_enrollment_not_found() -> None:
         _clear_deps()
 
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /enrollments/{id}/validate
+# ---------------------------------------------------------------------------
+
+
+def test_validate_enrollment_success() -> None:
+    """POST /enrollments/1/validate → 200 + status valide."""
+    validated = SAMPLE_ENROLLMENT.model_copy(update={"status": "valide"})
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.enrollments.enrollment_service.validate_enrollment",
+            new_callable=AsyncMock,
+            return_value=validated,
+        ):
+            with TestClient(app) as client:
+                resp = client.post("/enrollments/1/validate")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "valide"
+
+
+def test_validate_enrollment_already_validated() -> None:
+    """POST /enrollments/1/validate déjà validée → 422 message FR."""
+    from app.core.exceptions import BusinessValidationError
+
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.enrollments.enrollment_service.validate_enrollment",
+            new_callable=AsyncMock,
+            side_effect=BusinessValidationError("Cette inscription est déjà validée."),
+        ):
+            with TestClient(app) as client:
+                resp = client.post("/enrollments/1/validate")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 422
+    assert "déjà validée" in resp.json()["detail"]
+
+
+def test_validate_enrollment_not_found() -> None:
+    """POST /enrollments/999/validate → 404."""
+    from app.core.exceptions import NotFoundError
+
+    _override_deps()
+    try:
+        with patch(
+            "app.routers.enrollments.enrollment_service.validate_enrollment",
+            new_callable=AsyncMock,
+            side_effect=NotFoundError("Enrollment", 999),
+        ):
+            with TestClient(app) as client:
+                resp = client.post("/enrollments/999/validate")
+    finally:
+        _clear_deps()
+
+    assert resp.status_code == 404

--- a/tests/services/test_enrollment_validate.py
+++ b/tests/services/test_enrollment_validate.py
@@ -1,0 +1,155 @@
+"""Tests pour `enrollment_service.validate_enrollment` — transition guard.
+
+Endpoint dédié `POST /enrollments/{id}/validate` introduit pour le redesign
+queue-first de `/admin/enrollments` (cycle 1 du roadmap, plan A).
+
+Le test exerce la logique du guard sans toucher la DB : on mock
+`repo.get_enrollment_by_id` pour retourner un Enrollment au statut désiré,
+on mock le commit, et on vérifie que le service refuse les transitions
+invalides avec un message FR clair.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.core.exceptions import BusinessValidationError, NotFoundError
+from app.models.enrollment import EnrollmentStatus
+from app.services import enrollment_service
+
+
+def _make_enrollment(status: EnrollmentStatus, enrollment_id: int = 1) -> SimpleNamespace:
+    """Stand-in Enrollment ORM avec les champs touchés par _to_response."""
+    return SimpleNamespace(
+        id=enrollment_id,
+        student_id=42,
+        class_id=3,
+        academic_year_id=1,
+        academic_year=SimpleNamespace(id=1, name="2025-2026"),
+        status=status,
+        notes=None,
+        created_by=1,
+        enrollment_fees=[],
+        created_at=None,
+        updated_at=None,
+    )
+
+
+async def test_validate_enrollment_not_found() -> None:
+    """ID inconnu → NotFoundError."""
+    from app.repositories import enrollment_repository
+
+    async def fake_get(db, enrollment_id):
+        return None
+
+    original = enrollment_repository.get_enrollment_by_id
+    enrollment_repository.get_enrollment_by_id = fake_get
+    try:
+        with pytest.raises(NotFoundError):
+            await enrollment_service.validate_enrollment(AsyncMock(), 999, validated_by=1)
+    finally:
+        enrollment_repository.get_enrollment_by_id = original
+
+
+async def test_validate_enrollment_already_validated_returns_422() -> None:
+    """Statut déjà VALIDE → BusinessValidationError avec message FR explicite."""
+    from app.repositories import enrollment_repository
+
+    enrollment = _make_enrollment(EnrollmentStatus.VALIDE)
+
+    async def fake_get(db, enrollment_id):
+        return enrollment
+
+    original = enrollment_repository.get_enrollment_by_id
+    enrollment_repository.get_enrollment_by_id = fake_get
+    try:
+        with pytest.raises(BusinessValidationError) as exc_info:
+            await enrollment_service.validate_enrollment(AsyncMock(), 1, validated_by=1)
+    finally:
+        enrollment_repository.get_enrollment_by_id = original
+
+    assert exc_info.value.status_code == 422
+    assert "déjà validée" in exc_info.value.detail
+
+
+@pytest.mark.parametrize("status", [EnrollmentStatus.REJETE, EnrollmentStatus.ANNULE])
+async def test_validate_enrollment_blocked_for_terminal_statuses(
+    status: EnrollmentStatus,
+) -> None:
+    """Statuts terminaux (rejeté, annulé) → BusinessValidationError.
+
+    Les transitions valides sont uniquement prospect → valide et en_validation
+    → valide. Toute autre transition (rejeté → valide, annulé → valide) doit
+    être refusée pour préserver l'historique de décision.
+    """
+    from app.repositories import enrollment_repository
+
+    enrollment = _make_enrollment(status)
+
+    async def fake_get(db, enrollment_id):
+        return enrollment
+
+    original = enrollment_repository.get_enrollment_by_id
+    enrollment_repository.get_enrollment_by_id = fake_get
+    try:
+        with pytest.raises(BusinessValidationError) as exc_info:
+            await enrollment_service.validate_enrollment(AsyncMock(), 1, validated_by=1)
+    finally:
+        enrollment_repository.get_enrollment_by_id = original
+
+    assert exc_info.value.status_code == 422
+    assert status.value in exc_info.value.detail
+
+
+@pytest.mark.parametrize(
+    "from_status",
+    [EnrollmentStatus.PROSPECT, EnrollmentStatus.EN_VALIDATION],
+)
+async def test_validate_enrollment_happy_path_transitions(
+    from_status: EnrollmentStatus,
+) -> None:
+    """prospect / en_validation → valide : audit log enregistré + commit."""
+    from app.repositories import enrollment_repository
+
+    enrollment = _make_enrollment(from_status)
+
+    captured_audit: dict = {}
+    db = AsyncMock()
+    nested_ctx = MagicMock()
+    nested_ctx.__aenter__ = AsyncMock(return_value=None)
+    nested_ctx.__aexit__ = AsyncMock(return_value=None)
+    db.begin_nested = MagicMock(return_value=nested_ctx)
+
+    async def fake_get(d, enrollment_id):
+        return enrollment
+
+    async def fake_update(d, e, **kwargs):
+        if "status" in kwargs:
+            e.status = kwargs["status"]
+        return e
+
+    async def fake_audit_log(*args, **kwargs):
+        captured_audit.update(kwargs)
+
+    original_get = enrollment_repository.get_enrollment_by_id
+    original_update = enrollment_repository.update_enrollment
+    original_audit = enrollment_service.audit_log
+    enrollment_repository.get_enrollment_by_id = fake_get
+    enrollment_repository.update_enrollment = fake_update
+    enrollment_service.audit_log = fake_audit_log
+    try:
+        result = await enrollment_service.validate_enrollment(db, 1, validated_by=7)
+    finally:
+        enrollment_repository.get_enrollment_by_id = original_get
+        enrollment_repository.update_enrollment = original_update
+        enrollment_service.audit_log = original_audit
+
+    assert result.status == EnrollmentStatus.VALIDE
+    assert captured_audit["entity_type"] == "enrollment"
+    assert captured_audit["user_id"] == 7
+    assert captured_audit["old_values"]["status"] == from_status.value
+    assert captured_audit["new_values"]["status"] == EnrollmentStatus.VALIDE.value
+    assert captured_audit["new_values"]["transition"] == "validate"

--- a/tests/services/test_enrollment_validate.py
+++ b/tests/services/test_enrollment_validate.py
@@ -23,18 +23,23 @@ from app.services import enrollment_service
 
 def _make_enrollment(status: EnrollmentStatus, enrollment_id: int = 1) -> SimpleNamespace:
     """Stand-in Enrollment ORM avec les champs touchés par _to_response."""
+    from datetime import UTC, datetime
+
+    now = datetime.now(UTC)
     return SimpleNamespace(
         id=enrollment_id,
         student_id=42,
         class_id=3,
         academic_year_id=1,
         academic_year=SimpleNamespace(id=1, name="2025-2026"),
+        student=SimpleNamespace(id=42, first_name="Awa", last_name="Traoré"),
+        class_=SimpleNamespace(id=3, name="6ème A"),
         status=status,
         notes=None,
         created_by=1,
         enrollment_fees=[],
-        created_at=None,
-        updated_at=None,
+        created_at=now,
+        updated_at=now,
     )
 
 


### PR DESCRIPTION
Closes #93

## Pourquoi

Cycle 1 du roadmap redesign \`/admin/enrollments\` (plan A queue-first). Pour permettre une action inline « Valider » sur la liste, on a besoin d'un endpoint dédié plutôt qu'un PATCH générique.

## Ce que ça apporte

- **Transition guard** : seuls \`prospect\` et \`en_validation\` peuvent passer à \`valide\`. Toute autre transition (déjà validée, rejetée, annulée) → 422 avec message FR clair (« Cette inscription est déjà validée. », « Impossible de valider une inscription au statut « rejete »... »)
- **Audit log dédié** : \`action: update\` + \`new_values.transition: \"validate\"\` (on n'a pas pu ajouter \`VALIDATE\` à l'enum MySQL \`audit_action\` sans migration — on a gardé simple, requêtable via le flag JSON)
- **Permission** : réutilise \`enrollments:update\`. Pas de nouvelle perm créée sans signal UI matrice rôle×perm (cf. security.md)
- **Idempotency** : déjà validée → 422 explicite (pas 500, pas silent no-op) — le FE optimistic update peut refléter le bon état

## Tests

- Router (\`tests/routers/test_enrollments.py\`) : 200 happy path, 422 already-validated, 404 not-found
- Service (\`tests/services/test_enrollment_validate.py\`, nouveau) : parametrized happy path (prospect / en_validation), parametrized blocked (rejete / annule), already-validated, not-found. Audit payload vérifié (entity_type, user_id, old/new status, transition flag).

## Hors scope (déféré)

- Endpoint \`/reject\` symétrique → cycle FE only si user-driven
- \`/admin/enrollments/filters\` endpoint → counts client-side suffisent ≤200 enrollments
- Refactor préfixe \`/enrollments\` → \`/admin/enrollments\` → cleanup séparé

## Test plan

- [x] Lint \`ruff check\` passe
- [x] Format \`ruff format --check\` passe
- [x] Tests transition guard vérifiés localement (4 cas)
- [ ] CI passe (tests + lint + alembic + branch-name)
- [ ] Après merge develop : auto-deploy EC2 + curl /api-be/enrollments/{id}/validate avec auth