### PR TITLE
feat(documents): certificat de scolarite endpoint + PDF template (BE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- **Certificat de scolarité officiel** : l'admin (et le parent en self-service) peut télécharger un PDF République de Côte d'Ivoire signé par le chef d'établissement, avec corps formel "Le soussigné certifie que [élève], né(e) le ... à ..., est régulièrement inscrit(e) en classe de [...] au titre de l'année scolaire [...]". Endpoint `GET /students/{id}/documents/certificat-scolarite.pdf` avec garde d'accès parent (lien parent_student) et étudiant (compte propre) *(admin, parent, élève)* (#107).
 - Trois champs sur les paramètres de l'établissement pour signer officiellement les documents administratifs : signature/tampon (image), nom du chef d'établissement, et son titre. Endpoint d'upload dédié pour la signature et permissions seedées pour les futurs documents *(admin)* (#105).
 - Le logo de l'établissement et la signature officielle sont désormais embarqués dans tous les PDFs (bulletin, PV de conseil, reçu de paiement, emploi du temps) lorsqu'ils sont configurés. L'absence de configuration ne casse rien, le PDF se génère sans logo *(admin)* (#105).
 - Promotion en masse de fin d'année : l'admin choisit la classe de destination de chaque classe source et obtient en un appel un aperçu des élèves promus, des avertissements de capacité, et un rapport de promotions appliquées avec les exceptions *(admin)* (#95).

--- a/app/main.py
+++ b/app/main.py
@@ -27,6 +27,7 @@ from app.routers.parent_portal import router as parent_portal_router
 from app.routers.payments import router as payments_router
 from app.routers.promotions import router as promotions_router
 from app.routers.reports import router as reports_router
+from app.routers.student_documents import router as student_documents_router
 from app.routers.student_portal import router as student_portal_router
 from app.routers.super_admin import router as super_admin_router
 from app.routers.teacher_portal import router as teacher_portal_router
@@ -81,6 +82,7 @@ app.include_router(student_portal_router)
 app.include_router(parent_portal_router)
 app.include_router(teacher_portal_router)
 app.include_router(reports_router)
+app.include_router(student_documents_router)
 app.include_router(council_router)
 app.include_router(dren_stats_router)
 app.include_router(super_admin_router)

--- a/app/routers/student_documents.py
+++ b/app/routers/student_documents.py
@@ -1,0 +1,50 @@
+"""Router student_documents — documents officiels par eleve (certificat, attestation, ...)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db
+from app.services import student_documents_service
+from app.services.pdf_service import generate_certificate_scolarite_pdf
+
+router = APIRouter(prefix="/students", tags=["student-documents"])
+
+
+@router.get("/{student_id}/documents/certificat-scolarite.pdf")
+async def get_certificat_scolarite(
+    student_id: int,
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> Response:
+    """Genere le certificat de scolarite officiel d'un eleve.
+
+    Permission scoping :
+    - admin / staff / teacher : doit avoir la permission ``documents:certificate``
+    - parent : doit etre lie a l'eleve (via parent_student)
+    - student : ne peut acceder qu'a son propre certificat
+
+    Renvoie 422 si l'eleve n'a pas d'inscription valide pour l'annee courante.
+    """
+    await student_documents_service.verify_document_access(
+        db,
+        current_user_id=current_user.user_id,
+        student_id=student_id,
+        permission_slug="documents:certificate",
+    )
+
+    data = await student_documents_service.compose_certificate_data(db, student_id)
+    settings = await student_documents_service._get_school_settings_dict(db)
+    pdf_bytes = generate_certificate_scolarite_pdf(data, settings)
+
+    last_name = data["student"]["last_name"]
+    safe_year = data["academic_year_name"].replace(" ", "_").replace("/", "-")
+    filename = f"certificat_scolarite_{last_name}_{safe_year}.pdf"
+
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'inline; filename="{filename}"'},
+    )

--- a/app/services/pdf_service.py
+++ b/app/services/pdf_service.py
@@ -790,3 +790,92 @@ def generate_timetable_pdf(
     from weasyprint import HTML  # lazy import — see module docstring
 
     return HTML(string=html).write_pdf()
+
+
+# ---------------------------------------------------------------------------
+# Certificat de scolarite PDF
+# ---------------------------------------------------------------------------
+
+
+def generate_certificate_scolarite_pdf(
+    data: dict[str, Any], school_settings: dict[str, Any]
+) -> bytes:
+    """Generate the official certificat de scolarite PDF.
+
+    data keys (from student_documents_service.compose_certificate_data):
+        student: dict with first_name, last_name, birth_date, genre,
+                 enrollment_number, city, commune
+        class_name: str
+        academic_year_name: str
+        issued_at: datetime
+
+    school_settings: full settings dict (logo_url, signature_image_url,
+    head_master_name, head_master_title) — see PR #105.
+    """
+    from weasyprint import HTML  # lazy import — see module docstring
+
+    student = data.get("student", {}) or {}
+    first_name = _esc(student.get("first_name", ""))
+    last_name = _esc(student.get("last_name", ""))
+    full_name = f"{first_name} {last_name}".strip()
+    birth_date = student.get("birth_date")
+    birth_date_str = birth_date.strftime("%d/%m/%Y") if birth_date else "..."
+    genre = student.get("genre")
+    matricule = _esc(student.get("enrollment_number") or "...")
+    # Lieu de naissance : on n'a pas de champ dédié (#107 out of scope), on
+    # utilise la ville comme proxy. Si tenant pilote demande, ajouter un
+    # champ Student.birthplace dans une migration ultérieure.
+    birthplace = _esc(student.get("city") or student.get("commune") or "...")
+
+    class_name = _esc(data.get("class_name") or "")
+    academic_year_name = _esc(data.get("academic_year_name") or "")
+    issued_at = data.get("issued_at") or datetime.utcnow()
+    issued_str = issued_at.strftime("%d/%m/%Y") if isinstance(issued_at, datetime) else ""
+
+    # Forme grammaticale : "ne le ... a ..." vs "nee le ... a ..."
+    ne_form = "née" if genre == "F" else "né"
+    inscrit_form = "inscrite" if genre == "F" else "inscrit"
+
+    head_master_name = school_settings.get("head_master_name") or "Le Chef d'Établissement"
+    head_master_title = (
+        school_settings.get("head_master_title") or "Le Chef d'Établissement"
+    )
+
+    body_paragraph = (
+        f"<p>Je soussigné(e), <strong>{_esc(head_master_name)}</strong>, "
+        f"{_esc(head_master_title)}, certifie que :</p>"
+        f"<p style='text-align:center; font-size:13px; margin: 14px 0;'>"
+        f"<strong>{full_name}</strong></p>"
+        f"<p>{ne_form} le <strong>{birth_date_str}</strong> à <strong>{birthplace}</strong>, "
+        f"matricule <strong>{matricule}</strong>, est régulièrement {inscrit_form} "
+        f"en classe de <strong>{class_name}</strong> au titre de l'année scolaire "
+        f"<strong>{academic_year_name}</strong>.</p>"
+        f"<p>En foi de quoi, le présent certificat lui est délivré pour servir et valoir "
+        f"ce que de droit.</p>"
+    )
+
+    html = f"""
+    <!DOCTYPE html>
+    <html lang="fr">
+    <head><meta charset="UTF-8">{_BASE_STYLES}</head>
+    <body>
+        {_school_header_html(school_settings)}
+
+        <h1 style="text-align:center; margin: 18px 0 10px 0; letter-spacing:2px;">
+            CERTIFICAT DE SCOLARITÉ
+        </h1>
+
+        <div style="line-height: 1.7; font-size: 12px; margin: 12px 0;">
+            {body_paragraph}
+        </div>
+
+        <div style="margin-top: 24px; text-align: right;">
+            Fait le {_esc(issued_str)}
+        </div>
+
+        {_official_footer_html(school_settings)}
+    </body>
+    </html>
+    """
+
+    return HTML(string=html).write_pdf()

--- a/app/services/student_documents_service.py
+++ b/app/services/student_documents_service.py
@@ -1,0 +1,165 @@
+"""Service for official student documents.
+
+Composes data and dispatches access guards for documents like the certificat
+de scolarite. PDF rendering itself lives in pdf_service for cohesion.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.core.exceptions import (
+    BusinessValidationError,
+    NotFoundError,
+    PermissionDeniedError,
+    UnauthorizedError,
+)
+from app.models.academic import SchoolSettings
+from app.models.enrollment import Enrollment
+from app.models.user import Student, User, UserRoleEnum
+from app.services import parent_portal_service
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+async def _get_school_settings_dict(db: AsyncSession) -> dict[str, Any]:
+    """Read SchoolSettings as full dict for official documents (logo + signature)."""
+    settings = (await db.execute(select(SchoolSettings).limit(1))).scalar_one_or_none()
+    if settings is None:
+        return {"school_name": "Etablissement"}
+    return {
+        "school_name": settings.school_name,
+        "ministry_code": settings.ministry_code,
+        "address": settings.address,
+        "phone": settings.phone,
+        "email": settings.email,
+        "logo_url": settings.logo_url,
+        "signature_image_url": settings.signature_image_url,
+        "head_master_name": settings.head_master_name,
+        "head_master_title": settings.head_master_title,
+    }
+
+
+async def _get_active_enrollment(db: AsyncSession, student_id: int) -> Enrollment:
+    """Return the student's currently active (status=valide) enrollment.
+
+    Raises BusinessValidationError (422) if none found, with a French message
+    that an admin can show as-is to a parent at the desk.
+    """
+    stmt = (
+        select(Enrollment)
+        .where(Enrollment.student_id == student_id, Enrollment.status == "valide")
+        .options(
+            selectinload(Enrollment.class_),
+            selectinload(Enrollment.academic_year),
+        )
+        .order_by(Enrollment.created_at.desc())
+        .limit(1)
+    )
+    enrollment = (await db.execute(stmt)).scalar_one_or_none()
+    if enrollment is None:
+        raise BusinessValidationError(
+            "Aucune inscription valide trouvée pour cet élève. "
+            "Vérifiez que l'élève est inscrit à l'année scolaire courante."
+        )
+    return enrollment
+
+
+async def verify_document_access(
+    db: AsyncSession,
+    *,
+    current_user_id: int,
+    student_id: int,
+    permission_slug: str,
+) -> None:
+    """Hybrid access guard for student documents.
+
+    - Admin/director/staff/teacher : require the explicit permission slug
+      (e.g. ``documents:certificate``). This honors role-permission matrix
+      customization per tenant.
+    - Parent : must have a valid parent_student link to the requested student.
+      The permission slug is **not** required for parents (they always have
+      legitimate access to their own children's official documents).
+    - Student : must be the very student requested.
+
+    Raises ``PermissionDeniedError`` or ``UnauthorizedError`` when access is
+    not granted.
+    """
+    user = await db.get(User, current_user_id)
+    if user is None:
+        raise UnauthorizedError("User not found")
+
+    role = user.role.value if hasattr(user.role, "value") else str(user.role)
+
+    if role in (
+        UserRoleEnum.ADMIN.value,
+        UserRoleEnum.STAFF.value,
+        UserRoleEnum.TEACHER.value,
+    ):
+        # Permission-based: must hold the slug (matrix-driven).
+        from app.repositories.permission_repository import check_user_permission
+
+        if not await check_user_permission(db, current_user_id, permission_slug):
+            raise PermissionDeniedError(permission_slug)
+        return
+
+    if role == UserRoleEnum.PARENT.value:
+        parent = await parent_portal_service._get_parent_for_user(db, current_user_id)
+        await parent_portal_service._verify_child_access(db, parent.id, student_id)
+        return
+
+    if role == UserRoleEnum.STUDENT.value:
+        student = await db.get(Student, student_id)
+        if student is None or student.user_id != current_user_id:
+            raise PermissionDeniedError("not your document")
+        return
+
+    raise PermissionDeniedError(permission_slug)
+
+
+# ---------------------------------------------------------------------------
+# Document data composers
+# ---------------------------------------------------------------------------
+
+
+async def compose_certificate_data(
+    db: AsyncSession,
+    student_id: int,
+) -> dict[str, Any]:
+    """Compose data for the certificat de scolarite PDF.
+
+    Reads ``Student`` + active ``Enrollment`` + ``Class`` + ``AcademicYear``.
+    Raises ``NotFoundError`` if the student does not exist, or
+    ``BusinessValidationError`` (422) if no active enrollment is found.
+    """
+    student = await db.get(Student, student_id)
+    if student is None:
+        raise NotFoundError("Student", student_id)
+
+    enrollment = await _get_active_enrollment(db, student_id)
+
+    return {
+        "student": {
+            "first_name": student.first_name,
+            "last_name": student.last_name,
+            "birth_date": student.birth_date,
+            "genre": student.genre.value if student.genre else None,
+            "enrollment_number": student.enrollment_number,
+            "city": student.city,
+            "commune": student.commune,
+        },
+        "class_name": enrollment.class_.name if enrollment.class_ else "",
+        "academic_year_name": enrollment.academic_year.name if enrollment.academic_year else "",
+        "issued_at": datetime.utcnow(),
+    }

--- a/tests/routers/test_student_documents.py
+++ b/tests/routers/test_student_documents.py
@@ -1,0 +1,103 @@
+"""Tests for /students/{id}/documents/* endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.core.dependencies import TokenData, get_current_user, get_tenant_db
+from app.core.redis import get_redis
+from app.main import app
+
+
+MOCK_USER = TokenData(user_id=1, tenant_id="local", email="admin@college.ci")
+
+
+def _override_deps() -> None:
+    app.dependency_overrides[get_current_user] = lambda: MOCK_USER
+    app.dependency_overrides[get_tenant_db] = lambda: AsyncMock()
+    app.dependency_overrides[get_redis] = lambda: AsyncMock()
+
+
+def _clear_deps() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# GET /students/{id}/documents/certificat-scolarite.pdf
+# ---------------------------------------------------------------------------
+
+
+def test_get_certificat_no_auth() -> None:
+    """GET /students/1/documents/certificat-scolarite.pdf sans token → 401/403."""
+    _clear_deps()
+    with TestClient(app) as client:
+        resp = client.get("/students/1/documents/certificat-scolarite.pdf")
+    assert resp.status_code in (401, 403)
+
+
+def test_get_certificat_success() -> None:
+    """Admin avec permission → 200 + bytes PDF."""
+    _override_deps()
+    try:
+        with patch(
+            "app.services.student_documents_service.verify_document_access",
+            new=AsyncMock(return_value=None),
+        ), patch(
+            "app.services.student_documents_service.compose_certificate_data",
+            new=AsyncMock(
+                return_value={
+                    "student": {
+                        "first_name": "Aya",
+                        "last_name": "Koffi",
+                        "birth_date": None,
+                        "genre": "F",
+                        "enrollment_number": "2024-001",
+                        "city": "Abidjan",
+                        "commune": "Cocody",
+                    },
+                    "class_name": "6e A",
+                    "academic_year_name": "2025-2026",
+                    "issued_at": None,
+                }
+            ),
+        ), patch(
+            "app.services.student_documents_service._get_school_settings_dict",
+            new=AsyncMock(return_value={"school_name": "Ecole Test"}),
+        ), patch(
+            "app.routers.student_documents.generate_certificate_scolarite_pdf",
+            return_value=b"%PDF-1.4 fake bytes",
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/students/1/documents/certificat-scolarite.pdf")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "application/pdf"
+        assert "Koffi" in resp.headers["content-disposition"]
+    finally:
+        _clear_deps()
+
+
+def test_get_certificat_no_active_enrollment() -> None:
+    """Pas d'inscription valide → 422 message FR."""
+    from app.core.exceptions import BusinessValidationError
+
+    _override_deps()
+    try:
+        with patch(
+            "app.services.student_documents_service.verify_document_access",
+            new=AsyncMock(return_value=None),
+        ), patch(
+            "app.services.student_documents_service.compose_certificate_data",
+            new=AsyncMock(
+                side_effect=BusinessValidationError(
+                    "Aucune inscription valide trouvée pour cet élève."
+                )
+            ),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/students/1/documents/certificat-scolarite.pdf")
+        assert resp.status_code == 422
+        assert "inscription valide" in resp.text.lower() or "inscription" in resp.text.lower()
+    finally:
+        _clear_deps()


### PR DESCRIPTION
## Summary

PR #4 du Plan B-revised Documents Admin. **BE-only first customer-facing official document.**

⚠ Cette PR cible **\`feat/105-settings-pdf-foundation\`** (PR #106) comme base, pas develop. Une fois PR #106 mergée, cette PR sera automatiquement rebased sur develop.

## Why this PR exists

Mme Diallo persona daily : un parent vient au bureau vendredi soir demander un certificat de scolarité pour inscrire l'enfant ailleurs lundi. Aujourd'hui = papier manuscrit, ou rien. Demain = un click, PDF officiel signé.

## Architecture

### Service \`student_documents_service.py\` (NEW)

- \`compose_certificate_data(db, student_id)\` lit Student + active Enrollment + Class + AcademicYear + SchoolSettings. Raise BusinessValidationError 422 avec message FR si pas d'inscription valide ("Aucune inscription valide trouvée pour cet élève. Vérifiez que l'élève est inscrit à l'année scolaire courante.").
- \`verify_document_access\` : **hybrid access guard** (Critic-recommended depuis PR #3 brief) :
  - admin/staff/teacher → require_permission slug (matrix-driven)
  - parent → parent_student link verification (PAS de slug requis, parents toujours accès enfants)
  - student → user_id match (PAS de slug requis, propre certificat)
- \`_get_school_settings_dict\` réutilise les nouveaux fields PR #3.

### PDF template \`pdf_service.generate_certificate_scolarite_pdf\`

- En-tête République de Côte d'Ivoire + logo école + ministry_code (PR #3)
- Title \`CERTIFICAT DE SCOLARITÉ\`
- Corps formel avec accord grammatical né/née + inscrit/inscrite selon \`student.genre\`
- Footer signature officielle (PR #3 \`_official_footer_html\`)
- \`birth_place\` fallback sur \`student.city\` (pas de champ dédié — out of scope, ajouter migration si feedback pilote)

### Router \`student_documents.py\` (NEW)

- \`GET /students/{student_id}/documents/certificat-scolarite.pdf\`
- Verify access → compose data → render PDF → return inline + filename \`certificat_scolarite_NOM_2025-2026.pdf\`
- Monté dans main.py

## Tests

- 401/403 sans auth
- 200 + PDF bytes admin avec permission (service mocké, PDF rendering = b'%PDF-1.4...' fake)
- 422 message FR si pas d'inscription valide

## Test plan

- [ ] CI : pytest BE complet vert (en supposant PR #106 mergée first)
- [ ] Manuel post-deploy : configurer signature + head_master_name via PR #105 endpoint, puis générer un certificat → vérifier que logo + signature apparaissent
- [ ] Manuel : tenter accès parent à un autre enfant → 403
- [ ] Manuel : tenter accès student à un autre étudiant → 403
- [ ] Manuel : tenter accès sans inscription valide → 422 message FR

## Quality gate (4 axes)

| Axe | Verdict | Note |
|---|---|---|
| Architecture | PASS | Service composer + PDF renderer + router séparés (SRP), réutilise helpers PR #3, hybrid access guard extensible aux futurs documents |
| Quality vs Speed | PASS | Tests pytest pour les 3 cas critiques (auth, success, 422) |
| Production-grade | WARN | Pas de rate-limit slowapi (Critic-recommended initialement, deferred — attendre vrai trafic pilote pour tuner les seuils) |
| SOLID | PASS | Open/Closed : le pattern verify_document_access + compose_X_data se réplique pour attestation (PR #5) et autres docs futurs |

## Out of scope

- FE DocumentsTab admin + portail parent → PR #6
- Attestation de fréquentation → PR #5
- Champ \`birth_place\` dédié sur Student → migration ultérieure si feedback pilote
- Rate-limit slowapi → defer
- QR code anti-fraude → defer post-pilote

## Closes

Closes #107