### PR TITLE
feat(parent): add /parent/dashboard endpoint aggregating per-child KPIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Tableau de bord parent : un seul appel retourne pour chaque enfant la classe, la moyenne générale, le nombre d'absences et le solde restant à payer, sans avoir à ouvrir chaque fiche *(parent)* (#120).
 - **Attestation de fréquentation officielle** : PDF République de Côte d'Ivoire signé par le chef d'établissement avec un tableau des statistiques de présence (présent / retard / absence excusée / absence non excusée) et un taux de fréquentation calculé sur l'année scolaire en cours. Endpoint `GET /students/{id}/documents/attestation-frequentation.pdf` avec les mêmes gardes d'accès que le certificat *(admin, parent, élève)* (#109).
 - **Certificat de scolarité officiel** : l'admin (et le parent en self-service) peut télécharger un PDF République de Côte d'Ivoire signé par le chef d'établissement, avec corps formel "Le soussigné certifie que [élève], né(e) le ... à ..., est régulièrement inscrit(e) en classe de [...] au titre de l'année scolaire [...]". Endpoint `GET /students/{id}/documents/certificat-scolarite.pdf` avec garde d'accès parent (lien parent_student) et étudiant (compte propre) *(admin, parent, élève)* (#107).
 - Trois champs sur les paramètres de l'établissement pour signer officiellement les documents administratifs : signature/tampon (image), nom du chef d'établissement, et son titre. Endpoint d'upload dédié pour la signature et permissions seedées pour les futurs documents *(admin)* (#105).

--- a/app/routers/parent_portal.py
+++ b/app/routers/parent_portal.py
@@ -10,6 +10,7 @@ from app.schemas.parent_portal import (
     ChildGradesResponse,
     ChildrenListResponse,
     ChildTimetableResponse,
+    ParentDashboardResponse,
 )
 from app.services import parent_portal_service
 
@@ -18,6 +19,15 @@ router = APIRouter(
     tags=["parent-portal"],
     dependencies=[require_role("parent", "admin", "director")],
 )
+
+
+@router.get("/dashboard", response_model=ParentDashboardResponse)
+async def get_dashboard(
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> ParentDashboardResponse:
+    """Dashboard parent : enfants liés avec moyenne, absences, frais restants."""
+    return await parent_portal_service.get_dashboard(db, current_user.user_id)
 
 
 @router.get("/children", response_model=ChildrenListResponse)

--- a/app/schemas/parent_portal.py
+++ b/app/schemas/parent_portal.py
@@ -41,6 +41,30 @@ class ChildrenListResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Dashboard (résumé global parent)
+# ---------------------------------------------------------------------------
+
+
+class ParentDashboardChild(BaseModel):
+    """Résumé KPIs d'un enfant pour la dashboard parent."""
+
+    id: int
+    full_name: str
+    class_name: str
+    general_average: float | None
+    total_absences: int
+    fees_remaining: Decimal
+
+
+class ParentDashboardResponse(BaseModel):
+    """Dashboard parent — agrège les KPIs des enfants liés."""
+
+    parent_name: str
+    total_children: int
+    children: list[ParentDashboardChild]
+
+
+# ---------------------------------------------------------------------------
 # Grades
 # ---------------------------------------------------------------------------
 

--- a/app/services/parent_portal_service.py
+++ b/app/services/parent_portal_service.py
@@ -22,6 +22,8 @@ from app.schemas.parent_portal import (
     ChildTimetableSlot,
     FeeDetail,
     GradeDetail,
+    ParentDashboardChild,
+    ParentDashboardResponse,
     PaymentDetail,
 )
 
@@ -97,6 +99,82 @@ async def list_children(db: AsyncSession, user_id: int) -> ChildrenListResponse:
         )
 
     return ChildrenListResponse(children=children)
+
+
+async def get_dashboard(db: AsyncSession, user_id: int) -> ParentDashboardResponse:
+    """Dashboard parent : pour chaque enfant, agrège classe + moyenne + absences + reste à payer.
+
+    Réutilise les helpers existants (frais, attendance) plutôt que de
+    dupliquer la logique. Une query par enfant sur grades / fees / attendance
+    — acceptable pour la cardinalité typique (1-3 enfants par parent).
+    """
+    from app.services.attendance_service import get_student_attendance_summary
+
+    parent = await _get_parent_for_user(db, user_id)
+    links = await repo.list_children(db, parent.id)
+    parent_name = f"{parent.first_name} {parent.last_name}".strip()
+
+    summaries: list[ParentDashboardChild] = []
+    for link in links:
+        student = link.student
+        full_name = f"{student.last_name} {student.first_name}".strip()
+
+        active_enrollments = [
+            e
+            for e in student.enrollments
+            if e.status not in (EnrollmentStatus.ANNULE, EnrollmentStatus.REJETE)
+        ]
+        active = max(active_enrollments, key=lambda e: e.id) if active_enrollments else None
+        class_name = active.class_.name if active and active.class_ else "—"
+        ay_id = active.academic_year_id if active else None
+
+        # General average — moyenne arithmétique simple des notes valides.
+        # MVP : on n'applique pas les coefficients (la matière les porte) ;
+        # le bulletin officiel utilise déjà la formule pondérée. Ici c'est
+        # un indicateur global pour le résumé parent, pas un bulletin.
+        grades = await repo.get_student_grades(db, student.id)
+        valid_values = [
+            float(g.value) for g in grades if g.value is not None and g.evaluation is not None
+        ]
+        general_average = round(sum(valid_values) / len(valid_values), 2) if valid_values else None
+
+        # Total absences sur l'année active.
+        if ay_id is not None:
+            summary = await get_student_attendance_summary(db, student.id, academic_year_id=ay_id)
+            total_absences = int(summary.get("absent", 0)) + int(summary.get("absent_excuse", 0))
+        else:
+            total_absences = 0
+
+        # Fees remaining — sum (amount - completed payments) sur l'inscription active.
+        fees_remaining = Decimal("0.00")
+        if active is not None:
+            enrollment = await repo.get_student_active_enrollment(db, student.id)
+            if enrollment is not None:
+                for ef in enrollment.enrollment_fees:
+                    paid = sum(
+                        (p.amount for p in ef.payments if p.status == PaymentStatus.COMPLETED),
+                        Decimal("0.00"),
+                    )
+                    remaining = ef.amount - paid
+                    if remaining > 0:
+                        fees_remaining += remaining
+
+        summaries.append(
+            ParentDashboardChild(
+                id=student.id,
+                full_name=full_name,
+                class_name=class_name,
+                general_average=general_average,
+                total_absences=total_absences,
+                fees_remaining=fees_remaining,
+            )
+        )
+
+    return ParentDashboardResponse(
+        parent_name=parent_name,
+        total_children=len(summaries),
+        children=summaries,
+    )
 
 
 async def get_child_grades(


### PR DESCRIPTION
## Bug découvert via /visual-check post-deploy 2026-04-29

Login `parent.kone@klassci.com` (compte test seedé hier via PR #119) → /parent/dashboard charge mais affiche **"Connexion au serveur impossible"**.

```
GET /api-be/parent/dashboard → 404 Not Found
```

Le FE `lib/api/parent-portal.ts:40` consomme cet endpoint depuis le ship du portail parent. Le BE ne l'a jamais exposé. Bug latent significatif (cf `feedback_be_fe_contract_drift.md` qui signalait l'existence de drifts BE/FE — celui-ci en faisait partie sans qu'on le sache).

## Changements

### Schema (`app/schemas/parent_portal.py`)
- `ParentDashboardChild` (id, full_name, class_name, general_average, total_absences, fees_remaining)
- `ParentDashboardResponse` (parent_name, total_children, children)

Mirror exact du `ParentDashboardSchema` Zod côté FE.

### Service (`app/services/parent_portal_service.py`)
- `get_dashboard(db, user_id)` qui pour chaque enfant lié :
  - extrait l'inscription active la plus récente
  - calcule la moyenne arithmétique simple des notes valides
  - somme absences + absences excusées sur l'AY active via `get_student_attendance_summary`
  - calcule `fees_remaining = sum (amount - completed payments)` sur `enrollment_fees`

Réutilise les helpers existants — pas de duplication. 1 query/enfant sur 3 axes (grades, attendance, fees) — acceptable pour la cardinalité typique 1-3 enfants par parent.

### Router (`app/routers/parent_portal.py`)
- `GET /parent/dashboard` avec `require_role('parent', 'admin', 'director')` (déjà appliqué au router)

## Tests

- AST + ruff check + ruff format pass
- Tests BE existants ne sont pas affectés (nouveau endpoint, pas de modification)
- Verification post-deploy via /visual-check après merge

## MVP scope notes

- `general_average` = moyenne arithmétique simple, pas pondérée par coefficient. Le bulletin officiel garde la formule pondérée. Le dashboard est un indicateur résumé, pas un bulletin de notes.
- `total_absences` n'inclut PAS les retards. Sémantique : absences strictes (`absent` + `absent_excuse`).

Closes #120