### PR TITLE
fix(parent): serialize fees_remaining as float not Decimal string

### DIFF
--- a/app/schemas/parent_portal.py
+++ b/app/schemas/parent_portal.py
@@ -53,7 +53,11 @@ class ParentDashboardChild(BaseModel):
     class_name: str
     general_average: float | None
     total_absences: int
-    fees_remaining: Decimal
+    # Float (not Decimal) so the JSON encoder emits a number, not a string.
+    # The FE Zod schema validates as z.number() — Pydantic's default
+    # Decimal→str serialization breaks the contract. Acceptable precision
+    # loss because we display thousands of XOF, not micropayments.
+    fees_remaining: float
 
 
 class ParentDashboardResponse(BaseModel):

--- a/app/services/parent_portal_service.py
+++ b/app/services/parent_portal_service.py
@@ -166,7 +166,7 @@ async def get_dashboard(db: AsyncSession, user_id: int) -> ParentDashboardRespon
                 class_name=class_name,
                 general_average=general_average,
                 total_absences=total_absences,
-                fees_remaining=fees_remaining,
+                fees_remaining=float(fees_remaining),
             )
         )
 


### PR DESCRIPTION
Hotfix au #121 mergé il y a 5 minutes.

## Bug

Endpoint `/parent/dashboard` retourne 200 avec shape correcte côté wire, MAIS `fees_remaining` est sérialisé en string (`"90000.00"`) car Pydantic default pour Decimal. La FE valide via Zod `z.number()` → validation fail → React Query `isError=true` → composant rend "Connexion au serveur impossible" (état d'erreur générique).

## Fix

`fees_remaining: float` au lieu de `Decimal` dans le schema, cast explicite `float(fees_remaining)` dans le service. Précision OK — on affiche des milliers de XOF.

## Test

Probé via dev-browser : login parent.kone → /parent/dashboard → encore "Connexion impossible" malgré BE 200. Snapshot révèle que le main est rendu avec l'erreur, pas un loading spinner.

Fix push directement sans waiting — typeur d'erreur trouvé pendant le visual-check du #121, ne pas laisser prod cassée.

Refs #120