### PR TITLE
fix(teachers): repair SubjectInstance ImportError in get_teacher_full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Fiche enseignant : la vue d'ensemble (nombre de classes, d'élèves, d'évaluations, heures par semaine) restait à zéro à cause d'une 500 silencieuse sur le profil enrichi. Tous les indicateurs s'affichent désormais correctement *(admin)* (#114).
 - Liste des bulletins (`GET /reports/bulletins`) qui renvoyait une 500 « Internal Server Error » à cause d'un `NULLS LAST` dans le tri par rang non supporté par MySQL. Remplacé par l'astuce portable `IS NULL` qui place les bulletins sans rang en queue *(admin)* (#113).
 - Publication des bulletins : la mise à `publié` ne s'appliquait à aucune ligne (les notifications aux parents n'étaient jamais envoyées). Bug silencieux d'un `not` Python évalué au chargement du module au lieu d'un filtre SQL (#101).
 - Frais optionnels (cantine, transport, activités) qui n'étaient jamais récupérés automatiquement à l'inscription d'un élève : seuls les frais obligatoires apparaissaient. Même bug `not` Python sur la colonne SQLAlchemy *(admin)* (#101).

--- a/app/services/admin_service.py
+++ b/app/services/admin_service.py
@@ -592,11 +592,11 @@ async def get_teacher_full(db: AsyncSession, teacher_id: int) -> dict:
     result["students_count"] = students_count
     result["evaluations_count"] = evaluations_count
 
-    # Hours per week (sum of subject hours_per_week via SubjectInstance)
-    from app.models.academic import SubjectInstance
+    # Hours per week (sum of subject hours_per_week via Subject assigned to teacher)
+    from app.models.academic import Subject
 
-    hours_stmt = select(func.coalesce(func.sum(SubjectInstance.hours_per_week), 0)).where(
-        SubjectInstance.teacher_id == teacher_id
+    hours_stmt = select(func.coalesce(func.sum(Subject.hours_per_week), 0)).where(
+        Subject.teacher_id == teacher_id
     )
     result["hours_per_week"] = float((await db.execute(hours_stmt)).scalar() or 0)
 


### PR DESCRIPTION
## Symptôme

`GET /admin/teachers/{id}/full` retourne 500 systématique. La fiche enseignant n'a plus aucun KPI sur la vue d'ensemble (0 classes, 0 élèves, 0h, 0%) car React Query échoue 4 fois.

## Cause

`app/services/admin_service.py:596` importait `SubjectInstance` qui n'existe pas dans `app/models/academic.py` — la classe correcte s'appelle `Subject`. Probable artefact d'un refactor antérieur.

```
ImportError: cannot import name 'SubjectInstance' from 'app.models.academic'
```

## Fix

Renommé l'import et les 2 références à `Subject` (mêmes attributs : `hours_per_week`, `teacher_id`).

## Test

- Logs prod : 4× `Apr 28 08:40:24 ... ImportError` confirmés sur EC2 `16.58.132.68` avant le fix
- Code path : `get_teacher_full` → cellule "Hours per week"
- Régression : aucune (le module était simplement non-importable)

Closes #114