### PR TITLE
feat(tenant): reserve system slugs + configurable login URL template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Création de tenant : les slugs réservés (`admin`, `api`, `auth`, `www`, `local`, `super-admin`, ...) sont désormais refusés à la création pour éviter toute collision avec un chemin plateforme *(super-admin)* (#136).
+- Lien de connexion configurable via `PUBLIC_LOGIN_URL_TEMPLATE` : par défaut `https://college.klassci.com/login?c=<slug>` (pattern single-domain), bascule vers sous-domaine sans changement de code *(devops)* (#136).
 - Provisionnement d'un nouvel établissement en libre-service : nouveau rôle « Super Administrateur », tableau de bord dédié et création de tenant en quelques clics, avec validation en direct du nom d'URL et progression visible des étapes *(super-admin)* (#134).
 - Onboarding par ligne de commande pour les agents IA : le CLI `klassci` (`tenant create`, `tenant list`, `pat create`, `doctor`, `db query`, `logs`, `alembic`, etc.) permet de provisionner et opérer la plateforme sans passer par le navigateur ni SSH *(super-admin, devops)* (#134).
 - Tokens d'accès personnels (PAT) : créer, lister, et révoquer ses propres tokens avec scopes (`super-admin:tenants:read`, `super-admin:db:execute`, …), expiration obligatoire (90 jours par défaut), et affichage du token clair une seule fois à la création *(super-admin)* (#134).

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -29,6 +29,14 @@ class Settings(BaseSettings):
     # Tenant
     LOCAL_TENANT_ID: str = "local"  # tenant utilisé en dev local
 
+    # Public login URL template — utilisé pour générer le lien envoyé dans
+    # l'email de bienvenue tenant et l'URL affichée côté super-admin.
+    # {slug} est remplacé par le slug du tenant.
+    # Default = pattern single-domain (B-Lean) : ?c=<slug> en query param.
+    # Flip vers subdomain plus tard sans changer de code :
+    #   PUBLIC_LOGIN_URL_TEMPLATE="https://{slug}.college.klassci.com/login"
+    PUBLIC_LOGIN_URL_TEMPLATE: str = "https://college.klassci.com/login?c={slug}"
+
     # Host allowlist — protection CSRF / host header injection
     # Pattern regex matchant les hôtes acceptés en production multi-tenant.
     # Default couvre <tenant>.college.klassci.com (sous-domaines KLASSCI College).

--- a/app/core/slug.py
+++ b/app/core/slug.py
@@ -4,6 +4,14 @@ The pattern matches RFC 1123 subdomain format: 2-63 chars, lowercase
 alphanumeric + hyphens, no leading/trailing hyphen. Used by middleware
 host validation, JWT claim acceptance, schema validators, and routers.
 
+Two validation tiers:
+- ``validate_tenant_slug`` (regex only): defensive boundary checks on
+  slugs that may already exist (provisioning re-runs, middleware
+  resolution). Tolerant of the historical ``local`` system tenant.
+- ``validate_new_tenant_slug`` (regex + reserved): API-side validation
+  at the moment a new tenant is being created. Rejects reserved names
+  that would collide with system paths or future infrastructure.
+
 Drift between the four call sites silently breaks tenants — keep them
 all importing from here.
 """
@@ -13,16 +21,78 @@ import re
 TENANT_SLUG_PATTERN = r"^[a-z0-9][a-z0-9\-]{0,61}[a-z0-9]$"
 TENANT_SLUG_RE: re.Pattern[str] = re.compile(TENANT_SLUG_PATTERN)
 
+# Slugs that must never be assigned to a new tenant: they collide with
+# platform paths, common SaaS conventions, or the system tenant itself.
+# Kept frozenset for O(1) membership and immutable contract.
+RESERVED_SLUGS: frozenset[str] = frozenset(
+    {
+        # System tenant
+        "local",
+        # Platform path conflicts (URL routes)
+        "admin",
+        "super-admin",
+        "api",
+        "auth",
+        "login",
+        "logout",
+        "signup",
+        # SaaS conventions
+        "www",
+        "app",
+        "mail",
+        "static",
+        "cdn",
+        "docs",
+        "blog",
+        "status",
+        "health",
+        "metrics",
+        "support",
+        # Environment names (avoid confusion)
+        "test",
+        "dev",
+        "staging",
+        "prod",
+        "production",
+    }
+)
+
 
 def is_valid_tenant_slug(value: str) -> bool:
     return bool(TENANT_SLUG_RE.match(value))
 
 
+def is_reserved_tenant_slug(value: str) -> bool:
+    return value in RESERVED_SLUGS
+
+
 def validate_tenant_slug(value: str) -> str:
-    """Return the slug if valid, else raise ValueError with a stable message."""
+    """Return the slug if format-valid, else raise ValueError.
+
+    Format check only. Does NOT reject reserved names — use
+    ``validate_new_tenant_slug`` for that. This function is the
+    defensive boundary used internally on slugs that may already
+    exist (e.g. re-seeding the system tenant ``local``).
+    """
     if not is_valid_tenant_slug(value):
         raise ValueError(
             "Doit faire 2-63 caractères, minuscules + chiffres + tirets, "
             "sans tiret en début ni en fin."
+        )
+    return value
+
+
+def validate_new_tenant_slug(value: str) -> str:
+    """Return the slug if it can be assigned to a new tenant, else raise.
+
+    Stricter than ``validate_tenant_slug``: rejects format-invalid AND
+    reserved names. Use at the API boundary (provisioning request,
+    slug availability check) — never on resolution paths.
+    """
+    validate_tenant_slug(value)
+    if is_reserved_tenant_slug(value):
+        raise ValueError(
+            f"Le slug '{value}' est réservé (système ou collision avec un "
+            "chemin plateforme). Choisir un autre identifiant."
         )
     return value

--- a/app/routers/super_admin/tenants.py
+++ b/app/routers/super_admin/tenants.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, HTTPException
 
 from app.core.dependencies import require_permission
-from app.core.slug import is_valid_tenant_slug
+from app.core.slug import is_reserved_tenant_slug, is_valid_tenant_slug
 from app.schemas.tenant import (
     SlugCheckRequest,
     SlugCheckResponse,
@@ -103,6 +103,14 @@ async def check_slug(
             available=False,
             valid_format=False,
             reason="Doit faire 2-63 caractères, minuscules + chiffres + tirets, sans tiret en début/fin",
+        )
+
+    if is_reserved_tenant_slug(data.slug):
+        return SlugCheckResponse(
+            slug=data.slug,
+            available=False,
+            valid_format=True,
+            reason="Ce slug est réservé (système ou collision plateforme). Choisir un autre identifiant.",
         )
 
     taken = await slug_exists(data.slug)

--- a/app/schemas/tenant.py
+++ b/app/schemas/tenant.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from pydantic import BaseModel, EmailStr, field_validator
 
-from app.core.slug import validate_tenant_slug
+from app.core.slug import validate_new_tenant_slug
 
 
 class TenantProvisionRequest(BaseModel):
@@ -20,7 +20,7 @@ class TenantProvisionRequest(BaseModel):
     @field_validator("tenant_slug")
     @classmethod
     def validate_slug(cls, v: str) -> str:
-        return validate_tenant_slug(v)
+        return validate_new_tenant_slug(v)
 
     @field_validator("admin_password")
     @classmethod

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -77,23 +77,24 @@ def send_tenant_welcome(
     admin_email: str,
     admin_first_name: str,
     school_name: str,
-    tenant_slug: str,
+    login_url: str,
     temp_password: str,
-    base_domain: str = "college.klassci.com",
 ) -> bool:
     """Envoie l'email de bienvenue au nouvel admin tenant après provisioning.
 
-    Inclut URL personnalisée du tenant, identifiants temporaires, et CTA login.
-    Best-effort : si SMTP indisponible, log mais ne raise pas (le tenant existe
-    déjà en DB, on ne veut pas rollback à cause d'un email).
+    ``login_url`` est construit par l'appelant à partir de
+    ``settings.PUBLIC_LOGIN_URL_TEMPLATE`` — l'email service ne devine plus
+    le pattern d'URL (subdomain vs query param vs custom domain).
+
+    Best-effort : si SMTP indisponible, log mais ne raise pas (le tenant
+    existe déjà en DB, on ne veut pas rollback à cause d'un email).
     """
-    tenant_url = f"https://{tenant_slug}.{base_domain}"
     context = {
         "admin_first_name": admin_first_name or "Administrateur",
         "school_name": school_name,
         "admin_email": admin_email,
         "temp_password": temp_password,
-        "tenant_url": tenant_url,
+        "tenant_url": login_url,
     }
 
     html_body = _render_template("tenant_welcome.html", **context)

--- a/app/services/tenants/provisioning.py
+++ b/app/services/tenants/provisioning.py
@@ -17,9 +17,10 @@ from typing import Any
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from app.core.config import settings
 from app.core.database import management_database_url, tenant_database_url
 from app.core.security import hash_password
-from app.core.slug import validate_tenant_slug
+from app.core.slug import validate_new_tenant_slug, validate_tenant_slug
 from app.models.user import UserRoleEnum
 from app.services.tenants._engine import short_lived_engine
 from app.services.tenants.exceptions import TenantAlreadyProvisioned
@@ -230,7 +231,7 @@ async def provision_tenant(
     send_welcome_email: bool = True,
 ) -> dict[str, Any]:
     """Full provisioning workflow: create DB → migrate → seed → welcome email."""
-    validate_tenant_slug(tenant_slug)
+    validate_new_tenant_slug(tenant_slug)
 
     logger.info("=== Provisioning tenant '%s' ===", tenant_slug)
 
@@ -247,6 +248,8 @@ async def provision_tenant(
         ministry_code=ministry_code,
     )
 
+    login_url = settings.PUBLIC_LOGIN_URL_TEMPLATE.format(slug=tenant_slug)
+
     email_sent = False
     if send_welcome_email:
         from app.services.email_service import send_tenant_welcome
@@ -255,7 +258,7 @@ async def provision_tenant(
             admin_email=admin_email,
             admin_first_name=admin_first_name,
             school_name=school_name,
-            tenant_slug=tenant_slug,
+            login_url=login_url,
             temp_password=admin_password,
         )
         if not email_sent:
@@ -266,7 +269,7 @@ async def provision_tenant(
         "tenant_slug": tenant_slug,
         "database": tenant_slug,
         "admin_email": seed_result["admin_email"],
-        "tenant_url": f"https://{tenant_slug}.college.klassci.com",
+        "tenant_url": login_url,
         "welcome_email_sent": email_sent,
         "status": "provisioned",
     }

--- a/tests/test_slug.py
+++ b/tests/test_slug.py
@@ -1,0 +1,132 @@
+"""Tenant slug validation — format and reserved-name checks.
+
+Covers the two validation tiers:
+- ``validate_tenant_slug``: format only, tolerant of the historical
+  system tenant ``local``.
+- ``validate_new_tenant_slug``: format + reserved, used at the API
+  boundary when assigning a slug to a new tenant.
+"""
+
+import pytest
+
+from app.core.slug import (
+    RESERVED_SLUGS,
+    is_reserved_tenant_slug,
+    is_valid_tenant_slug,
+    validate_new_tenant_slug,
+    validate_tenant_slug,
+)
+
+
+class TestIsValidTenantSlug:
+    @pytest.mark.parametrize(
+        "slug",
+        [
+            "lycee-moderne",
+            "ab",
+            "ecole2026",
+            "cca-2026",
+            "lm",
+            "a1",
+            "lmab",
+            "local",  # format-valid, even though reserved
+            "admin",  # format-valid, even though reserved
+        ],
+    )
+    def test_valid_format(self, slug: str) -> None:
+        assert is_valid_tenant_slug(slug) is True
+
+    @pytest.mark.parametrize(
+        "slug",
+        [
+            "",
+            "a",  # 1 char, too short
+            "A",  # uppercase
+            "Lycee-Moderne",
+            "-foo",  # leading hyphen
+            "foo-",  # trailing hyphen
+            "foo_bar",  # underscore not allowed
+            "foo.bar",  # dot not allowed
+            "foo bar",  # space
+            "a" * 64,  # > 63 chars
+        ],
+    )
+    def test_invalid_format(self, slug: str) -> None:
+        assert is_valid_tenant_slug(slug) is False
+
+
+class TestIsReservedTenantSlug:
+    @pytest.mark.parametrize(
+        "slug",
+        [
+            "local",
+            "admin",
+            "super-admin",
+            "api",
+            "auth",
+            "www",
+            "mail",
+            "login",
+            "logout",
+            "test",
+            "dev",
+            "staging",
+            "prod",
+            "production",
+        ],
+    )
+    def test_reserved_returns_true(self, slug: str) -> None:
+        assert is_reserved_tenant_slug(slug) is True
+        assert slug in RESERVED_SLUGS
+
+    @pytest.mark.parametrize(
+        "slug",
+        [
+            "lycee-moderne",
+            "ecole-x",
+            "cca-2026",
+            "lmab",
+            "monlycee",
+        ],
+    )
+    def test_non_reserved_returns_false(self, slug: str) -> None:
+        assert is_reserved_tenant_slug(slug) is False
+
+
+class TestValidateTenantSlug:
+    """Regex-only validation — tolerant of reserved slugs (system tenant)."""
+
+    def test_valid_returns_value(self) -> None:
+        assert validate_tenant_slug("lycee-moderne") == "lycee-moderne"
+
+    def test_reserved_slug_does_not_raise(self) -> None:
+        # The system tenant ``local`` must still pass defensive boundary
+        # checks during re-seeding / migration re-runs.
+        assert validate_tenant_slug("local") == "local"
+
+    def test_invalid_format_raises(self) -> None:
+        with pytest.raises(ValueError, match="2-63 caractères"):
+            validate_tenant_slug("-bad")
+
+
+class TestValidateNewTenantSlug:
+    """Strict validation — used at API boundary for new tenants."""
+
+    def test_valid_non_reserved_returns_value(self) -> None:
+        assert validate_new_tenant_slug("lycee-moderne") == "lycee-moderne"
+
+    def test_invalid_format_raises_format_error(self) -> None:
+        with pytest.raises(ValueError, match="2-63 caractères"):
+            validate_new_tenant_slug("-bad")
+
+    @pytest.mark.parametrize("slug", sorted(RESERVED_SLUGS))
+    def test_reserved_slug_raises_reserved_error(self, slug: str) -> None:
+        with pytest.raises(ValueError, match="réservé"):
+            validate_new_tenant_slug(slug)
+
+    def test_reserved_check_runs_after_format_check(self) -> None:
+        # An invalid-format slug that happens to also be reserved should
+        # fail with the format error first (defense in depth: don't leak
+        # the reserved list to clients sending garbage).
+        with pytest.raises(ValueError, match="2-63 caractères"):
+            validate_new_tenant_slug("ADMIN")  # uppercase = format fail


### PR DESCRIPTION
## Summary

BE half of Plan Ultimate B-Lean (multi-tenant client login). Sister FE PR : `African-DC/klassci-college-frontend` PR for issue #183.

- `app/core/slug.py` : new `RESERVED_SLUGS` frozenset + `validate_new_tenant_slug()` strict variant that rejects format-invalid AND reserved names (`admin`, `api`, `auth`, `www`, `local`, `super-admin`, env names...). `validate_tenant_slug()` (regex-only) is preserved as the defensive boundary tolerant of the historical `local` system tenant.
- `app/core/config.py` : new `PUBLIC_LOGIN_URL_TEMPLATE` setting, default `https://college.klassci.com/login?c={slug}`. Flipping to subdomain later is an env change, not a code refactor.
- `app/schemas/tenant.py` : `TenantProvisionRequest` validator now uses the strict variant (Pydantic raises 422 if reserved).
- `app/services/email_service.py` : `send_tenant_welcome` accepts `login_url` directly. Email service no longer derives the URL from tenant_slug + hardcoded base domain.
- `app/services/tenants/provisioning.py` : entry calls strict validator, welcome email gets `login_url` from settings template, `tenant_url` in return value uses the same template.
- `app/routers/super_admin/tenants.py` : `check_slug` endpoint returns explicit reason when slug is reserved.

## Test plan

- [x] 68 new slug tests pass : `tests/test_slug.py` (regex-only validation, reserved checks, strict combined, ordering).
- [x] Full BE suite green : 424 passed, 3 skipped (existing 32 tenant tests unaffected).
- [x] Ruff clean on app/ + new test file.
- [ ] Smoke test in dev : provision a tenant with slug `admin` → 422.
- [ ] Smoke test in dev : provision a tenant with slug `lycee-test` → success, welcome email URL points at `?c=lycee-test`.

Closes #136