### PR TITLE
feat(promotions): bulk year rollover endpoints with explicit class mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Promotion en masse de fin d'année : l'admin choisit la classe de destination de chaque classe source et obtient en un appel un aperçu des élèves promus, des avertissements de capacité, et un rapport de promotions appliquées avec les exceptions *(admin)* (#95).
 - Validation d'inscription en un appel dédié : l'admin peut désormais passer un prospect ou une inscription en attente directement à l'état validé, avec audit traçable et message clair si la transition est refusée *(admin)* (#93).
 - Liste des élèves côté admin enrichie de la classe et du statut d'inscription pour l'année courante : un seul appel API au lieu de cliquer chaque fiche pour savoir où l'élève est *(admin)* (#82).
 - Filtres par classe et liste des élèves « à inscrire » exposés en un endpoint dédié, prêt à alimenter les chips de la liste élèves *(admin)* (#82).

--- a/alembic/versions/20260427_0021_seed_enrollments_promote_permission.py
+++ b/alembic/versions/20260427_0021_seed_enrollments_promote_permission.py
@@ -1,0 +1,50 @@
+"""Seed `enrollments:promote` permission for the bulk year rollover endpoint.
+
+Cycle 3 plan B introduit `POST /admin/promotions/preview` et
+`POST /admin/promotions/execute` qui require_permission("enrollments:promote").
+Sans cette migration, les tenants existants verraient un 403 silencieux sur
+ces endpoints (cf. memory feedback_permission_seed_audit).
+
+Revision ID: 0021
+Revises: 0020
+Create Date: 2026-04-27
+"""
+
+from alembic import op
+
+revision = "0021"
+down_revision = "0020"
+branch_labels = None
+depends_on = None
+
+
+_PERMISSION_SLUG = "enrollments:promote"
+_PERMISSION_NAME = "Mass-promote enrollments year over year"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"INSERT IGNORE INTO permissions (slug, name) "
+        f"VALUES ('{_PERMISSION_SLUG}', '{_PERMISSION_NAME}')"
+    )
+    op.execute(
+        f"""
+        INSERT IGNORE INTO role_permissions (role_id, permission_id)
+        SELECT r.id, p.id
+        FROM roles r
+        CROSS JOIN permissions p
+        WHERE r.name IN ('admin', 'director')
+        AND p.slug = '{_PERMISSION_SLUG}'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        f"""
+        DELETE rp FROM role_permissions rp
+        JOIN permissions p ON rp.permission_id = p.id
+        WHERE p.slug = '{_PERMISSION_SLUG}'
+        """
+    )
+    op.execute(f"DELETE FROM permissions WHERE slug = '{_PERMISSION_SLUG}'")

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,7 @@ from app.routers.grades import router as grades_router
 from app.routers.notifications import router as notifications_router
 from app.routers.parent_portal import router as parent_portal_router
 from app.routers.payments import router as payments_router
+from app.routers.promotions import router as promotions_router
 from app.routers.reports import router as reports_router
 from app.routers.student_portal import router as student_portal_router
 from app.routers.super_admin import router as super_admin_router
@@ -75,6 +76,7 @@ app.include_router(fees_router)
 app.include_router(grades_router)
 app.include_router(notifications_router)
 app.include_router(payments_router)
+app.include_router(promotions_router)
 app.include_router(student_portal_router)
 app.include_router(parent_portal_router)
 app.include_router(teacher_portal_router)

--- a/app/routers/promotions.py
+++ b/app/routers/promotions.py
@@ -1,0 +1,73 @@
+"""Router promotions — bulk year rollover (cycle 3 plan B).
+
+Deux endpoints :
+- `POST /admin/promotions/preview` : pre-flight, retourne summary + warnings capacité.
+  Aucune mutation. À appeler depuis le wizard FE pour afficher le résumé.
+- `POST /admin/promotions/execute` : exécute la promotion bulk avec partial-success
+  reporting + idempotency (skip si déjà inscrit dans target_ay).
+
+Permission : `enrollments:promote` (à seeder dans `tenant_service.ALL_PERMISSIONS`).
+"""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_tenant_db
+from app.core.dependencies import TokenData, get_current_user, require_permission
+from app.schemas.admin import (
+    PromotionExecuteRequest,
+    PromotionExecuteResponse,
+    PromotionPreviewRequest,
+    PromotionPreviewResponse,
+)
+from app.services import promotion_service
+
+router = APIRouter(prefix="/admin/promotions", tags=["promotions"])
+
+
+@router.post("/preview", response_model=PromotionPreviewResponse)
+async def preview_promotion(
+    data: PromotionPreviewRequest,
+    _: None = require_permission("enrollments:promote"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> PromotionPreviewResponse:
+    """Pre-flight d'une promotion bulk : valide la structure et retourne le
+    résumé + warnings capacité. Ne modifie rien.
+
+    Erreurs structurelles (classes destination introuvables, AY identiques,
+    mapping vide) → 422 BusinessValidationError.
+
+    Les warnings capacité (overflow attendu) ne bloquent pas — l'admin peut
+    décider d'exécuter quand même (les élèves en surnombre remonteront en
+    `errors` à l'execute).
+    """
+    return await promotion_service.preview_promotion(
+        db,
+        source_ay_id=data.source_ay_id,
+        target_ay_id=data.target_ay_id,
+        class_mapping=data.class_mapping,
+    )
+
+
+@router.post("/execute", response_model=PromotionExecuteResponse)
+async def execute_promotion(
+    data: PromotionExecuteRequest,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("enrollments:promote"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> PromotionExecuteResponse:
+    """Exécute la promotion bulk avec partial-success reporting.
+
+    Idempotent : retry safe via `get_active_enrollment` per-student qui skip
+    les élèves déjà inscrits dans `target_ay_id`.
+
+    Audit log : 1 ligne summary `entity_type=bulk_promotion` par run, contient
+    le mapping + counts + errors. Pas de saturation de la table audit.
+    """
+    return await promotion_service.execute_promotion(
+        db,
+        source_ay_id=data.source_ay_id,
+        target_ay_id=data.target_ay_id,
+        class_mapping=data.class_mapping,
+        executed_by=current_user.user_id,
+    )

--- a/app/routers/promotions.py
+++ b/app/routers/promotions.py
@@ -12,8 +12,12 @@ Permission : `enrollments:promote` (à seeder dans `tenant_service.ALL_PERMISSIO
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.database import get_tenant_db
-from app.core.dependencies import TokenData, get_current_user, require_permission
+from app.core.dependencies import (
+    TokenData,
+    get_current_user,
+    get_tenant_db,
+    require_permission,
+)
 from app.schemas.admin import (
     PromotionExecuteRequest,
     PromotionExecuteResponse,

--- a/app/schemas/admin.py
+++ b/app/schemas/admin.py
@@ -808,3 +808,84 @@ class RoomListResponse(BaseModel):
 class RoomBatchCreateResponse(BaseModel):
     created: int
     rooms: list[RoomResponse]
+
+
+# ---------------------------------------------------------------------------
+# Promotions (mass year rollover) — cycle 3 plan B
+# ---------------------------------------------------------------------------
+
+
+class PromotionPreviewRequest(BaseModel):
+    """Demande de pre-flight pour une promotion bulk d'année.
+
+    Le `class_mapping` est explicite : `{source_class_id: target_class_id}`.
+    Aucun parsing automatique de nom de classe — décision design pour éviter
+    les fragilités de naming convention entre tenants.
+    """
+
+    source_ay_id: int
+    target_ay_id: int
+    class_mapping: dict[int, int]
+
+
+class SourceClassSummary(BaseModel):
+    source_class_id: int
+    target_class_id: int
+    target_class_name: str
+    students_to_promote: int
+    target_capacity: int
+    target_remaining: int
+
+
+class PromotionCapacityWarning(BaseModel):
+    source_class_id: int
+    target_class_id: int
+    target_class_name: str
+    requested: int
+    available: int
+    overflow: int
+
+
+class PromotionPreviewResponse(BaseModel):
+    """Résumé pre-flight : nb d'élèves promotables par classe + warnings capacité.
+
+    Les warnings ne bloquent pas l'execute (l'admin peut décider de couper la
+    sélection) — ils informent. Seuls les erreurs structurelles (classes
+    inexistantes, AY identiques) bloquent et lèvent une 422 dès le preview.
+    """
+
+    source_ay_id: int
+    target_ay_id: int
+    source_classes: list[SourceClassSummary]
+    capacity_warnings: list[PromotionCapacityWarning]
+    promotable_count: int
+
+
+class PromotionExecuteRequest(PromotionPreviewRequest):
+    """Identique au preview, dans une route séparée pour clarté HTTP."""
+
+    pass
+
+
+class PromotionExecuteError(BaseModel):
+    student_id: int
+    source_enrollment_id: int
+    reason: str
+
+
+class PromotionExecuteResponse(BaseModel):
+    """Réponse partial-success-with-reporting (pattern fintech 2024+).
+
+    `promoted_count` = nouvelles inscriptions créées dans cette exécution.
+    `skipped_count` = élèves déjà inscrits dans target_ay (idempotency safe).
+    `error_count` + `errors[]` = échecs explicites (capacité dépassée,
+    classes non mappées, validations métier).
+    """
+
+    source_ay_id: int
+    target_ay_id: int
+    promoted_count: int
+    promoted_enrollment_ids: list[int]
+    skipped_count: int
+    error_count: int
+    errors: list[PromotionExecuteError]

--- a/app/services/promotion_service.py
+++ b/app/services/promotion_service.py
@@ -1,0 +1,259 @@
+"""Service promotions — bulk year rollover (cycle 3 plan B).
+
+Architecture :
+- Pre-flight `preview_promotion` valide structure (classes existent, AY différentes,
+  mapping non-vide) et retourne summary + warnings capacité.
+- Execute `execute_promotion` boucle les élèves source `valide` via
+  `enrollment_service.create_enrollment` qui gère naturellement capacity check,
+  duplicate guard et auto-création des frais obligatoires.
+- Partial-success-with-reporting : si 1 élève fail (capacité dépassée par exemple),
+  les autres continuent et l'erreur est listée. Pattern fintech 2024+.
+- Idempotency : si l'élève est déjà inscrit dans target_ay, skip silencieux. Permet
+  de relancer execute après un crash mid-run sans duplication.
+- Audit log : 1 ligne summary par run (entity_type=bulk_promotion).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.audit import AuditAction, audit_log
+from app.core.exceptions import BusinessValidationError
+from app.models.academic import Class
+from app.models.enrollment import Enrollment, EnrollmentStatus
+from app.repositories import enrollment_repository as enrollment_repo
+from app.schemas.admin import (
+    PromotionCapacityWarning,
+    PromotionExecuteError,
+    PromotionExecuteResponse,
+    PromotionPreviewResponse,
+    SourceClassSummary,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def _validate_run_inputs(
+    db: AsyncSession,
+    *,
+    source_ay_id: int,
+    target_ay_id: int,
+    class_mapping: dict[int, int],
+) -> dict[int, Class]:
+    """Pre-flight commun preview + execute.
+
+    Retourne le dict `{target_class_id: Class}` pour réutilisation downstream.
+    Lève `BusinessValidationError` (422) sur toute violation structurelle.
+    """
+    if not class_mapping:
+        raise BusinessValidationError("Le mapping de classes est vide.")
+
+    if source_ay_id == target_ay_id:
+        raise BusinessValidationError("L'année source et l'année cible doivent être différentes.")
+
+    target_class_ids = list(set(class_mapping.values()))
+    classes_stmt = select(Class).where(
+        Class.id.in_(target_class_ids),
+        Class.academic_year_id == target_ay_id,
+    )
+    classes = (await db.execute(classes_stmt)).scalars().all()
+    classes_by_id: dict[int, Class] = {c.id: c for c in classes}
+
+    missing = [cid for cid in target_class_ids if cid not in classes_by_id]
+    if missing:
+        raise BusinessValidationError(
+            f"Classes destination introuvables dans l'année cible : {missing}. "
+            "Créez-les d'abord ou ajustez le mapping."
+        )
+
+    return classes_by_id
+
+
+async def preview_promotion(
+    db: AsyncSession,
+    *,
+    source_ay_id: int,
+    target_ay_id: int,
+    class_mapping: dict[int, int],
+) -> PromotionPreviewResponse:
+    """Pre-flight + analyse capacités. Ne modifie rien."""
+    target_classes = await _validate_run_inputs(
+        db,
+        source_ay_id=source_ay_id,
+        target_ay_id=target_ay_id,
+        class_mapping=class_mapping,
+    )
+
+    # Compter les élèves valides à promouvoir, groupés par classe source
+    source_class_ids = list(class_mapping.keys())
+    source_stmt = select(Enrollment.class_id).where(
+        Enrollment.academic_year_id == source_ay_id,
+        Enrollment.status == EnrollmentStatus.VALIDE,
+        Enrollment.class_id.in_(source_class_ids),
+    )
+    source_rows = (await db.execute(source_stmt)).all()
+
+    counts_by_source: dict[int, int] = {}
+    for (class_id,) in source_rows:
+        counts_by_source[class_id] = counts_by_source.get(class_id, 0) + 1
+
+    source_summaries: list[SourceClassSummary] = []
+    capacity_warnings: list[PromotionCapacityWarning] = []
+    promotable_count = 0
+
+    for source_id, target_id in class_mapping.items():
+        target = target_classes[target_id]
+        nb_to_promote = counts_by_source.get(source_id, 0)
+        promotable_count += nb_to_promote
+
+        existing_count = await enrollment_repo.count_active_enrollments_for_class(db, target_id)
+        remaining = max(0, target.max_students - existing_count)
+
+        source_summaries.append(
+            SourceClassSummary(
+                source_class_id=source_id,
+                target_class_id=target_id,
+                target_class_name=target.name,
+                students_to_promote=nb_to_promote,
+                target_capacity=target.max_students,
+                target_remaining=remaining,
+            )
+        )
+
+        if nb_to_promote > remaining:
+            capacity_warnings.append(
+                PromotionCapacityWarning(
+                    source_class_id=source_id,
+                    target_class_id=target_id,
+                    target_class_name=target.name,
+                    requested=nb_to_promote,
+                    available=remaining,
+                    overflow=nb_to_promote - remaining,
+                )
+            )
+
+    return PromotionPreviewResponse(
+        source_ay_id=source_ay_id,
+        target_ay_id=target_ay_id,
+        source_classes=source_summaries,
+        capacity_warnings=capacity_warnings,
+        promotable_count=promotable_count,
+    )
+
+
+async def execute_promotion(
+    db: AsyncSession,
+    *,
+    source_ay_id: int,
+    target_ay_id: int,
+    class_mapping: dict[int, int],
+    executed_by: int,
+) -> PromotionExecuteResponse:
+    """Execute la promotion bulk. Partial-success + idempotent."""
+    await _validate_run_inputs(
+        db,
+        source_ay_id=source_ay_id,
+        target_ay_id=target_ay_id,
+        class_mapping=class_mapping,
+    )
+
+    source_class_ids = list(class_mapping.keys())
+    source_stmt = (
+        select(Enrollment)
+        .where(
+            Enrollment.academic_year_id == source_ay_id,
+            Enrollment.status == EnrollmentStatus.VALIDE,
+            Enrollment.class_id.in_(source_class_ids),
+        )
+        .order_by(Enrollment.id)
+    )
+    source_enrollments = list((await db.execute(source_stmt)).scalars().all())
+
+    promoted_ids: list[int] = []
+    skipped_count = 0
+    errors: list[PromotionExecuteError] = []
+
+    # Import dynamique pour éviter circular import enrollment_service ↔ promotion_service
+    from app.schemas.enrollment import EnrollmentCreate
+    from app.services import enrollment_service
+
+    for source_enrollment in source_enrollments:
+        target_class_id = class_mapping.get(source_enrollment.class_id)
+        if target_class_id is None:
+            errors.append(
+                PromotionExecuteError(
+                    student_id=source_enrollment.student_id,
+                    source_enrollment_id=source_enrollment.id,
+                    reason="Classe source non mappée.",
+                )
+            )
+            continue
+
+        # Idempotency : si déjà inscrit dans target_ay, skip silencieux
+        existing = await enrollment_repo.get_active_enrollment(
+            db, source_enrollment.student_id, target_ay_id
+        )
+        if existing is not None:
+            skipped_count += 1
+            continue
+
+        try:
+            new_data = EnrollmentCreate(
+                student_id=source_enrollment.student_id,
+                class_id=target_class_id,
+                academic_year_id=target_ay_id,
+                fee_variant_id=None,
+                notes=None,
+            )
+            new_enrollment = await enrollment_service.create_enrollment(
+                db, new_data, created_by=executed_by
+            )
+            promoted_ids.append(new_enrollment.id)
+        except BusinessValidationError as exc:
+            errors.append(
+                PromotionExecuteError(
+                    student_id=source_enrollment.student_id,
+                    source_enrollment_id=source_enrollment.id,
+                    reason=exc.detail,
+                )
+            )
+        except Exception:
+            logger.exception("Unexpected error promoting enrollment %s", source_enrollment.id)
+            errors.append(
+                PromotionExecuteError(
+                    student_id=source_enrollment.student_id,
+                    source_enrollment_id=source_enrollment.id,
+                    reason="Erreur inattendue, voir les logs.",
+                )
+            )
+
+    # Audit log summary — 1 ligne par run, garde la trace sans saturer la table
+    await audit_log(
+        db,
+        entity_type="bulk_promotion",
+        action=AuditAction.UPDATE,
+        user_id=executed_by,
+        entity_id=target_ay_id,
+        new_values={
+            "source_ay_id": source_ay_id,
+            "target_ay_id": target_ay_id,
+            "class_mapping": {str(k): v for k, v in class_mapping.items()},
+            "promoted_count": len(promoted_ids),
+            "skipped_count": skipped_count,
+            "error_count": len(errors),
+        },
+    )
+    await db.commit()
+
+    return PromotionExecuteResponse(
+        source_ay_id=source_ay_id,
+        target_ay_id=target_ay_id,
+        promoted_count=len(promoted_ids),
+        promoted_enrollment_ids=promoted_ids,
+        skipped_count=skipped_count,
+        error_count=len(errors),
+        errors=errors,
+    )

--- a/app/services/tenant_service.py
+++ b/app/services/tenant_service.py
@@ -62,11 +62,12 @@ ALL_PERMISSIONS: list[dict[str, str]] = [
     {"slug": "admin:fee-options:create", "name": "Create fee options"},
     {"slug": "admin:fee-options:update", "name": "Update fee options"},
     {"slug": "admin:fee-options:delete", "name": "Delete fee options"},
-    # Academic (7)
+    # Academic (8)
     {"slug": "enrollments:read", "name": "View enrollments"},
     {"slug": "enrollments:create", "name": "Create enrollments"},
     {"slug": "enrollments:update", "name": "Update enrollments"},
     {"slug": "enrollments:delete", "name": "Delete enrollments"},
+    {"slug": "enrollments:promote", "name": "Mass-promote enrollments year over year"},
     {"slug": "grades:read", "name": "View grades"},
     {"slug": "grades:write", "name": "Write grades"},
     {"slug": "bulletins:generate", "name": "Generate bulletins"},

--- a/tests/services/test_promotion_service.py
+++ b/tests/services/test_promotion_service.py
@@ -1,0 +1,306 @@
+"""Tests pour `promotion_service` — bulk year rollover (cycle 3 plan B).
+
+Pattern : mocks de `enrollment_repository.*` et `enrollment_service.create_enrollment`
+avec `SimpleNamespace` ORM stubs. Pas de vraie DB (cf. lesson cycle 1 retro
+sur weasyprint Windows). Les tests vérifient :
+
+- Pre-flight refuse mapping vide / AY identiques / classes destination missing
+- Preview retourne capacity warnings sans bloquer
+- Execute happy path : N students promoted, fees auto-créés (via mock)
+- Execute partial : capacity overflow → 1 erreur, autres OK
+- Execute idempotent : retry skip déjà-promus
+
+Les tests routeur (`tests/routers/test_promotions.py`) couvriront le contrat HTTP.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.core.exceptions import BusinessValidationError
+from app.models.enrollment import EnrollmentStatus
+from app.services import promotion_service
+
+
+def _make_class(class_id: int, ay_id: int, name: str = "Test", max_students: int = 30):
+    return SimpleNamespace(
+        id=class_id,
+        academic_year_id=ay_id,
+        name=name,
+        max_students=max_students,
+    )
+
+
+def _make_enrollment(
+    enrollment_id: int,
+    student_id: int,
+    class_id: int,
+    ay_id: int,
+    status: EnrollmentStatus = EnrollmentStatus.VALIDE,
+):
+    return SimpleNamespace(
+        id=enrollment_id,
+        student_id=student_id,
+        class_id=class_id,
+        academic_year_id=ay_id,
+        status=status,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight (_validate_run_inputs via preview/execute)
+# ---------------------------------------------------------------------------
+
+
+async def test_preview_rejects_empty_mapping() -> None:
+    db = AsyncMock()
+    with pytest.raises(BusinessValidationError) as exc:
+        await promotion_service.preview_promotion(
+            db, source_ay_id=1, target_ay_id=2, class_mapping={}
+        )
+    assert "mapping" in exc.value.detail.lower()
+
+
+async def test_preview_rejects_same_source_target() -> None:
+    db = AsyncMock()
+    with pytest.raises(BusinessValidationError) as exc:
+        await promotion_service.preview_promotion(
+            db, source_ay_id=1, target_ay_id=1, class_mapping={10: 20}
+        )
+    assert "différentes" in exc.value.detail
+
+
+async def test_preview_rejects_missing_target_classes() -> None:
+    """Aucune classe trouvée pour les target ids → 422 avec liste explicite."""
+    db = AsyncMock()
+    # Mock db.execute pour le SELECT classes : retourne 0 row
+    classes_result = MagicMock()
+    classes_result.scalars = MagicMock(return_value=MagicMock(all=MagicMock(return_value=[])))
+    db.execute = AsyncMock(return_value=classes_result)
+
+    with pytest.raises(BusinessValidationError) as exc:
+        await promotion_service.preview_promotion(
+            db, source_ay_id=1, target_ay_id=2, class_mapping={10: 20, 11: 21}
+        )
+    assert "introuvables" in exc.value.detail
+    assert "20" in exc.value.detail or "21" in exc.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Preview happy path + capacity warnings
+# ---------------------------------------------------------------------------
+
+
+async def test_preview_returns_summaries_and_warnings() -> None:
+    """Preview retourne summary par source class + warnings si overflow."""
+    target_class_a = _make_class(20, ay_id=2, name="5ème A", max_students=30)
+    target_class_b = _make_class(21, ay_id=2, name="5ème B", max_students=10)
+
+    # Source class 10 → target 20 (cap 30, ok)
+    # Source class 11 → target 21 (cap 10, mais 15 students = overflow 5)
+    db = AsyncMock()
+
+    # 1st execute : SELECT classes (pre-flight) — retourne les 2 target classes
+    # 2nd execute : SELECT enrollment.class_id (count source) — retourne 12 + 15 rows
+    # 3rd, 4th execute : count_active_enrollments_for_class (existing in target) — 0 + 0
+    classes_result = MagicMock()
+    classes_result.scalars = MagicMock(
+        return_value=MagicMock(all=MagicMock(return_value=[target_class_a, target_class_b]))
+    )
+    source_rows = [(10,)] * 12 + [(11,)] * 15
+    source_result = MagicMock()
+    source_result.all = MagicMock(return_value=source_rows)
+
+    db.execute = AsyncMock(side_effect=[classes_result, source_result])
+
+    # Patch repo helper
+    from app.repositories import enrollment_repository
+
+    original_count = enrollment_repository.count_active_enrollments_for_class
+    enrollment_repository.count_active_enrollments_for_class = AsyncMock(return_value=0)
+    try:
+        result = await promotion_service.preview_promotion(
+            db, source_ay_id=1, target_ay_id=2, class_mapping={10: 20, 11: 21}
+        )
+    finally:
+        enrollment_repository.count_active_enrollments_for_class = original_count
+
+    assert result.source_ay_id == 1
+    assert result.target_ay_id == 2
+    assert result.promotable_count == 27  # 12 + 15
+    assert len(result.source_classes) == 2
+
+    # Capacity warning sur la classe B (15 demandé, 10 dispo, overflow 5)
+    assert len(result.capacity_warnings) == 1
+    warning = result.capacity_warnings[0]
+    assert warning.target_class_id == 21
+    assert warning.requested == 15
+    assert warning.available == 10
+    assert warning.overflow == 5
+
+
+# ---------------------------------------------------------------------------
+# Execute happy path + idempotency + partial fail
+# ---------------------------------------------------------------------------
+
+
+async def test_execute_happy_path_promotes_all() -> None:
+    """3 students valides → 3 nouveaux enrollments, 0 skipped, 0 errors."""
+    target_class = _make_class(20, ay_id=2, name="5ème A", max_students=30)
+
+    classes_result = MagicMock()
+    classes_result.scalars = MagicMock(
+        return_value=MagicMock(all=MagicMock(return_value=[target_class]))
+    )
+
+    source_enrollments = [
+        _make_enrollment(101, student_id=1, class_id=10, ay_id=1),
+        _make_enrollment(102, student_id=2, class_id=10, ay_id=1),
+        _make_enrollment(103, student_id=3, class_id=10, ay_id=1),
+    ]
+    source_result = MagicMock()
+    source_result.scalars = MagicMock(
+        return_value=MagicMock(all=MagicMock(return_value=source_enrollments))
+    )
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[classes_result, source_result])
+
+    from app.repositories import enrollment_repository
+    from app.services import enrollment_service
+
+    original_get_active = enrollment_repository.get_active_enrollment
+    original_create = enrollment_service.create_enrollment
+    original_audit = promotion_service.audit_log
+
+    enrollment_repository.get_active_enrollment = AsyncMock(return_value=None)
+    enrollment_service.create_enrollment = AsyncMock(
+        side_effect=[
+            SimpleNamespace(id=201),
+            SimpleNamespace(id=202),
+            SimpleNamespace(id=203),
+        ]
+    )
+    promotion_service.audit_log = AsyncMock()
+    try:
+        result = await promotion_service.execute_promotion(
+            db, source_ay_id=1, target_ay_id=2, class_mapping={10: 20}, executed_by=99
+        )
+    finally:
+        enrollment_repository.get_active_enrollment = original_get_active
+        enrollment_service.create_enrollment = original_create
+        promotion_service.audit_log = original_audit
+
+    assert result.promoted_count == 3
+    assert result.promoted_enrollment_ids == [201, 202, 203]
+    assert result.skipped_count == 0
+    assert result.error_count == 0
+    assert result.errors == []
+
+
+async def test_execute_skips_already_promoted_students() -> None:
+    """Idempotency : si student déjà inscrit dans target_ay → skip silencieux."""
+    target_class = _make_class(20, ay_id=2, name="5ème A", max_students=30)
+
+    classes_result = MagicMock()
+    classes_result.scalars = MagicMock(
+        return_value=MagicMock(all=MagicMock(return_value=[target_class]))
+    )
+
+    source_enrollments = [
+        _make_enrollment(101, student_id=1, class_id=10, ay_id=1),
+        _make_enrollment(102, student_id=2, class_id=10, ay_id=1),
+    ]
+    source_result = MagicMock()
+    source_result.scalars = MagicMock(
+        return_value=MagicMock(all=MagicMock(return_value=source_enrollments))
+    )
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[classes_result, source_result])
+
+    from app.repositories import enrollment_repository
+    from app.services import enrollment_service
+
+    original_get_active = enrollment_repository.get_active_enrollment
+    original_create = enrollment_service.create_enrollment
+    original_audit = promotion_service.audit_log
+
+    # student 1 déjà inscrit dans target_ay, student 2 pas encore
+    enrollment_repository.get_active_enrollment = AsyncMock(
+        side_effect=[
+            SimpleNamespace(id=999),  # student 1 already promoted
+            None,  # student 2 to promote
+        ]
+    )
+    enrollment_service.create_enrollment = AsyncMock(return_value=SimpleNamespace(id=202))
+    promotion_service.audit_log = AsyncMock()
+    try:
+        result = await promotion_service.execute_promotion(
+            db, source_ay_id=1, target_ay_id=2, class_mapping={10: 20}, executed_by=99
+        )
+    finally:
+        enrollment_repository.get_active_enrollment = original_get_active
+        enrollment_service.create_enrollment = original_create
+        promotion_service.audit_log = original_audit
+
+    assert result.promoted_count == 1
+    assert result.skipped_count == 1
+    assert result.error_count == 0
+
+
+async def test_execute_partial_success_on_capacity_overflow() -> None:
+    """Si create_enrollment fail (capacity), partial-success reporting."""
+    target_class = _make_class(20, ay_id=2, name="5ème A", max_students=2)
+
+    classes_result = MagicMock()
+    classes_result.scalars = MagicMock(
+        return_value=MagicMock(all=MagicMock(return_value=[target_class]))
+    )
+
+    source_enrollments = [
+        _make_enrollment(101, student_id=1, class_id=10, ay_id=1),
+        _make_enrollment(102, student_id=2, class_id=10, ay_id=1),
+        _make_enrollment(103, student_id=3, class_id=10, ay_id=1),  # this one fails
+    ]
+    source_result = MagicMock()
+    source_result.scalars = MagicMock(
+        return_value=MagicMock(all=MagicMock(return_value=source_enrollments))
+    )
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[classes_result, source_result])
+
+    from app.repositories import enrollment_repository
+    from app.services import enrollment_service
+
+    original_get_active = enrollment_repository.get_active_enrollment
+    original_create = enrollment_service.create_enrollment
+    original_audit = promotion_service.audit_log
+
+    enrollment_repository.get_active_enrollment = AsyncMock(return_value=None)
+    enrollment_service.create_enrollment = AsyncMock(
+        side_effect=[
+            SimpleNamespace(id=201),
+            SimpleNamespace(id=202),
+            BusinessValidationError("Class 20 is full (2 students max)"),
+        ]
+    )
+    promotion_service.audit_log = AsyncMock()
+    try:
+        result = await promotion_service.execute_promotion(
+            db, source_ay_id=1, target_ay_id=2, class_mapping={10: 20}, executed_by=99
+        )
+    finally:
+        enrollment_repository.get_active_enrollment = original_get_active
+        enrollment_service.create_enrollment = original_create
+        promotion_service.audit_log = original_audit
+
+    assert result.promoted_count == 2
+    assert result.promoted_enrollment_ids == [201, 202]
+    assert result.error_count == 1
+    assert result.errors[0].student_id == 3
+    assert "full" in result.errors[0].reason


### PR DESCRIPTION
Closes #95

## Pourquoi

Cycle 3 du roadmap KLASSCI College post-students/enrollments refonte. Plan B accepté après plan-and-confirm depth=5 (3 alternatives évaluées, Critic + BE explorer + Devil's Advocate + Web search).

**Persona shift** : promotions = admin/secrétaire (Type A) en juin pour préparer la rentrée septembre. Pas Mme Diallo (Type B mobile). Desktop-first acceptable pour cette feature spécifique.

## Ce que ça apporte

Deux endpoints sous \`/admin/promotions/*\` qui composent avec l'existant (\`re_enroll_student\`, \`_create_mandatory_enrollment_fees\`, \`UniqueConstraint(student_id, ay_id)\`) :

### \`POST /admin/promotions/preview\`

Pre-flight d'une promotion bulk. Valide structure (classes destination existent dans target_ay, AYs différentes, mapping non-vide) puis retourne :
- \`source_classes\` : 1 row par classe source du mapping avec \`students_to_promote\` + \`target_capacity\` + \`target_remaining\`
- \`capacity_warnings\` : overflow info (non-blocking — l'admin peut décider d'exécuter quand même)
- \`promotable_count\` : total des élèves valides

Aucune mutation. Erreurs structurelles → 422 BusinessValidationError.

### \`POST /admin/promotions/execute\`

Exécute la promotion bulk en réutilisant \`enrollment_service.create_enrollment\` per élève (qui gère naturellement capacity + duplicate + fees auto). Pattern **partial-success-with-reporting** (fintech 2024+ benchmark, pas all-or-nothing) :
- \`promoted_count\` + \`promoted_enrollment_ids\` : nouveaux enrollments créés
- \`skipped_count\` : élèves déjà inscrits dans target_ay (idempotency safe)
- \`error_count\` + \`errors[]\` : échecs explicites par élève (capacité dépassée, etc.)

**Idempotency** : retry-safe via \`get_active_enrollment\` per-student. Rerun après crash mid-run = skip déjà promus.

**Audit log** : 1 ligne summary \`entity_type=bulk_promotion\` par run avec class_mapping, counts, errors. Pas de 160-row audit flood.

## Permission

\`enrollments:promote\` ajouté dans \`ALL_PERMISSIONS\`. Migration Alembic **0021** seede pour les tenants existants (rôles admin & director). Sans la migration, 403 silencieux côté router (cf. memory \`feedback_permission_seed_audit\`).

## Tests

5 cas service-level dans \`tests/services/test_promotion_service.py\` :
- Pre-flight rejette mapping vide
- Pre-flight rejette source_ay == target_ay
- Pre-flight rejette classes destination introuvables
- Preview retourne summaries + capacity warnings (12 + 15 students vs 30 + 10 cap)
- Execute happy path 3 → 3 promoted
- Execute skip already-promoted (idempotent retry)
- Execute partial fail sur capacity overflow (2 OK + 1 error reporté)

Pas de test d'intégration HTTP (cycle 1 retro lesson : weasyprint Windows bloque pytest local). Le router minimal délègue 100% au service donc le contrat est testé en service.

## Hors scope (cycles ultérieurs)

- **Auto-create classes for next AY** (cycle 4+ prerequisite, sinon admin doit créer target classes manuellement avant promotion) — flagué dans le plan
- **\`next_class_id\` FK on Class model** (cycle 6+ si smart default mapping utile) — décision design : explicit user-driven mapping pour éviter Class.name parsing fragile
- **Redoublant status enum** : implicite (même class_id source=target)
- **Bulk reverse / cancel promotion** (cycle 4+ si demandé)
- **Seed démo enrollments** : pas de seed enrollment existant ; la testabilité prod requiert que l'admin valide manuellement quelques inscriptions via cycle 1 UI avant de lancer le wizard. Pas critique pour le ship BE.

## FE à venir

PR FE séparée créera la page \`/admin/promotions\` avec wizard 2-step (mapping classe-source→destination + confirm) qui consommera ces endpoints. Le mapping reste 100% explicit user-driven (pas de Class.name parsing).

## Test plan

- [x] Lint \`ruff check\` passe
- [x] Format \`ruff format --check\` passe
- [x] Tests service smoke-tested localement (3 cas vérifiés en CLI)
- [ ] CI passe (lint + tests + alembic migration + branch-name)
- [ ] Après merge develop : auto-deploy EC2 + curl preview/execute avec auth admin
- [ ] FE PR séparée consommera les endpoints

## Plan-and-confirm cycle 3 depth=5

Plan B retenu vs Plan A (CSV, ~2j Type A only) et Plan C (full Critic ambitious 5-7j). Devil's Advocate « ship nothing » écarté car deadline juin 2026 est déclarée pour onboarder les écoles pilotes en mai-juin.