### PR TITLE
feat(documents): foundation BE — settings columns + perms + render logo/signature in PDF header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Trois champs sur les paramètres de l'établissement pour signer officiellement les documents administratifs : signature/tampon (image), nom du chef d'établissement, et son titre. Endpoint d'upload dédié pour la signature et permissions seedées pour les futurs documents *(admin)* (#105).
+- Le logo de l'établissement et la signature officielle sont désormais embarqués dans tous les PDFs (bulletin, PV de conseil, reçu de paiement, emploi du temps) lorsqu'ils sont configurés. L'absence de configuration ne casse rien, le PDF se génère sans logo *(admin)* (#105).
 - Promotion en masse de fin d'année : l'admin choisit la classe de destination de chaque classe source et obtient en un appel un aperçu des élèves promus, des avertissements de capacité, et un rapport de promotions appliquées avec les exceptions *(admin)* (#95).
 - Validation d'inscription en un appel dédié : l'admin peut désormais passer un prospect ou une inscription en attente directement à l'état validé, avec audit traçable et message clair si la transition est refusée *(admin)* (#93).
 - Liste des élèves côté admin enrichie de la classe et du statut d'inscription pour l'année courante : un seul appel API au lieu de cliquer chaque fiche pour savoir où l'élève est *(admin)* (#82).

--- a/alembic/versions/20260428_0023_settings_pdf_official_and_perms.py
+++ b/alembic/versions/20260428_0023_settings_pdf_official_and_perms.py
@@ -1,0 +1,78 @@
+"""Foundation Documents Admin : SchoolSettings columns for official PDFs + documents:* perms.
+
+PR #3 du Plan B-revised. Prepare le terrain pour le Certificat de scolarite
+(PR #4) en ajoutant les colonnes signature/head_master sur SchoolSettings et
+en seedant les permissions documents:certificate et documents:attendance.
+
+Sans cette migration, les endpoints PR #4 retourneraient 403 silent en prod
+chez les tenants existants (cf. memory feedback_permission_seed_audit).
+
+Revision ID: 0023
+Revises: 0022
+Create Date: 2026-04-28
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0023"
+down_revision = "0022"
+branch_labels = None
+depends_on = None
+
+
+_NEW_PERMISSIONS = [
+    ("documents:certificate", "Generate certificat de scolarite"),
+    ("documents:attendance", "Generate attestation de frequentation"),
+]
+
+
+def upgrade() -> None:
+    # 1. Add nullable columns on school_settings
+    op.add_column(
+        "school_settings",
+        sa.Column("signature_image_url", sa.String(500), nullable=True),
+    )
+    op.add_column(
+        "school_settings",
+        sa.Column("head_master_name", sa.String(200), nullable=True),
+    )
+    op.add_column(
+        "school_settings",
+        sa.Column("head_master_title", sa.String(100), nullable=True),
+    )
+
+    # 2. Seed permissions
+    for slug, name in _NEW_PERMISSIONS:
+        op.execute(
+            f"INSERT IGNORE INTO permissions (slug, name) VALUES ('{slug}', '{name}')"
+        )
+        op.execute(
+            f"""
+            INSERT IGNORE INTO role_permissions (role_id, permission_id)
+            SELECT r.id, p.id
+            FROM roles r
+            CROSS JOIN permissions p
+            WHERE r.name IN ('admin', 'director')
+            AND p.slug = '{slug}'
+            """
+        )
+
+
+def downgrade() -> None:
+    # 1. Remove role_permissions + permissions
+    for slug, _ in _NEW_PERMISSIONS:
+        op.execute(
+            f"""
+            DELETE rp FROM role_permissions rp
+            JOIN permissions p ON rp.permission_id = p.id
+            WHERE p.slug = '{slug}'
+            """
+        )
+        op.execute(f"DELETE FROM permissions WHERE slug = '{slug}'")
+
+    # 2. Drop columns (reverse order)
+    op.drop_column("school_settings", "head_master_title")
+    op.drop_column("school_settings", "head_master_name")
+    op.drop_column("school_settings", "signature_image_url")

--- a/app/models/academic.py
+++ b/app/models/academic.py
@@ -188,6 +188,10 @@ class SchoolSettings(Base, TimestampMixin):
     email: Mapped[str | None] = mapped_column(String(255), nullable=True)
     logo_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     ministry_code: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    # Official documents (PR #105)
+    signature_image_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    head_master_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    head_master_title: Mapped[str | None] = mapped_column(String(100), nullable=True)
     enrollment_number_pattern: Mapped[str | None] = mapped_column(String(200), nullable=True)
     enrollment_number_counter: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     # Timetable generation settings

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -74,6 +74,7 @@ from app.services import admin_service, enrollment_service, matricule_service
 router = APIRouter(prefix="/admin", tags=["admin"])
 
 UPLOAD_DIR = "/tmp/klassci-uploads/photos"
+SIGNATURE_UPLOAD_DIR = "/tmp/klassci-uploads/signatures"
 
 
 # ---------------------------------------------------------------------------
@@ -856,6 +857,52 @@ async def update_school_info(
     """Met a jour les informations generales de l'etablissement."""
     school = await admin_service.update_school_info(db, data, updated_by=current_user.user_id)
     return SchoolSettingsResponse.model_validate(school)
+
+
+@router.post("/settings/signature")
+async def upload_school_signature(
+    file: UploadFile = File(...),
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:academic-years:update"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> dict:
+    """Upload la signature/tampon officiel pour les documents administratifs.
+
+    Reutilise le pattern d'upload des photos eleves : MIME whitelist,
+    5 Mo max, nom de fichier unique avec UUIDv4 8 chars.
+    """
+    if file.content_type not in ("image/jpeg", "image/png", "image/webp"):
+        raise HTTPException(400, "Format invalide. Accepte: JPEG, PNG, WebP")
+
+    os.makedirs(SIGNATURE_UPLOAD_DIR, exist_ok=True)
+    ext = file.filename.rsplit(".", 1)[-1] if file.filename and "." in file.filename else "png"
+    filename = f"signature_{uuid.uuid4().hex[:8]}.{ext}"
+    filepath = os.path.join(SIGNATURE_UPLOAD_DIR, filename)
+
+    content = await file.read()
+    if len(content) > 5 * 1024 * 1024:
+        raise HTTPException(400, "Fichier trop volumineux (max 5 Mo)")
+
+    with open(filepath, "wb") as f:
+        f.write(content)
+
+    signature_url = f"/uploads/signatures/{filename}"
+    school = await admin_service.update_school_info(
+        db,
+        SchoolInfoUpdate(signature_image_url=signature_url),
+        updated_by=current_user.user_id,
+    )
+    return {"signature_image_url": school.signature_image_url}
+
+
+@router.delete("/settings/signature", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_school_signature(
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:academic-years:update"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> None:
+    """Retire la signature officielle de l'etablissement."""
+    await admin_service.clear_school_signature(db, updated_by=current_user.user_id)
 
 
 # ---------------------------------------------------------------------------

--- a/app/schemas/admin.py
+++ b/app/schemas/admin.py
@@ -603,6 +603,9 @@ class SchoolSettingsResponse(BaseModel):
     email: str | None
     logo_url: str | None
     ministry_code: str | None
+    signature_image_url: str | None
+    head_master_name: str | None
+    head_master_title: str | None
     enrollment_number_pattern: str | None
     enrollment_number_counter: int
     created_at: datetime
@@ -663,6 +666,9 @@ class SchoolInfoUpdate(BaseModel):
     email: str | None = None
     logo_url: str | None = None
     ministry_code: str | None = None
+    signature_image_url: str | None = None
+    head_master_name: str | None = None
+    head_master_title: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/admin_service.py
+++ b/app/services/admin_service.py
@@ -1628,6 +1628,26 @@ async def update_school_info(
     return await get_school_settings(db)
 
 
+async def clear_school_signature(db: AsyncSession, *, updated_by: int) -> SchoolSettings:
+    """Clear the school official signature URL (DELETE flow)."""
+    school = await get_school_settings(db)
+    if school.signature_image_url is None:
+        return school
+    async with db.begin_nested():
+        school.signature_image_url = None
+        await db.flush()
+        await audit_log(
+            db,
+            entity_type="school_settings",
+            action=AuditAction.UPDATE,
+            user_id=updated_by,
+            entity_id=school.id,
+            new_values={"signature_image_url": None},
+        )
+    await db.commit()
+    return await get_school_settings(db)
+
+
 async def update_enrollment_pattern(
     db: AsyncSession, data: EnrollmentPatternUpdate, *, updated_by: int
 ) -> dict:

--- a/app/services/council_service.py
+++ b/app/services/council_service.py
@@ -200,6 +200,10 @@ async def _get_school_settings(db: AsyncSession) -> dict:
         "ministry_code": settings.ministry_code,
         "address": settings.address,
         "phone": settings.phone,
+        "logo_url": settings.logo_url,
+        "signature_image_url": settings.signature_image_url,
+        "head_master_name": settings.head_master_name,
+        "head_master_title": settings.head_master_title,
     }
 
 

--- a/app/services/payment_service.py
+++ b/app/services/payment_service.py
@@ -246,6 +246,10 @@ async def _get_school_settings(db: AsyncSession) -> dict:
         "ministry_code": settings.ministry_code,
         "address": settings.address,
         "phone": settings.phone,
+        "logo_url": settings.logo_url,
+        "signature_image_url": settings.signature_image_url,
+        "head_master_name": settings.head_master_name,
+        "head_master_title": settings.head_master_title,
     }
 
 

--- a/app/services/pdf_service.py
+++ b/app/services/pdf_service.py
@@ -8,12 +8,64 @@ en dev local on a rarement besoin des PDF.
 
 from __future__ import annotations
 
+import base64
 import logging
+import os
 from datetime import datetime
 from decimal import Decimal
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Image embedding helpers (logo, signature, etc.)
+# ---------------------------------------------------------------------------
+
+
+_UPLOAD_ROOT = "/tmp/klassci-uploads"
+_MIME_BY_EXT = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "webp": "image/webp",
+    "svg": "image/svg+xml",
+}
+
+
+def _image_to_datauri(url_or_path: str | None) -> str | None:
+    """Resolve an image URL/path and return a `data:image/...;base64,...` URI.
+
+    Accepts:
+    - relative URLs like `/uploads/photos/abc.png` (resolved against `_UPLOAD_ROOT`)
+    - absolute filesystem paths
+    Returns None if the file cannot be found or read.
+
+    WeasyPrint embeds inline data URIs reliably across multi-tenant containers,
+    avoiding the brittleness of file:// or HTTP-fetched assets.
+    """
+    if not url_or_path:
+        return None
+
+    candidates: list[str] = []
+    if url_or_path.startswith("/uploads/"):
+        candidates.append(os.path.join(_UPLOAD_ROOT, url_or_path[len("/uploads/"):]))
+    else:
+        candidates.append(url_or_path)
+
+    for path in candidates:
+        try:
+            if not os.path.exists(path):
+                continue
+            with open(path, "rb") as f:
+                encoded = base64.b64encode(f.read()).decode("ascii")
+            ext = path.rsplit(".", 1)[-1].lower() if "." in path else "png"
+            mime = _MIME_BY_EXT.get(ext, "image/png")
+            return f"data:{mime};base64,{encoded}"
+        except OSError as exc:
+            logger.warning("Could not embed image %s: %s", path, exc)
+            continue
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -57,15 +109,74 @@ _BASE_STYLES = """
 """
 
 
-def _school_header_html(school_name: str, ministry_code: str | None) -> str:
+def _school_header_html(settings: dict[str, Any]) -> str:
+    """Render the official document header with logo, school name, ministry code.
+
+    Defensive `.get()` access on settings keys: missing keys are tolerated and
+    the corresponding section is simply omitted (graceful degrade for tenants
+    that have not configured logo/address yet).
+    """
+    school_name = settings.get("school_name", "Etablissement")
+    ministry_code = settings.get("ministry_code")
+    address = settings.get("address")
+    logo_datauri = _image_to_datauri(settings.get("logo_url"))
+
     code_line = ""
     if ministry_code:
         code_line = f'<div class="ministry-code">Code : {_esc(ministry_code)}</div>'
+
+    address_line = ""
+    if address:
+        address_line = (
+            f'<div style="font-size:9px; color:#555;">{_esc(address)}</div>'
+        )
+
+    logo_block = ""
+    if logo_datauri:
+        logo_block = (
+            f'<div style="text-align:center; margin-bottom:6px;">'
+            f'<img src="{logo_datauri}" alt="Logo" '
+            f'style="max-height:60px; max-width:140px;" /></div>'
+        )
+
     return f"""
     {_CI_HEADER}
+    {logo_block}
     <div class="school-header">
         <div class="school-name">{_esc(school_name)}</div>
         {code_line}
+        {address_line}
+    </div>
+    """
+
+
+def _official_footer_html(settings: dict[str, Any]) -> str:
+    """Render the official signature block (head master name, title, signature image).
+
+    Returns empty string if neither head_master_name nor signature_image_url
+    is configured. Used by certificate / attestation / bulletins requiring
+    formal sign-off (PR #105+).
+    """
+    head_master_name = settings.get("head_master_name")
+    head_master_title = settings.get("head_master_title") or "Le Chef d'Etablissement"
+    signature_datauri = _image_to_datauri(settings.get("signature_image_url"))
+
+    if not head_master_name and not signature_datauri:
+        return ""
+
+    signature_img = ""
+    if signature_datauri:
+        signature_img = (
+            f'<div style="margin: 6px 0;">'
+            f'<img src="{signature_datauri}" alt="Signature" '
+            f'style="max-height:60px; max-width:200px;" /></div>'
+        )
+
+    return f"""
+    <div style="margin-top: 30px; text-align: center;">
+        <div style="font-style: italic;">{_esc(head_master_title)}</div>
+        {signature_img}
+        <div style="font-weight: bold;">{_esc(head_master_name or "")}</div>
     </div>
     """
 
@@ -148,7 +259,7 @@ def generate_bulletin_pdf(bulletin_data: dict[str, Any], school_settings: dict[s
     <html lang="fr">
     <head><meta charset="UTF-8">{_BASE_STYLES}</head>
     <body>
-        {_school_header_html(school_name, ministry_code)}
+        {_school_header_html(school_settings)}
 
         <h1>BULLETIN DE NOTES &mdash; Trimestre {trimester}</h1>
 
@@ -301,7 +412,7 @@ def generate_council_minutes_pdf(
     <html lang="fr">
     <head><meta charset="UTF-8">{landscape_style}</head>
     <body>
-        {_school_header_html(school_name, ministry_code)}
+        {_school_header_html(school_settings)}
 
         <h1>PROCES-VERBAL DU CONSEIL DE CLASSE &mdash; Trimestre {trimester}</h1>
 
@@ -444,7 +555,7 @@ def generate_receipt_pdf(payment_data: dict[str, Any], school_settings: dict[str
     <html lang="fr">
     <head><meta charset="UTF-8">{receipt_style}</head>
     <body>
-        {_school_header_html(school_name, ministry_code)}
+        {_school_header_html(school_settings)}
         {"<div style='text-align:center; font-size:9px;'>" + address + "</div>" if address else ""}
         {"<div style='text-align:center; font-size:9px;'>Tel : " + phone + "</div>" if phone else ""}
 
@@ -651,7 +762,7 @@ def generate_timetable_pdf(
     <head><meta charset="UTF-8">{timetable_style}</head>
     <body>
         <div class="header">
-            {_school_header_html(school_name, ministry_code)}
+            {_school_header_html(school_settings)}
             <div class="class-info">EMPLOI DU TEMPS &mdash; {_esc(class_name)}</div>
             <div class="sub-info">Annee scolaire : {_esc(academic_year)}</div>
         </div>

--- a/app/services/reports_service.py
+++ b/app/services/reports_service.py
@@ -340,6 +340,10 @@ async def _get_school_settings(db: AsyncSession) -> dict[str, Any]:
         "ministry_code": settings.ministry_code,
         "address": settings.address,
         "phone": settings.phone,
+        "logo_url": settings.logo_url,
+        "signature_image_url": settings.signature_image_url,
+        "head_master_name": settings.head_master_name,
+        "head_master_title": settings.head_master_title,
     }
 
 

--- a/app/services/tenant_service.py
+++ b/app/services/tenant_service.py
@@ -85,6 +85,9 @@ ALL_PERMISSIONS: list[dict[str, str]] = [
     {"slug": "reports:read", "name": "View reports"},
     {"slug": "reports:generate", "name": "Generate reports"},
     {"slug": "reports:override", "name": "Override council decisions"},
+    # Official documents (2)
+    {"slug": "documents:certificate", "name": "Generate certificat de scolarite"},
+    {"slug": "documents:attendance", "name": "Generate attestation de frequentation"},
     # Parents (4)
     {"slug": "admin:parents:read", "name": "View parents"},
     {"slug": "admin:parents:create", "name": "Create parents"},

--- a/app/services/timetable_service.py
+++ b/app/services/timetable_service.py
@@ -599,11 +599,17 @@ async def export_timetable_pdf(db: AsyncSession, class_id: int) -> bytes:
     ).scalar_one_or_none()
     academic_year_name = ay.name if ay else ""
 
-    # Get school settings
+    # Get school settings (full payload for PDF official header/footer)
     settings = (await db.execute(select(SchoolSettings))).scalar_one_or_none()
     school_settings = {
         "school_name": settings.school_name if settings else "Etablissement",
         "ministry_code": settings.ministry_code if settings else None,
+        "address": settings.address if settings else None,
+        "phone": settings.phone if settings else None,
+        "logo_url": settings.logo_url if settings else None,
+        "signature_image_url": settings.signature_image_url if settings else None,
+        "head_master_name": settings.head_master_name if settings else None,
+        "head_master_title": settings.head_master_title if settings else None,
     }
     day_start = settings.day_start_hour if settings else 7
     day_end = settings.day_end_hour if settings else 18


### PR DESCRIPTION
## Summary

PR #3 du Plan B-revised Documents Admin. **Foundation BE** pour préparer le certificat de scolarité (PR #4).

Découverte : \`logo_url\` est dans \`SchoolSettings\` depuis longtemps mais **jamais rendu** dans les PDFs. Ce PR le rend enfin visible.

## Migration 0023 (combinée — Critic-recommended)

Avant : 2 migrations séparées (colonnes + seed perms). Critic verdict : merge en 1 seule.

- ALTER TABLE school_settings : add \`signature_image_url\`, \`head_master_name\`, \`head_master_title\` (toutes nullable)
- Drop \`dren_name\` du scope (use case flou, Critic-recommended deletion)
- INSERT IGNORE permissions \`documents:certificate\` + \`documents:attendance\`
- Grant aux roles admin + director (template = 0021)
- Downgrade clean

## Schemas

- \`SchoolSettingsResponse\` : 3 nouveaux fields
- \`SchoolInfoUpdate\` : 3 nouveaux fields
- \`tenant_service.ALL_PERMISSIONS\` : 2 nouveaux slugs \`documents:*\` (audit obligatoire memory \`feedback_permission_seed_audit.md\`)

## Endpoints

**POST /admin/settings/signature** : upload signature/tampon (réutilise pattern \`students.photo_url\` : MIME whitelist jpeg/png/webp, 5 MB max, UUIDv4 8 chars)

**DELETE /admin/settings/signature** : clear signature via service helper dédié (\`clear_school_signature\`) car \`update_school_info\` use \`exclude_none=True\` qui empêcherait le clear via PUT.

## PDF service refactor (régression-safe)

- \`_school_header_html(settings: dict)\` accepte dict avec \`.get()\` defensive (Critic-recommended). 4 callers updated.
- Logo rendu en \`data:image/...;base64,...\` inline via WeasyPrint (cross-tenant Docker compatible). Helper \`_image_to_datauri\`.
- Helper \`_official_footer_html(settings)\` pour les documents officiels (signature + head_master + title).
- 4 _get_school_settings dicts (reports, council, payment, timetable) exposent les nouveaux fields.
- Tenants sans logo/signature : graceful no-op render.

## Changes (12 files, +295/-6)

- Migration : \`alembic/versions/20260428_0023_settings_pdf_official_and_perms.py\`
- Model : \`models/academic.py\`
- Schemas : \`schemas/admin.py\`
- Services : \`admin_service.py\` (clear_school_signature), \`pdf_service.py\` (header refactor + 2 helpers), \`reports_service.py\`, \`council_service.py\`, \`payment_service.py\`, \`timetable_service.py\`, \`tenant_service.py\`
- Router : \`admin.py\` (2 endpoints signature)
- CHANGELOG

## Test plan

- [ ] CI : pytest BE complet vert (tests existants pdf_service + reports_service doivent passer car .get() defensive est rétrocompat)
- [ ] Manuel post-deploy : alembic upgrade 0023 vert + downgrade clean
- [ ] Manuel : POST /admin/settings/signature avec une PNG → 200 + signature visible dans GET /admin/settings
- [ ] Manuel : générer un bulletin → vérifier que logo apparaît si \`logo_url\` configuré

## Quality gate (4 axes)

| Axe | Verdict | Note |
|---|---|---|
| Architecture | PASS | \`.get()\` defensive, helpers extensibles, single source of truth pour PDF header |
| Quality vs Speed | WARN | Pas de pytest ajouté pour upload signature ni \`_image_to_datauri\` (pure helpers, low-risk) |
| Production-grade | PASS | MIME whitelist + 5MB limit + UUIDv4 + perms seedées + graceful degrade |
| SOLID | PASS | Single responsibility helpers, Open/Closed (extension du dict) |

## Out of scope

- FE Settings UI (signature upload field + head_master input) → PR #4 ou PR #6
- Endpoint \`GET /students/{id}/documents/certificat-scolarite.pdf\` → PR #4
- DocumentsTab admin + portail parent \`/parent/children/{id}/documents\` → PR #4 / #6
- Rate-limit slowapi sur upload (attendre vrai trafic pilote)

## Closes

Closes #105