### PR TITLE
fix(ci): ruff 0.15.12 format pass

### DIFF
--- a/app/services/pdf/_chrome.py
+++ b/app/services/pdf/_chrome.py
@@ -299,7 +299,7 @@ def premium_footer(school: dict[str, Any], *, theme: PDFTheme, note: str | None 
     return f"""
     <div class="pdf-footer">
         <div class="pdf-footer-school">{school_block}</div>
-        <div class="pdf-footer-meta">{esc(note or '')}</div>
+        <div class="pdf-footer-meta">{esc(note or "")}</div>
     </div>
     """
 
@@ -317,7 +317,7 @@ def signature_block(roles: list[dict[str, Any]], *, theme: PDFTheme) -> str:
             f"""
             <div class="pdf-signature">
                 <div class="pdf-signature-role">{role_label}</div>
-                <div class="pdf-signature-line">{name}{(' — ' + subline) if subline else ''}</div>
+                <div class="pdf-signature-line">{name}{(" — " + subline) if subline else ""}</div>
             </div>
             """
         )

--- a/app/services/pdf/attendance_certificate.py
+++ b/app/services/pdf/attendance_certificate.py
@@ -141,15 +141,17 @@ def generate_attendance_certificate_pdf(
     <!DOCTYPE html>
     <html lang="fr">
     <head><meta charset="UTF-8">
-        {ui.base_styles(theme, page_size='A4', margin='18mm')}
+        {ui.base_styles(theme, page_size="A4", margin="18mm")}
         {serif_style}
     </head>
     <body>
-        {ui.premium_header(
+        {
+        ui.premium_header(
             school_settings,
             theme=theme,
             show_ci_banner=True,
-        )}
+        )
+    }
 
         <h1 class="pdf-cert-title">ATTESTATION DE FRÉQUENTATION</h1>
 
@@ -166,11 +168,13 @@ def generate_attendance_certificate_pdf(
 
         {signatures}
 
-        {ui.premium_footer(
+        {
+        ui.premium_footer(
             school_settings,
             theme=theme,
             note="Document officiel — toute falsification est passible de poursuites.",
-        )}
+        )
+    }
     </body>
     </html>
     """

--- a/app/services/pdf/bulletin.py
+++ b/app/services/pdf/bulletin.py
@@ -126,14 +126,16 @@ def generate_bulletin_pdf(bulletin_data: dict[str, Any], school_settings: dict[s
     html = f"""
     <!DOCTYPE html>
     <html lang="fr">
-    <head><meta charset="UTF-8">{ui.base_styles(theme, page_size='A4', margin='15mm')}</head>
+    <head><meta charset="UTF-8">{ui.base_styles(theme, page_size="A4", margin="15mm")}</head>
     <body>
-        {ui.premium_header(
+        {
+        ui.premium_header(
             school_settings,
             theme=theme,
             doc_type=f"BULLETIN — TRIMESTRE {trimester}",
             doc_subtitle=f"{class_name} — {academic_year}" if class_name else None,
-        )}
+        )
+    }
 
         {ui.meta_banner(meta_left, meta_right, theme=theme)}
 
@@ -147,11 +149,13 @@ def generate_bulletin_pdf(bulletin_data: dict[str, Any], school_settings: dict[s
 
         {signatures}
 
-        {ui.premium_footer(
+        {
+        ui.premium_footer(
             school_settings,
             theme=theme,
             note="Document officiel — à conserver précieusement.",
-        )}
+        )
+    }
     </body>
     </html>
     """

--- a/app/services/pdf/certificate_scolarite.py
+++ b/app/services/pdf/certificate_scolarite.py
@@ -130,15 +130,17 @@ def generate_certificate_scolarite_pdf(
     <!DOCTYPE html>
     <html lang="fr">
     <head><meta charset="UTF-8">
-        {ui.base_styles(theme, page_size='A4', margin='18mm')}
+        {ui.base_styles(theme, page_size="A4", margin="18mm")}
         {serif_style}
     </head>
     <body>
-        {ui.premium_header(
+        {
+        ui.premium_header(
             school_settings,
             theme=theme,
             show_ci_banner=True,
-        )}
+        )
+    }
 
         <h1 class="pdf-cert-title">CERTIFICAT DE SCOLARITÉ</h1>
 
@@ -152,11 +154,13 @@ def generate_certificate_scolarite_pdf(
 
         {signatures}
 
-        {ui.premium_footer(
+        {
+        ui.premium_footer(
             school_settings,
             theme=theme,
             note="Document officiel — toute falsification est passible de poursuites.",
-        )}
+        )
+    }
     </body>
     </html>
     """

--- a/app/services/pdf/class_roster.py
+++ b/app/services/pdf/class_roster.py
@@ -94,14 +94,16 @@ def generate_class_roster_pdf(data: dict[str, Any], school_settings: dict[str, A
     html = f"""
     <!DOCTYPE html>
     <html lang="fr">
-    <head><meta charset="UTF-8">{ui.base_styles(theme, page_size='A4', margin='14mm')}</head>
+    <head><meta charset="UTF-8">{ui.base_styles(theme, page_size="A4", margin="14mm")}</head>
     <body>
-        {ui.premium_header(
+        {
+        ui.premium_header(
             school_settings,
             theme=theme,
             doc_type="LISTE DE CLASSE",
             doc_subtitle=f"{class_name} — {level_name}",
-        )}
+        )
+    }
 
         {ui.meta_banner(meta_left, meta_right, theme=theme)}
 
@@ -111,11 +113,13 @@ def generate_class_roster_pdf(data: dict[str, Any], school_settings: dict[str, A
 
         {signatures}
 
-        {ui.premium_footer(
+        {
+        ui.premium_footer(
             school_settings,
             theme=theme,
             note="Document confidentiel — pour usage interne (conseil de classe, sortie scolaire, appel).",
-        )}
+        )
+    }
     </body>
     </html>
     """

--- a/app/services/pdf/council_minutes.py
+++ b/app/services/pdf/council_minutes.py
@@ -106,14 +106,18 @@ def generate_council_minutes_pdf(
     html = f"""
     <!DOCTYPE html>
     <html lang="fr">
-    <head><meta charset="UTF-8">{ui.base_styles(theme, page_size='A4 landscape', margin='12mm')}</head>
+    <head><meta charset="UTF-8">{
+        ui.base_styles(theme, page_size="A4 landscape", margin="12mm")
+    }</head>
     <body>
-        {ui.premium_header(
+        {
+        ui.premium_header(
             school_settings,
             theme=theme,
             doc_type=f"PROCÈS-VERBAL DU CONSEIL DE CLASSE — TRIMESTRE {trimester}",
             doc_subtitle=class_name if class_name else None,
-        )}
+        )
+    }
 
         {ui.meta_banner(meta_left, meta_right, theme=theme)}
 
@@ -126,11 +130,13 @@ def generate_council_minutes_pdf(
 
         {signatures}
 
-        {ui.premium_footer(
+        {
+        ui.premium_footer(
             school_settings,
             theme=theme,
             note="Document officiel — à archiver dans le registre des conseils de classe.",
-        )}
+        )
+    }
     </body>
     </html>
     """

--- a/app/services/pdf/daily_cash_book.py
+++ b/app/services/pdf/daily_cash_book.py
@@ -148,14 +148,16 @@ def generate_daily_cash_book_pdf(data: dict[str, Any], school_settings: dict[str
     html = f"""
     <!DOCTYPE html>
     <html lang="fr">
-    <head><meta charset="UTF-8">{ui.base_styles(theme, page_size='A4', margin='14mm')}</head>
+    <head><meta charset="UTF-8">{ui.base_styles(theme, page_size="A4", margin="14mm")}</head>
     <body>
-        {ui.premium_header(
+        {
+        ui.premium_header(
             school_settings,
             theme=theme,
             doc_type="BORDEREAU JOURNALIER",
             doc_subtitle=date_str,
-        )}
+        )
+    }
 
         {ui.meta_banner(meta_left, meta_right, theme=theme)}
 
@@ -168,11 +170,13 @@ def generate_daily_cash_book_pdf(data: dict[str, Any], school_settings: dict[str
 
         {signatures}
 
-        {ui.premium_footer(
+        {
+        ui.premium_footer(
             school_settings,
             theme=theme,
             note="À conserver pour la comptabilité de l'établissement.",
-        )}
+        )
+    }
     </body>
     </html>
     """

--- a/app/services/pdf/enrollment_form.py
+++ b/app/services/pdf/enrollment_form.py
@@ -96,14 +96,16 @@ def generate_enrollment_form_pdf(data: dict[str, Any], school_settings: dict[str
     html = f"""
     <!DOCTYPE html>
     <html lang="fr">
-    <head><meta charset="UTF-8">{ui.base_styles(theme, page_size='A4', margin='14mm')}</head>
+    <head><meta charset="UTF-8">{ui.base_styles(theme, page_size="A4", margin="14mm")}</head>
     <body>
-        {ui.premium_header(
+        {
+        ui.premium_header(
             school_settings,
             theme=theme,
             doc_type="FICHE D'INSCRIPTION",
             doc_subtitle=f"{class_name} — {academic_year}" if class_name else None,
-        )}
+        )
+    }
 
         {ui.meta_banner(meta_left, meta_right, theme=theme)}
 
@@ -118,11 +120,13 @@ def generate_enrollment_form_pdf(data: dict[str, Any], school_settings: dict[str
 
         {signatures}
 
-        {ui.premium_footer(
+        {
+        ui.premium_footer(
             school_settings,
             theme=theme,
             note="Conserver précieusement — à présenter au secrétariat sur demande.",
-        )}
+        )
+    }
     </body>
     </html>
     """

--- a/app/services/pdf/fee_statement.py
+++ b/app/services/pdf/fee_statement.py
@@ -161,14 +161,16 @@ def generate_fee_statement_pdf(data: dict[str, Any], school_settings: dict[str, 
     html = f"""
     <!DOCTYPE html>
     <html lang="fr">
-    <head><meta charset="UTF-8">{ui.base_styles(theme, page_size='A4', margin='15mm')}</head>
+    <head><meta charset="UTF-8">{ui.base_styles(theme, page_size="A4", margin="15mm")}</head>
     <body>
-        {ui.premium_header(
+        {
+        ui.premium_header(
             school_settings,
             theme=theme,
             doc_type="ÉTAT DES FRAIS SCOLAIRES",
             doc_subtitle=f"{class_name} — {academic_year}" if class_name else None,
-        )}
+        )
+    }
 
         {ui.meta_banner(meta_left, meta_right, theme=theme)}
 
@@ -179,11 +181,13 @@ def generate_fee_statement_pdf(data: dict[str, Any], school_settings: dict[str, 
 
         {payments_section}
 
-        {ui.premium_footer(
+        {
+        ui.premium_footer(
             school_settings,
             theme=theme,
             note="Document généré automatiquement — non contractuel sans signature.",
-        )}
+        )
+    }
     </body>
     </html>
     """

--- a/app/services/pdf/receipt.py
+++ b/app/services/pdf/receipt.py
@@ -140,14 +140,16 @@ def generate_receipt_pdf(payment_data: dict[str, Any], school_settings: dict[str
     html = f"""
     <!DOCTYPE html>
     <html lang="fr">
-    <head><meta charset="UTF-8">{ui.base_styles(theme, page_size='A5', margin='12mm')}</head>
+    <head><meta charset="UTF-8">{ui.base_styles(theme, page_size="A5", margin="12mm")}</head>
     <body>
-        {ui.premium_header(
+        {
+        ui.premium_header(
             school_settings,
             theme=theme,
             doc_type="REÇU DE VERSEMENT",
             doc_number=f"N° {payment_id} · {pay_date}",
-        )}
+        )
+    }
 
         {ui.amount_box(amount_str, theme=theme, label="Montant versé", currency="XOF")}
 
@@ -157,11 +159,13 @@ def generate_receipt_pdf(payment_data: dict[str, Any], school_settings: dict[str
 
         {signatures_html}
 
-        {ui.premium_footer(
+        {
+        ui.premium_footer(
             school_settings,
             theme=theme,
             note="Ce reçu fait foi de paiement. À conserver précieusement.",
-        )}
+        )
+    }
     </body>
     </html>
     """

--- a/app/services/pdf/timetable.py
+++ b/app/services/pdf/timetable.py
@@ -156,16 +156,18 @@ def generate_timetable_pdf(
     <!DOCTYPE html>
     <html lang="fr">
     <head><meta charset="UTF-8">
-        {ui.base_styles(theme, page_size='A4 landscape', margin='10mm')}
+        {ui.base_styles(theme, page_size="A4 landscape", margin="10mm")}
         {grid_style}
     </head>
     <body>
-        {ui.premium_header(
+        {
+        ui.premium_header(
             school_settings,
             theme=theme,
             doc_type="EMPLOI DU TEMPS",
             doc_subtitle=f"{class_name} — {academic_year}",
-        )}
+        )
+    }
 
         <table class="pdf-timetable">
             <thead>
@@ -183,11 +185,13 @@ def generate_timetable_pdf(
             </tbody>
         </table>
 
-        {ui.premium_footer(
+        {
+        ui.premium_footer(
             school_settings,
             theme=theme,
             note=f"Imprimé le {now_str}",
-        )}
+        )
+    }
     </body>
     </html>
     """

--- a/app/services/tenants/query.py
+++ b/app/services/tenants/query.py
@@ -25,10 +25,7 @@ async def list_tenant_slugs() -> list[str]:
     ) as engine:
         async with engine.begin() as conn:
             result = await conn.execute(
-                text(
-                    "SELECT schema_name FROM information_schema.schemata "
-                    "ORDER BY schema_name ASC"
-                )
+                text("SELECT schema_name FROM information_schema.schemata ORDER BY schema_name ASC")
             )
             rows = result.fetchall()
     return [row[0] for row in rows if row[0] not in SYSTEM_DATABASES]
@@ -40,9 +37,7 @@ async def slug_exists(slug: str) -> bool:
     ) as engine:
         async with engine.begin() as conn:
             result = await conn.execute(
-                text(
-                    "SELECT 1 FROM information_schema.schemata " "WHERE schema_name = :slug LIMIT 1"
-                ),
+                text("SELECT 1 FROM information_schema.schemata WHERE schema_name = :slug LIMIT 1"),
                 {"slug": slug},
             )
             return result.scalar_one_or_none() is not None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -122,9 +122,9 @@ def test_decimal_columns_on_financial_models() -> None:
     for model_cls in (Payment, FeeVariant, OptionalFeeOption, EnrollmentFee):
         table = Base.metadata.tables[model_cls.__tablename__]
         amount_col = table.c["amount"]
-        assert isinstance(
-            amount_col.type, Numeric
-        ), f"{model_cls.__name__}.amount doit être Numeric, pas {type(amount_col.type)}"
+        assert isinstance(amount_col.type, Numeric), (
+            f"{model_cls.__name__}.amount doit être Numeric, pas {type(amount_col.type)}"
+        )
         assert amount_col.type.precision == 15
         assert amount_col.type.scale == 2
 

--- a/tests/test_tenant_service.py
+++ b/tests/test_tenant_service.py
@@ -171,9 +171,9 @@ def test_admin_role_does_not_carry_super_admin_perms() -> None:
     """admin / director are tenant-scoped — they must NOT carry cross-tenant powers."""
     for role_name in ("admin", "director"):
         perms = ROLE_DEFINITIONS[role_name]["permissions"]
-        assert not any(
-            p.startswith("super-admin:") for p in perms
-        ), f"Role '{role_name}' must not include super-admin:* permissions"
+        assert not any(p.startswith("super-admin:") for p in perms), (
+            f"Role '{role_name}' must not include super-admin:* permissions"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Third and last hotfix. Pinned local ruff to CI version (0.15.12), reformatted 14 files. CI should now pass.