### PR TITLE
fix(auth): allow super_admin in UserInToken Literal

### DIFF
--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -13,7 +13,7 @@ class LoginRequest(BaseModel):
 class UserInToken(BaseModel):
     id: int
     email: str
-    role: Literal["admin", "staff", "teacher", "student", "parent"]
+    role: Literal["admin", "staff", "teacher", "student", "parent", "super_admin"]
     first_name: str
     last_name: str
 


### PR DESCRIPTION
Hotfix #134 follow-up. /auth/login 500'd for super_admin users.