### PR TITLE
chore(pdf): lazy-import weasyprint to unblock Windows local dev

### DIFF
--- a/app/services/pdf_service.py
+++ b/app/services/pdf_service.py
@@ -1,4 +1,10 @@
-"""Service PDF — generation de bulletins, PV de conseil et reçus de paiement."""
+"""Service PDF — generation de bulletins, PV de conseil et reçus de paiement.
+
+WeasyPrint est importé paresseusement (à l'intérieur de chaque fonction qui
+l'utilise) pour permettre au BE de booter sur Windows sans GTK installé. Les
+endpoints PDF crashent à l'appel et non au boot, ce qui est acceptable car
+en dev local on a rarement besoin des PDF.
+"""
 
 from __future__ import annotations
 
@@ -6,8 +12,6 @@ import logging
 from datetime import datetime
 from decimal import Decimal
 from typing import Any
-
-from weasyprint import HTML
 
 logger = logging.getLogger(__name__)
 
@@ -199,6 +203,8 @@ def generate_bulletin_pdf(bulletin_data: dict[str, Any], school_settings: dict[s
     </html>
     """
 
+    from weasyprint import HTML  # lazy import — see module docstring
+
     return HTML(string=html).write_pdf()
 
 
@@ -366,6 +372,8 @@ def generate_council_minutes_pdf(
     </html>
     """
 
+    from weasyprint import HTML  # lazy import — see module docstring
+
     return HTML(string=html).write_pdf()
 
 
@@ -486,6 +494,8 @@ def generate_receipt_pdf(payment_data: dict[str, Any], school_settings: dict[str
     </body>
     </html>
     """
+
+    from weasyprint import HTML  # lazy import — see module docstring
 
     return HTML(string=html).write_pdf()
 
@@ -665,5 +675,7 @@ def generate_timetable_pdf(
     </body>
     </html>
     """
+
+    from weasyprint import HTML  # lazy import — see module docstring
 
     return HTML(string=html).write_pdf()


### PR DESCRIPTION
## Pourquoi

Sur Windows, `from weasyprint import HTML` au top de `pdf_service.py` échoue parce que les libs GTK (gobject-2.0-0 / cairo / pango) ne sont pas installées par défaut. Conséquence : impossible de booter le BE en local Windows pour faire un /visual-check.

## Ce que ça change

- Suppression de l'import top-level `from weasyprint import HTML` dans `app/services/pdf_service.py`
- Ajout d'un import paresseux `from weasyprint import HTML` à l'intérieur de chaque fonction qui l'utilise (4 occurrences : bulletin, council, receipt, timetable)

## Impact utilisateur

Aucun. Le comportement des endpoints PDF est strictement identique en prod (Linux, GTK installé). En cas d'absence de GTK, la 1ère requête PDF crashe au lieu du boot — préférable car endpoints rares en dev local.

## Why no CHANGELOG

Pure chore d'ergonomie dev — « si la ligne ne dit pas ce que l'utilisateur peut faire de plus/mieux/différemment, elle n'a pas sa place » (cf. rules/changelog.md). Label `skip-changelog` posé.