### PR TITLE
fix(ci): ruff format pass

### DIFF
--- a/app/models/academic.py
+++ b/app/models/academic.py
@@ -243,10 +243,24 @@ class SchoolSettings(Base, TimestampMixin):
         Integer, nullable=False, default=17, server_default="17"
     )
     # Notification settings (canaux + types)
-    notify_by_email: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
-    notify_by_sms: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
-    notify_grades: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
-    notify_absences: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
-    notify_payments: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
-    notify_enrollment: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
-    notify_reenrollment: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
+    notify_by_email: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
+    )
+    notify_by_sms: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
+    )
+    notify_grades: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
+    )
+    notify_absences: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
+    )
+    notify_payments: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
+    )
+    notify_enrollment: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
+    )
+    notify_reenrollment: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
+    )

--- a/app/repositories/payment_repository.py
+++ b/app/repositories/payment_repository.py
@@ -62,16 +62,12 @@ async def get_payment_by_id(db: AsyncSession, payment_id: int) -> Payment | None
 
     Inclut maintenant `allocations` (avec category) + `enrollment.student.user`.
     """
-    stmt = (
-        select(Payment).where(Payment.id == payment_id).options(*_payment_full_options())
-    )
+    stmt = select(Payment).where(Payment.id == payment_id).options(*_payment_full_options())
     result = await db.execute(stmt)
     return result.scalar_one_or_none()
 
 
-async def get_payment_with_allocations(
-    db: AsyncSession, payment_id: int
-) -> Payment | None:
+async def get_payment_with_allocations(db: AsyncSession, payment_id: int) -> Payment | None:
     """Alias explicite — même chargement que `get_payment_by_id`."""
     return await get_payment_by_id(db, payment_id)
 
@@ -119,9 +115,7 @@ async def list_payments(
     return list(rows), total
 
 
-async def get_payments_by_enrollment_id(
-    db: AsyncSession, enrollment_id: int
-) -> list[Payment]:
+async def get_payments_by_enrollment_id(db: AsyncSession, enrollment_id: int) -> list[Payment]:
     """Retourne tous les paiements d'une inscription (via Payment.enrollment_id)."""
     stmt = (
         select(Payment)
@@ -210,9 +204,7 @@ async def get_enrollment_fees_ordered_by_priority(
 # ---------------------------------------------------------------------------
 
 
-async def get_total_paid_for_enrollment_fee(
-    db: AsyncSession, enrollment_fee_id: int
-) -> Decimal:
+async def get_total_paid_for_enrollment_fee(db: AsyncSession, enrollment_fee_id: int) -> Decimal:
     """Total alloué à un fee depuis les paiements COMPLETED.
 
     Source de vérité = `payment_allocations`. Exclut les payments
@@ -230,9 +222,7 @@ async def get_total_paid_for_enrollment_fee(
     return Decimal(str(result.scalar()))
 
 
-async def get_total_paid_for_enrollment(
-    db: AsyncSession, enrollment_id: int
-) -> Decimal:
+async def get_total_paid_for_enrollment(db: AsyncSession, enrollment_id: int) -> Decimal:
     """Total versé sur une inscription (somme des Payment.amount COMPLETED)."""
     stmt = select(
         func.coalesce(func.sum(Payment.amount), 0),
@@ -249,9 +239,7 @@ async def get_total_paid_for_enrollment(
 # ---------------------------------------------------------------------------
 
 
-async def get_enrollment_for_update(
-    db: AsyncSession, enrollment_id: int
-) -> Enrollment | None:
+async def get_enrollment_for_update(db: AsyncSession, enrollment_id: int) -> Enrollment | None:
     """Verrouille l'inscription le temps du calcul de l'allocation."""
     from app.models.user import Student
 
@@ -322,9 +310,7 @@ async def create_allocation(
     return allocation
 
 
-async def get_allocations_for_payment(
-    db: AsyncSession, payment_id: int
-) -> list[PaymentAllocation]:
+async def get_allocations_for_payment(db: AsyncSession, payment_id: int) -> list[PaymentAllocation]:
     """Toutes les allocations d'un Payment, avec category pour l'audit."""
     stmt = (
         select(PaymentAllocation)

--- a/app/routers/class_documents.py
+++ b/app/routers/class_documents.py
@@ -32,9 +32,5 @@ async def get_class_roster_pdf(
     return Response(
         content=pdf_bytes,
         media_type="application/pdf",
-        headers={
-            "Content-Disposition": (
-                f'inline; filename="liste-classe-{class_id}.pdf"'
-            )
-        },
+        headers={"Content-Disposition": (f'inline; filename="liste-classe-{class_id}.pdf"')},
     )

--- a/app/routers/enrollment_payments.py
+++ b/app/routers/enrollment_payments.py
@@ -98,11 +98,7 @@ async def get_fee_statement_pdf(
     return Response(
         content=pdf_bytes,
         media_type="application/pdf",
-        headers={
-            "Content-Disposition": (
-                f'inline; filename="etat-frais-{enrollment_id}.pdf"'
-            )
-        },
+        headers={"Content-Disposition": (f'inline; filename="etat-frais-{enrollment_id}.pdf"')},
     )
 
 
@@ -121,15 +117,11 @@ async def get_enrollment_form_pdf(
     responsables (père/mère/tuteur) + tableau frais avec total + signatures
     Parent + Chef d'établissement.
     """
-    pdf_bytes = await enrollment_form_service.get_enrollment_form_pdf(
-        db, enrollment_id
-    )
+    pdf_bytes = await enrollment_form_service.get_enrollment_form_pdf(db, enrollment_id)
     return Response(
         content=pdf_bytes,
         media_type="application/pdf",
         headers={
-            "Content-Disposition": (
-                f'inline; filename="fiche-inscription-{enrollment_id}.pdf"'
-            )
+            "Content-Disposition": (f'inline; filename="fiche-inscription-{enrollment_id}.pdf"')
         },
     )

--- a/app/routers/payments.py
+++ b/app/routers/payments.py
@@ -95,11 +95,7 @@ async def get_daily_cash_book(
     return Response(
         content=pdf_bytes,
         media_type="application/pdf",
-        headers={
-            "Content-Disposition": (
-                f'inline; filename="bordereau-{target.isoformat()}.pdf"'
-            )
-        },
+        headers={"Content-Disposition": (f'inline; filename="bordereau-{target.isoformat()}.pdf"')},
     )
 
 

--- a/app/services/admin_service.py
+++ b/app/services/admin_service.py
@@ -457,9 +457,7 @@ async def get_teacher(db: AsyncSession, teacher_id: int) -> TeacherResponse:
     return _teacher_to_response(teacher)
 
 
-async def _ensure_default_user_role(
-    db: AsyncSession, user_id: int, role_name: str
-) -> None:
+async def _ensure_default_user_role(db: AsyncSession, user_id: int, role_name: str) -> None:
     """Attache un user à son rôle par défaut dans user_roles (idempotent).
 
     Indispensable pour que les endpoints qui font `require_permission(slug)`
@@ -672,9 +670,7 @@ async def get_teacher_full(db: AsyncSession, teacher_id: int) -> dict:
         )
         slots_count = (await db.execute(slots_count_stmt)).scalar() or 0
         if slots_count > 0:
-            result["availability_rate"] = round(
-                min(slots_count / MAX_SLOTS_PER_WEEK * 100, 100), 1
-            )
+            result["availability_rate"] = round(min(slots_count / MAX_SLOTS_PER_WEEK * 100, 100), 1)
             result["availability_source"] = "implicit"
         else:
             result["availability_rate"] = 0
@@ -1764,9 +1760,7 @@ async def get_trimesters_for_current_year(db: AsyncSession) -> list[Trimester]:
     if year_id is None:
         return []
     stmt = (
-        select(Trimester)
-        .where(Trimester.academic_year_id == year_id)
-        .order_by(Trimester.order_no)
+        select(Trimester).where(Trimester.academic_year_id == year_id).order_by(Trimester.order_no)
     )
     return list((await db.execute(stmt)).scalars().all())
 
@@ -1815,9 +1809,7 @@ async def upsert_trimesters_for_current_year(
         raise NotFoundError("AcademicYear", 0)
 
     async with db.begin_nested():
-        await db.execute(
-            sa_delete(Trimester).where(Trimester.academic_year_id == year_id)
-        )
+        await db.execute(sa_delete(Trimester).where(Trimester.academic_year_id == year_id))
         await db.flush()
         for i, item in enumerate(items, start=1):
             db.add(
@@ -1836,16 +1828,20 @@ async def upsert_trimesters_for_current_year(
             entity_id=year_id,
             action=AuditAction.UPDATE,
             user_id=updated_by,
-            new_values={"items": [
-                {"label": it["label"], "start_date": str(it["start_date"]),
-                 "end_date": str(it["end_date"])} for it in items
-            ]},
+            new_values={
+                "items": [
+                    {
+                        "label": it["label"],
+                        "start_date": str(it["start_date"]),
+                        "end_date": str(it["end_date"]),
+                    }
+                    for it in items
+                ]
+            },
         )
     await db.commit()
     stmt = (
-        select(Trimester)
-        .where(Trimester.academic_year_id == year_id)
-        .order_by(Trimester.order_no)
+        select(Trimester).where(Trimester.academic_year_id == year_id).order_by(Trimester.order_no)
     )
     return list((await db.execute(stmt)).scalars().all())
 

--- a/app/services/class_roster_service.py
+++ b/app/services/class_roster_service.py
@@ -40,9 +40,7 @@ async def _current_academic_year(db: AsyncSession) -> AcademicYear | None:
     return result.scalar_one_or_none()
 
 
-async def _load_students(
-    db: AsyncSession, class_id: int, academic_year_id: int
-) -> list[dict]:
+async def _load_students(db: AsyncSession, class_id: int, academic_year_id: int) -> list[dict]:
     """Charge les étudiants inscrits VALIDES dans la classe pour l'AY courante."""
     stmt = (
         select(Enrollment)

--- a/app/services/daily_cash_book_service.py
+++ b/app/services/daily_cash_book_service.py
@@ -23,9 +23,7 @@ from app.services.pdf import generate_daily_cash_book_pdf
 from app.services.pdf._helpers import enum_value
 
 
-async def _load_payments_for_day(
-    db: AsyncSession, target_date: date
-) -> list[Payment]:
+async def _load_payments_for_day(db: AsyncSession, target_date: date) -> list[Payment]:
     """Charge tous les paiements de la journée avec student name pour PDF."""
     day_start = datetime.combine(target_date, time.min)
     day_end = day_start + timedelta(days=1)
@@ -33,8 +31,7 @@ async def _load_payments_for_day(
         select(Payment)
         .where(Payment.created_at >= day_start, Payment.created_at < day_end)
         .options(
-            selectinload(Payment.enrollment)
-            .selectinload(Enrollment.student),
+            selectinload(Payment.enrollment).selectinload(Enrollment.student),
         )
         .order_by(Payment.created_at.asc())
     )

--- a/app/services/enrollment_form_service.py
+++ b/app/services/enrollment_form_service.py
@@ -27,9 +27,7 @@ _RELATIONSHIP_LABELS = {
 }
 
 
-async def _load_enrollment_context(
-    db: AsyncSession, enrollment_id: int
-) -> Enrollment:
+async def _load_enrollment_context(db: AsyncSession, enrollment_id: int) -> Enrollment:
     """Charge l'inscription avec tout ce qu'il faut pour la fiche."""
     stmt = (
         select(Enrollment)
@@ -100,9 +98,7 @@ def _fees_dict(enrollment: Enrollment) -> list[dict]:
     fees = list(enrollment.enrollment_fees or [])
     fees.sort(
         key=lambda f: (
-            f.fee_variant.category.priority
-            if f.fee_variant and f.fee_variant.category
-            else 100,
+            f.fee_variant.category.priority if f.fee_variant and f.fee_variant.category else 100,
             f.id,
         )
     )
@@ -122,11 +118,7 @@ def _fees_dict(enrollment: Enrollment) -> list[dict]:
 async def get_enrollment_form_pdf(db: AsyncSession, enrollment_id: int) -> bytes:
     """Génère la fiche d'inscription en PDF."""
     enrollment = await _load_enrollment_context(db, enrollment_id)
-    parents = (
-        await _load_parents(db, enrollment.student.id)
-        if enrollment.student
-        else []
-    )
+    parents = await _load_parents(db, enrollment.student.id) if enrollment.student else []
 
     klass = enrollment.class_
     ay = enrollment.academic_year
@@ -137,11 +129,7 @@ async def get_enrollment_form_pdf(db: AsyncSession, enrollment_id: int) -> bytes
         "status": enum_value(enrollment.status),
         "student": _student_dict(enrollment),
         "class_name": getattr(klass, "name", "") if klass else "",
-        "level_name": (
-            getattr(klass.level, "name", "")
-            if klass and klass.level
-            else ""
-        ),
+        "level_name": (getattr(klass.level, "name", "") if klass and klass.level else ""),
         "academic_year_name": getattr(ay, "name", "") if ay else "",
         "parents": parents,
         "fees": _fees_dict(enrollment),

--- a/app/services/fee_statement_service.py
+++ b/app/services/fee_statement_service.py
@@ -27,9 +27,7 @@ from app.services.pdf import generate_fee_statement_pdf
 from app.services.pdf._helpers import enum_value
 
 
-async def _load_enrollment_context(
-    db: AsyncSession, enrollment_id: int
-) -> Enrollment:
+async def _load_enrollment_context(db: AsyncSession, enrollment_id: int) -> Enrollment:
     """Charge l'inscription avec student + class + academic_year + fees.
 
     Selectinload exhaustif pour éviter MissingGreenlet pendant la compose.
@@ -66,9 +64,7 @@ async def _build_fees_section(
     # Tri stable par priorité catégorie ASC puis id
     fees.sort(
         key=lambda f: (
-            f.fee_variant.category.priority
-            if f.fee_variant and f.fee_variant.category
-            else 100,
+            f.fee_variant.category.priority if f.fee_variant and f.fee_variant.category else 100,
             f.id,
         )
     )
@@ -96,9 +92,7 @@ async def _build_fees_section(
     return rows, total_expected, total_paid_all
 
 
-async def _build_payments_section(
-    db: AsyncSession, enrollment_id: int
-) -> list[dict]:
+async def _build_payments_section(db: AsyncSession, enrollment_id: int) -> list[dict]:
     """Compose l'historique des versements (Payment.enrollment_id direct)."""
     payments = await repo.get_payments_by_enrollment_id(db, enrollment_id)
     rows: list[dict] = []
@@ -124,9 +118,7 @@ async def get_fee_statement_pdf(db: AsyncSession, enrollment_id: int) -> bytes:
     payments_rows = await _build_payments_section(db, enrollment_id)
 
     total_remaining = max(total_expected - total_paid, Decimal("0"))
-    completion_rate = (
-        float(total_paid / total_expected * 100) if total_expected > 0 else 0.0
-    )
+    completion_rate = float(total_paid / total_expected * 100) if total_expected > 0 else 0.0
 
     student = enrollment.student
     klass = enrollment.class_

--- a/app/services/payments/lifecycle.py
+++ b/app/services/payments/lifecycle.py
@@ -21,17 +21,13 @@ from app.services.payments._response import payment_to_response
 from app.services.payments._state import VALID_TRANSITIONS
 
 
-async def _load_payment_for_transition(
-    db: AsyncSession, payment_id: int
-) -> Payment:
+async def _load_payment_for_transition(db: AsyncSession, payment_id: int) -> Payment:
     """Lock un Payment + ses allocations pour transition de statut."""
     stmt = (
         select(Payment)
         .where(Payment.id == payment_id)
         .options(
-            selectinload(Payment.allocations).selectinload(
-                PaymentAllocation.enrollment_fee
-            ),
+            selectinload(Payment.allocations).selectinload(PaymentAllocation.enrollment_fee),
         )
         .with_for_update(of=Payment)
     )
@@ -66,9 +62,7 @@ async def validate_payment(
         await db.flush()
 
         for allocation in payment.allocations:
-            fee = await repo.get_enrollment_fee_for_update(
-                db, allocation.enrollment_fee_id
-            )
+            fee = await repo.get_enrollment_fee_for_update(db, allocation.enrollment_fee_id)
             if fee is not None:
                 await recompute_fee_status(db, fee)
         await db.flush()

--- a/app/services/payments/preview.py
+++ b/app/services/payments/preview.py
@@ -67,7 +67,11 @@ async def preview_allocation(
         fees_with_paid.append((fee, paid))
 
     total_remaining_before = sum(
-        (f.amount - paid for f, paid in fees_with_paid if f.status != EnrollmentFeeStatus.WAIVED.value),
+        (
+            f.amount - paid
+            for f, paid in fees_with_paid
+            if f.status != EnrollmentFeeStatus.WAIVED.value
+        ),
         Decimal("0"),
     )
     total_remaining_before = max(total_remaining_before, Decimal("0"))

--- a/app/services/payments/query.py
+++ b/app/services/payments/query.py
@@ -57,9 +57,7 @@ async def get_payment(db: AsyncSession, payment_id: int) -> PaymentResponse:
     return payment_to_response(payment)
 
 
-async def get_student_payments(
-    db: AsyncSession, enrollment_id: int
-) -> list[PaymentResponse]:
+async def get_student_payments(db: AsyncSession, enrollment_id: int) -> list[PaymentResponse]:
     """Retourne tous les paiements liés à une inscription."""
     payments = await repo.get_payments_by_enrollment_id(db, enrollment_id)
     return [payment_to_response(p) for p in payments]
@@ -113,9 +111,9 @@ async def get_payments_summary(
         ).label("total_cancelled"),
     )
     if academic_year_id is not None:
-        pay_stmt = pay_stmt.join(
-            Enrollment, Payment.enrollment_id == Enrollment.id
-        ).where(Enrollment.academic_year_id == academic_year_id)
+        pay_stmt = pay_stmt.join(Enrollment, Payment.enrollment_id == Enrollment.id).where(
+            Enrollment.academic_year_id == academic_year_id
+        )
 
     pay_row = (await db.execute(pay_stmt)).one()
 
@@ -123,9 +121,7 @@ async def get_payments_summary(
     total_pending = float(pay_row.total_pending)
     total_cancelled = float(pay_row.total_cancelled)
     payment_count = pay_row.payment_count
-    completion_rate = (
-        round(total_paid / total_expected * 100, 1) if total_expected > 0 else 0.0
-    )
+    completion_rate = round(total_paid / total_expected * 100, 1) if total_expected > 0 else 0.0
 
     return PaymentSummaryResponse(
         total_expected=total_expected,

--- a/app/services/payments/receipt.py
+++ b/app/services/payments/receipt.py
@@ -52,9 +52,7 @@ def _status_after(fee_amount: Decimal, paid_after: Decimal, current_status: str)
     return "pending"
 
 
-async def _build_allocation_breakdown(
-    db: AsyncSession, payment: Payment
-) -> list[dict]:
+async def _build_allocation_breakdown(db: AsyncSession, payment: Payment) -> list[dict]:
     """Liste enrichie pour le tableau PDF — fee_name + amount + cumul + status."""
     breakdown: list[dict] = []
     for allocation in payment.allocations or []:

--- a/app/services/pdf/_blocks.py
+++ b/app/services/pdf/_blocks.py
@@ -38,9 +38,7 @@ def amount_box(
     currency: str = "XOF",
 ) -> str:
     """Box gros montant centré gradient KLASSCI."""
-    amount_str = (
-        format_decimal(amount) if isinstance(amount, Decimal) else esc(str(amount))
-    )
+    amount_str = format_decimal(amount) if isinstance(amount, Decimal) else esc(str(amount))
     return f"""
     <div class="pdf-amount-box">
         <div class="pdf-amount-label">{esc(label)}</div>
@@ -58,9 +56,7 @@ def kpi_card(
 ) -> str:
     """KPI card unique. `tone` parmi primary/accent/success/warn."""
     value_class = (
-        f"pdf-kpi-value pdf-kpi-value-{esc(tone)}"
-        if tone != "primary"
-        else "pdf-kpi-value"
+        f"pdf-kpi-value pdf-kpi-value-{esc(tone)}" if tone != "primary" else "pdf-kpi-value"
     )
     return f"""
     <div class="pdf-kpi">
@@ -119,9 +115,7 @@ def info_grid(items: list[tuple[str, Any]], *, columns: int = 2) -> str:
 def meta_banner(left: str, right: str = "", *, theme: PDFTheme) -> str:
     """Panneau gradient compact entre header et content principal."""
     right_html = (
-        f'<div style="text-align:right; color:var(--muted);">{right}</div>'
-        if right
-        else ""
+        f'<div style="text-align:right; color:var(--muted);">{right}</div>' if right else ""
     )
     return f"""
     <div style="background:linear-gradient(135deg, var(--soft-bg), #eef2ff);

--- a/app/services/pdf/_chrome.py
+++ b/app/services/pdf/_chrome.py
@@ -283,9 +283,7 @@ def premium_header(
     """
 
 
-def premium_footer(
-    school: dict[str, Any], *, theme: PDFTheme, note: str | None = None
-) -> str:
+def premium_footer(school: dict[str, Any], *, theme: PDFTheme, note: str | None = None) -> str:
     """Footer : adresse école compacte à gauche + note/date à droite."""
     school = school or {}
     pieces: list[str] = []
@@ -293,11 +291,7 @@ def premium_footer(
         pieces.append(f"<strong>{esc(school['school_name'])}</strong>")
     if school.get("address"):
         pieces.append(esc(school["address"]))
-    contact = " · ".join(
-        esc(school.get(k))
-        for k in ("phone", "email", "website")
-        if school.get(k)
-    )
+    contact = " · ".join(esc(school.get(k)) for k in ("phone", "email", "website") if school.get(k))
     if contact:
         pieces.append(contact)
     school_block = "<br/>".join(pieces) if pieces else ""

--- a/app/services/pdf/_class_roster_parts.py
+++ b/app/services/pdf/_class_roster_parts.py
@@ -19,8 +19,8 @@ def photo_cell_html(student: dict[str, Any]) -> str:
     initials = esc((student.get("initials") or "")[:2])
     return (
         f'<div style="width:28px; height:28px; border-radius:50%; '
-        f'background:var(--border); color:var(--muted); display:flex; '
-        f'align-items:center; justify-content:center; font-size:9px; '
+        f"background:var(--border); color:var(--muted); display:flex; "
+        f"align-items:center; justify-content:center; font-size:9px; "
         f'font-weight:bold;">{initials}</div>'
     )
 

--- a/app/services/pdf/_council_minutes_parts.py
+++ b/app/services/pdf/_council_minutes_parts.py
@@ -10,9 +10,7 @@ from app.services.pdf._helpers import format_decimal
 def count_decisions(decisions: list[dict[str, Any]], target: str) -> int:
     """Compte les décisions finales (ou auto à défaut) correspondant à `target`."""
     return sum(
-        1
-        for d in decisions
-        if (d.get("final_decision") or d.get("auto_decision")) == target
+        1 for d in decisions if (d.get("final_decision") or d.get("auto_decision")) == target
     )
 
 

--- a/app/services/pdf/_enrollment_form_parts.py
+++ b/app/services/pdf/_enrollment_form_parts.py
@@ -23,10 +23,7 @@ def student_identity_block(student: dict[str, Any]) -> str:
     first_name = esc(student.get("first_name", ""))
     full_name = f"{last_name} {first_name}".strip() or "—"
     genre_raw = student.get("genre") or ""
-    genre_label = (
-        "Masculin" if genre_raw == "M"
-        else ("Féminin" if genre_raw == "F" else "—")
-    )
+    genre_label = "Masculin" if genre_raw == "M" else ("Féminin" if genre_raw == "F" else "—")
     birth_date = student.get("birth_date")
     birth_str = birth_date.strftime("%d/%m/%Y") if birth_date else "—"
     birthplace = student.get("birthplace") or student.get("city") or "—"
@@ -42,8 +39,8 @@ def student_identity_block(student: dict[str, Any]) -> str:
         if photo_data
         else (
             '<div style="width:90px; height:110px; background:var(--soft-bg); '
-            'border:1px solid var(--border); border-radius:4px; '
-            'display:flex; align-items:center; justify-content:center; '
+            "border:1px solid var(--border); border-radius:4px; "
+            "display:flex; align-items:center; justify-content:center; "
             'color:var(--muted); font-size:10px;">Photo</div>'
         )
     )
@@ -83,10 +80,7 @@ def parent_card(label: str, parent: dict[str, Any] | None) -> str:
             </div>
         </div>
         """
-    name = (
-        esc(f"{parent.get('last_name', '')} {parent.get('first_name', '')}".strip())
-        or "—"
-    )
+    name = esc(f"{parent.get('last_name', '')} {parent.get('first_name', '')}".strip()) or "—"
     phone = esc(parent.get("phone") or "—")
     email = esc(parent.get("email") or "—")
     relationship = esc(parent.get("relationship_label") or "")
@@ -139,9 +133,7 @@ def fee_rows_and_total(
         name = f.get("category_name", "")
         amount = f.get("amount")
         mandatory = f.get("is_mandatory", True)
-        amount_str = (
-            format_decimal(amount) if isinstance(amount, Decimal) else str(amount or "—")
-        )
+        amount_str = format_decimal(amount) if isinstance(amount, Decimal) else str(amount or "—")
         kind = "Obligatoire" if mandatory else "Optionnel"
         rows.append(
             [

--- a/app/services/pdf/_tables.py
+++ b/app/services/pdf/_tables.py
@@ -46,9 +46,7 @@ def premium_table(
         if isinstance(h, dict):
             align = h.get("align", "left")
             align_style = f"text-align:{align};" if align != "left" else ""
-            head_cells.append(
-                f'<th style="{align_style}">{esc(h.get("label", ""))}</th>'
-            )
+            head_cells.append(f'<th style="{align_style}">{esc(h.get("label", ""))}</th>')
         else:
             head_cells.append(f"<th>{esc(h)}</th>")
     head_html = "<tr>" + "".join(head_cells) + "</tr>"

--- a/app/services/pdf/attendance_certificate.py
+++ b/app/services/pdf/attendance_certificate.py
@@ -73,9 +73,7 @@ def generate_attendance_certificate_pdf(
     class_name = data.get("class_name") or ""
     academic_year_name = data.get("academic_year_name") or ""
     issued_at = data.get("issued_at") or datetime.utcnow()
-    issued_str = (
-        issued_at.strftime("%d/%m/%Y") if isinstance(issued_at, datetime) else ""
-    )
+    issued_str = issued_at.strftime("%d/%m/%Y") if isinstance(issued_at, datetime) else ""
 
     inscrit_form = "inscrite" if genre == "F" else "inscrit"
 

--- a/app/services/pdf/bulletin.py
+++ b/app/services/pdf/bulletin.py
@@ -38,9 +38,7 @@ def _subject_rows(subject_averages: list[dict[str, Any]]) -> list[list[Any]]:
     return rows
 
 
-def generate_bulletin_pdf(
-    bulletin_data: dict[str, Any], school_settings: dict[str, Any]
-) -> bytes:
+def generate_bulletin_pdf(bulletin_data: dict[str, Any], school_settings: dict[str, Any]) -> bytes:
     """Generate a PDF bulletin for a single student.
 
     bulletin_data keys:
@@ -67,11 +65,7 @@ def generate_bulletin_pdf(
     generated_at = bulletin_data.get("generated_at")
 
     rank_display = f"{rank}/{total_students}" if rank else "—"
-    gen_date = (
-        generated_at.strftime("%d/%m/%Y")
-        if isinstance(generated_at, datetime)
-        else ""
-    )
+    gen_date = generated_at.strftime("%d/%m/%Y") if isinstance(generated_at, datetime) else ""
 
     meta_left = (
         f"<strong>Élève :</strong> {ui.esc(student_name)}<br/>"
@@ -116,7 +110,7 @@ def generate_bulletin_pdf(
         comment_block = (
             ui.section_title("Appréciation du professeur principal", theme=theme)
             + f'<div style="padding:8px 12px; border:1px solid var(--border); '
-            f'border-radius:6px; background:var(--soft-bg); font-size:11px; '
+            f"border-radius:6px; background:var(--soft-bg); font-size:11px; "
             f'line-height:1.5;">{ui.esc(teacher_comment)}</div>'
         )
 

--- a/app/services/pdf/certificate_scolarite.py
+++ b/app/services/pdf/certificate_scolarite.py
@@ -78,9 +78,7 @@ def generate_certificate_scolarite_pdf(
     class_name = data.get("class_name") or ""
     academic_year_name = data.get("academic_year_name") or ""
     issued_at = data.get("issued_at") or datetime.utcnow()
-    issued_str = (
-        issued_at.strftime("%d/%m/%Y") if isinstance(issued_at, datetime) else ""
-    )
+    issued_str = issued_at.strftime("%d/%m/%Y") if isinstance(issued_at, datetime) else ""
 
     ne_form = "née" if genre == "F" else "né"
     inscrit_form = "inscrite" if genre == "F" else "inscrit"

--- a/app/services/pdf/class_roster.py
+++ b/app/services/pdf/class_roster.py
@@ -27,9 +27,7 @@ from app.services.pdf._class_roster_parts import (
 from app.services.pdf.theme import PDFTheme
 
 
-def generate_class_roster_pdf(
-    data: dict[str, Any], school_settings: dict[str, Any]
-) -> bytes:
+def generate_class_roster_pdf(data: dict[str, Any], school_settings: dict[str, Any]) -> bytes:
     """Génère la liste de classe en PDF — theme école dynamique.
 
     data keys (composé par class_roster_service) :

--- a/app/services/pdf/council_minutes.py
+++ b/app/services/pdf/council_minutes.py
@@ -52,11 +52,7 @@ def generate_council_minutes_pdf(
     generated_at = council_data.get("generated_at")
     decisions = council_data.get("decisions", []) or []
 
-    gen_date = (
-        generated_at.strftime("%d/%m/%Y")
-        if isinstance(generated_at, datetime)
-        else ""
-    )
+    gen_date = generated_at.strftime("%d/%m/%Y") if isinstance(generated_at, datetime) else ""
     total_students = len(decisions)
 
     meta_left = (
@@ -94,7 +90,7 @@ def generate_council_minutes_pdf(
         notes_block = (
             ui.section_title("Observations du conseil", theme=theme)
             + f'<div style="padding:8px 12px; border:1px solid var(--border); '
-            f'border-radius:6px; background:var(--soft-bg); font-size:10.5px; '
+            f"border-radius:6px; background:var(--soft-bg); font-size:10.5px; "
             f'line-height:1.5;">{ui.esc(notes)}</div>'
         )
 

--- a/app/services/pdf/daily_cash_book.py
+++ b/app/services/pdf/daily_cash_book.py
@@ -64,9 +64,7 @@ def _totals_rows(totals_by_method: dict[str, Decimal]) -> list[list[Any]]:
     return rows
 
 
-def generate_daily_cash_book_pdf(
-    data: dict[str, Any], school_settings: dict[str, Any]
-) -> bytes:
+def generate_daily_cash_book_pdf(data: dict[str, Any], school_settings: dict[str, Any]) -> bytes:
     """Génère le bordereau journalier pour une date donnée.
 
     data keys :
@@ -107,9 +105,7 @@ def generate_daily_cash_book_pdf(
         f"{count_completed} versement{'s' if count_completed > 1 else ''} validé{'s' if count_completed > 1 else ''}",
     ]
     if count_cancelled:
-        counts_pieces.append(
-            f"{count_cancelled} annulé{'s' if count_cancelled > 1 else ''}"
-        )
+        counts_pieces.append(f"{count_cancelled} annulé{'s' if count_cancelled > 1 else ''}")
     counts_line = (
         '<div class="muted text-center" style="font-size:9px; margin:-8px 0 12px;">'
         + " · ".join(ui.esc(p) for p in counts_pieces)
@@ -117,36 +113,28 @@ def generate_daily_cash_book_pdf(
     )
 
     total_str = (
-        format_decimal(total_general)
-        if isinstance(total_general, Decimal)
-        else str(total_general)
+        format_decimal(total_general) if isinstance(total_general, Decimal) else str(total_general)
     )
 
-    method_section = (
-        ui.section_title("Récapitulatif par méthode", theme=theme)
-        + ui.premium_table(
-            headers=["Méthode", {"label": "Total XOF", "align": "right"}],
-            rows=_totals_rows(totals_by_method),
-            theme=theme,
-        )
+    method_section = ui.section_title("Récapitulatif par méthode", theme=theme) + ui.premium_table(
+        headers=["Méthode", {"label": "Total XOF", "align": "right"}],
+        rows=_totals_rows(totals_by_method),
+        theme=theme,
     )
 
-    detail_section = (
-        ui.section_title("Détail des versements", theme=theme)
-        + ui.premium_table(
-            headers=[
-                "N°",
-                "Heure",
-                "Élève",
-                "Méthode",
-                "Référence",
-                {"label": "Montant", "align": "right"},
-                "Statut",
-            ],
-            rows=_payment_rows(payments),
-            theme=theme,
-            empty_message="Aucun versement encaissé ce jour.",
-        )
+    detail_section = ui.section_title("Détail des versements", theme=theme) + ui.premium_table(
+        headers=[
+            "N°",
+            "Heure",
+            "Élève",
+            "Méthode",
+            "Référence",
+            {"label": "Montant", "align": "right"},
+            "Statut",
+        ],
+        rows=_payment_rows(payments),
+        theme=theme,
+        empty_message="Aucun versement encaissé ce jour.",
     )
 
     signatures = ui.signature_block(

--- a/app/services/pdf/enrollment_form.py
+++ b/app/services/pdf/enrollment_form.py
@@ -30,9 +30,7 @@ from app.services.pdf._helpers import enum_value
 from app.services.pdf.theme import PDFTheme, status_label
 
 
-def generate_enrollment_form_pdf(
-    data: dict[str, Any], school_settings: dict[str, Any]
-) -> bytes:
+def generate_enrollment_form_pdf(data: dict[str, Any], school_settings: dict[str, Any]) -> bytes:
     """Génère la fiche d'inscription officielle en PDF.
 
     data keys (composé par enrollment_form_service) :

--- a/app/services/pdf/fee_statement.py
+++ b/app/services/pdf/fee_statement.py
@@ -81,9 +81,7 @@ def _payment_rows(payments: list[dict[str, Any]]) -> list[list[Any]]:
     return rows
 
 
-def generate_fee_statement_pdf(
-    data: dict[str, Any], school_settings: dict[str, Any]
-) -> bytes:
+def generate_fee_statement_pdf(data: dict[str, Any], school_settings: dict[str, Any]) -> bytes:
     """Génère un état des frais individuel pour une inscription.
 
     data keys :
@@ -131,37 +129,33 @@ def generate_fee_statement_pdf(
         theme=theme,
     )
 
-    fees_section = (
-        ui.section_title("Détail des frais", theme=theme)
-        + ui.premium_table(
-            headers=[
-                "Catégorie",
-                {"label": "Montant", "align": "right"},
-                {"label": "Versé", "align": "right"},
-                {"label": "Reste", "align": "right"},
-                "Statut",
-            ],
-            rows=_fee_rows(fees),
-            theme=theme,
-            empty_message="Aucun frais configuré pour cette inscription.",
-        )
+    fees_section = ui.section_title("Détail des frais", theme=theme) + ui.premium_table(
+        headers=[
+            "Catégorie",
+            {"label": "Montant", "align": "right"},
+            {"label": "Versé", "align": "right"},
+            {"label": "Reste", "align": "right"},
+            "Statut",
+        ],
+        rows=_fee_rows(fees),
+        theme=theme,
+        empty_message="Aucun frais configuré pour cette inscription.",
     )
 
-    payments_section = (
-        ui.section_title("Historique des versements", theme=theme)
-        + ui.premium_table(
-            headers=[
-                "N°",
-                "Date",
-                "Méthode",
-                "Référence",
-                {"label": "Montant", "align": "right"},
-                "Statut",
-            ],
-            rows=_payment_rows(payments),
-            theme=theme,
-            empty_message="Aucun versement enregistré à ce jour.",
-        )
+    payments_section = ui.section_title(
+        "Historique des versements", theme=theme
+    ) + ui.premium_table(
+        headers=[
+            "N°",
+            "Date",
+            "Méthode",
+            "Référence",
+            {"label": "Montant", "align": "right"},
+            "Statut",
+        ],
+        rows=_payment_rows(payments),
+        theme=theme,
+        empty_message="Aucun versement enregistré à ce jour.",
     )
 
     html = f"""

--- a/app/services/pdf/receipt.py
+++ b/app/services/pdf/receipt.py
@@ -25,21 +25,19 @@ def _allocations_rows(allocations: list[dict[str, Any]]) -> list[list[Any]]:
         amount_str = (
             format_decimal(amount)
             if isinstance(amount, Decimal)
-            else str(amount) if amount is not None else "—"
+            else str(amount)
+            if amount is not None
+            else "—"
         )
         paid_after = a.get("fee_paid_after")
         fee_total = a.get("fee_total")
         cumul = ""
         if paid_after is not None and fee_total is not None:
             paid_str = (
-                format_decimal(paid_after)
-                if isinstance(paid_after, Decimal)
-                else str(paid_after)
+                format_decimal(paid_after) if isinstance(paid_after, Decimal) else str(paid_after)
             )
             total_str = (
-                format_decimal(fee_total)
-                if isinstance(fee_total, Decimal)
-                else str(fee_total)
+                format_decimal(fee_total) if isinstance(fee_total, Decimal) else str(fee_total)
             )
             cumul = f"{paid_str} / {total_str}"
         status_key = a.get("status_after", "")
@@ -54,9 +52,7 @@ def _allocations_rows(allocations: list[dict[str, Any]]) -> list[list[Any]]:
     return rows
 
 
-def generate_receipt_pdf(
-    payment_data: dict[str, Any], school_settings: dict[str, Any]
-) -> bytes:
+def generate_receipt_pdf(payment_data: dict[str, Any], school_settings: dict[str, Any]) -> bytes:
     """Generate a payment receipt PDF — premium template + theme école dynamique.
 
     payment_data keys: payment_id, amount, method, reference, status, notes,
@@ -81,9 +77,7 @@ def generate_receipt_pdf(
     received_by = payment_data.get("received_by_name") or "—"
     allocations = payment_data.get("allocations") or []
 
-    amount_str = (
-        format_decimal(amount) if isinstance(amount, Decimal) else str(amount or "—")
-    )
+    amount_str = format_decimal(amount) if isinstance(amount, Decimal) else str(amount or "—")
     pay_date = (
         created_at.strftime("%d/%m/%Y à %H:%M")
         if isinstance(created_at, datetime)
@@ -109,7 +103,8 @@ def generate_receipt_pdf(
     info_html = (
         '<div class="pdf-info-grid" style="grid-template-columns:1fr;">'
         + "".join(
-            ui.info_row(lbl, val) if not (isinstance(val, str) and val.startswith("<span"))
+            ui.info_row(lbl, val)
+            if not (isinstance(val, str) and val.startswith("<span"))
             else f'<div class="pdf-info-row"><span class="pdf-info-label">{esc(lbl)}</span><span class="pdf-info-value">{val}</span></div>'
             for lbl, val in info_items
         )
@@ -120,18 +115,17 @@ def generate_receipt_pdf(
     allocations_section = ""
     if allocations:
         rows = _allocations_rows(allocations)
-        allocations_section = (
-            ui.section_title("Détail de l'allocation", theme=theme)
-            + ui.premium_table(
-                headers=[
-                    "Frais",
-                    {"label": "Affecté", "align": "right"},
-                    {"label": "Cumul après", "align": "right"},
-                    "Statut",
-                ],
-                rows=rows,
-                theme=theme,
-            )
+        allocations_section = ui.section_title(
+            "Détail de l'allocation", theme=theme
+        ) + ui.premium_table(
+            headers=[
+                "Frais",
+                {"label": "Affecté", "align": "right"},
+                {"label": "Cumul après", "align": "right"},
+                "Statut",
+            ],
+            rows=rows,
+            theme=theme,
         )
 
     # Signatures

--- a/app/services/pdf/theme.py
+++ b/app/services/pdf/theme.py
@@ -19,8 +19,8 @@ from typing import Any
 # Palette KLASSCI par défaut (fallback si school.primary_color is NULL)
 # ---------------------------------------------------------------------------
 
-DEFAULT_PRIMARY = "#0F3F8C"   # Bleu KLASSCI
-DEFAULT_ACCENT = "#F58220"    # Orange KLASSCI
+DEFAULT_PRIMARY = "#0F3F8C"  # Bleu KLASSCI
+DEFAULT_ACCENT = "#F58220"  # Orange KLASSCI
 
 
 @dataclass(frozen=True)
@@ -34,14 +34,14 @@ class PDFTheme:
 
     primary: str = DEFAULT_PRIMARY
     accent: str = DEFAULT_ACCENT
-    ink: str = "#0F172A"          # texte principal
-    muted: str = "#64748B"        # texte secondaire
-    border: str = "#E2E8F0"       # lignes neutres
-    soft_bg: str = "#F8FAFC"      # fond zebra
-    success: str = "#10B981"      # paiement OK
-    warn: str = "#F59E0B"         # partial / warning
-    danger: str = "#EF4444"       # erreur
-    info: str = "#3B82F6"         # info neutre
+    ink: str = "#0F172A"  # texte principal
+    muted: str = "#64748B"  # texte secondaire
+    border: str = "#E2E8F0"  # lignes neutres
+    soft_bg: str = "#F8FAFC"  # fond zebra
+    success: str = "#10B981"  # paiement OK
+    warn: str = "#F59E0B"  # partial / warning
+    danger: str = "#EF4444"  # erreur
+    info: str = "#3B82F6"  # info neutre
     font_family: str = "'Helvetica', 'Arial', sans-serif"
     font_serif: str = "'Georgia', 'Times New Roman', serif"
 

--- a/app/services/pdf/timetable.py
+++ b/app/services/pdf/timetable.py
@@ -61,12 +61,10 @@ def _cell_for_hour(
             teacher = esc(s.get("teacher_name", ""))
             room = esc(s.get("room", ""))
             time_str = f"{s['start_time']}-{s['end_time']}"
-            room_div = (
-                f'<div style="color:var(--muted);">{room}</div>' if room else ""
-            )
+            room_div = f'<div style="color:var(--muted);">{room}</div>' if room else ""
             return (
                 f'<td rowspan="{span}" style="background:{bg}; vertical-align:top; '
-                f'padding:4px; border:1px solid var(--border); font-size:8px; '
+                f"padding:4px; border:1px solid var(--border); font-size:8px; "
                 f'line-height:1.3;">'
                 f'<div style="font-weight:bold; font-size:9px; color:var(--primary);">'
                 f"{subject}</div>"
@@ -122,8 +120,7 @@ def generate_timetable_pdf(
     table_rows = ""
     for hour in hours:
         cells = "".join(
-            _cell_for_hour(slots_by_day[day], hour, subject_colors)
-            for day in _DAYS_ORDER
+            _cell_for_hour(slots_by_day[day], hour, subject_colors) for day in _DAYS_ORDER
         )
         table_rows += f"""
         <tr>

--- a/app/services/student_documents_service.py
+++ b/app/services/student_documents_service.py
@@ -32,8 +32,6 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-
-
 async def _get_active_enrollment(db: AsyncSession, student_id: int) -> Enrollment:
     """Return the student's currently active (status=valide) enrollment.
 


### PR DESCRIPTION
Second hotfix after the merged PR #138 + #139 chain. The CI runs both 'ruff check' (lint) and 'ruff format --check' (style). Only the lint was fixed in #139; this PR fixes the format pass (32 files reformatted, zero semantic change).