### PR TITLE
fix(reports,enrollment): silent `not <Column>` bugs in publish_bulletins + optional fees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Publication des bulletins : la mise à `publié` ne s'appliquait à aucune ligne (les notifications aux parents n'étaient jamais envoyées). Bug silencieux d'un `not` Python évalué au chargement du module au lieu d'un filtre SQL (#101).
+- Frais optionnels (cantine, transport, activités) qui n'étaient jamais récupérés automatiquement à l'inscription d'un élève : seuls les frais obligatoires apparaissaient. Même bug `not` Python sur la colonne SQLAlchemy *(admin)* (#101).
 - Fiche élève, création, modification et upload de photo qui renvoyaient « Connexion au serveur impossible » depuis l'enrichissement de la liste : restaurés en eager-loadant l'inscription année courante au chargement d'un élève *(admin)*.
 - Création d'évaluation qui échouait silencieusement avec « Erreur serveur » : l'audit serveur sait désormais sérialiser correctement la date *(admin, enseignant)* (#76).
 - Permissions de gestion des rôles, des salles et des séries désormais seedées par défaut. Auparavant, les pages correspondantes côté portail étaient inaccessibles en silence (#73).

--- a/app/services/enrollment_service.py
+++ b/app/services/enrollment_service.py
@@ -794,7 +794,7 @@ async def get_applicable_fee_variants(
                 ),
                 # Optional: match academic_year, level NULL (global) or matching
                 and_(
-                    not FeeCategory.is_mandatory,
+                    FeeCategory.is_mandatory.is_(False),
                     FeeVariant.academic_year_id == academic_year_id,
                     level_condition,
                     series_condition,

--- a/app/services/reports_service.py
+++ b/app/services/reports_service.py
@@ -403,7 +403,7 @@ async def publish_bulletins(
             Bulletin.class_id == class_id,
             Bulletin.trimester == trimester,
             Bulletin.academic_year_id == academic_year_id,
-            not Bulletin.is_published,
+            Bulletin.is_published.is_(False),
         )
         .values(is_published=True)
     )


### PR DESCRIPTION
## Summary

- 🐛 **2 bugs silencieux identifiés par audit grep** lors du planning ultrathink Documents Admin : pattern Python `not` sur colonne SQLAlchemy évalué au module load → `WHERE False` constant au runtime.
- 🩹 Fix surgical : `Column.is_(False)` à la place de `not Column` aux 2 endroits.
- ✅ Atomic, BE only, low-risk : 3 fichiers, +4/-2 lignes.

## Bugs fixés

### `reports_service.py:406` — `publish_bulletins`

\`\`\`python
# Avant
.where(
    Bulletin.class_id == class_id,
    Bulletin.trimester == trimester,
    Bulletin.academic_year_id == academic_year_id,
    not Bulletin.is_published,  # 🐛 Python not → False constant
)
# Après
    Bulletin.is_published.is_(False),
\`\`\`

**Impact prod** : `publish_bulletins()` retournait toujours `count=0`. Aucun bulletin n'était publié. Aucun parent jamais notifié de la disponibilité d'un nouveau bulletin.

### `enrollment_service.py:797` — `_get_mandatory_fee_variants`

\`\`\`python
or_(
    and_(FeeCategory.is_mandatory, ...),       # mandatory branch ✓
    and_(not FeeCategory.is_mandatory, ...),   # 🐛 optional branch never matches
)
# Après : FeeCategory.is_mandatory.is_(False)
\`\`\`

**Impact prod** : à l'inscription d'un élève, seuls les frais obligatoires étaient auto-récupérés. Les frais optionnels (cantine, transport, activités) ne remontaient jamais. L'admin devait les ajouter manuellement à chaque inscription.

## Test plan

- [ ] CI : pytest BE complet vert (focus `tests/services/test_enrollment_validate.py`)
- [ ] Manuel post-deploy : créer un bulletin, appeler `POST /reports/bulletins/publish`, vérifier rowcount > 0 dans la réponse + notifications dispatched
- [ ] Manuel post-deploy : enroll un nouvel étudiant dans une classe avec frais optionnels mappés, vérifier que les frais optionnels apparaissent dans les enrollment_fees créés

## Quality gate (pre-commit 4 axes)

| Axe | Verdict | Note |
|---|---|---|
| Architecture | PASS | Fix surgical, aucun impact archi |
| Quality vs Speed | WARN | Pas de test pytest ajouté (pytest indispo localement, fix trivial bien identifié, CI tournera) |
| Production-grade | PASS | Élimine 2 bugs silencieux en prod |
| SOLID | PASS | Aucun impact |

## Out of scope (PRs futurs Plan C Documents Admin)

- **PR #2** : Cleanup Celery Puppeteer orphelin (`tasks/grades_tasks.py` DELETE, refactor `grades_service.py`, drop bulletin endpoints `routers/grades.py`) + Phase 0 FE fix `dren.ts` PDF/Excel URLs + repointer FE `bulletins.ts:37` vers `/reports/bulletins/generate`. Nécessite coordination BE+FE.
- **PR #3** : Foundation BE settings + perms + PDF ABC refactor (Phase 2+3 Plan C)
- **PR #4** : Jinja2 template-from-DB par tenant (Phase 4 Plan C centerpiece)
- **PR #5** : QR code anti-fraude + certificat unifié (Phases 5+6 Plan C)
- **PR #6** : FE Documents UI complet + ship final (Phases 7+8+9 Plan C)

## Closes

Closes #101