### PR TITLE
fix(test): align fixtures with refactored schemas

### DIFF
--- a/tests/routers/test_admin.py
+++ b/tests/routers/test_admin.py
@@ -358,7 +358,12 @@ def test_create_staff_success() -> None:
             with TestClient(app) as client:
                 resp = client.post(
                     "/admin/staff",
-                    json={"first_name": "Paul", "last_name": "Kone", "user_id": 3},
+                    json={
+                        "first_name": "Paul",
+                        "last_name": "Kone",
+                        "email": "paul.kone@klassci.local",
+                        "password": "Strong@2026",
+                    },
                 )
     finally:
         _clear_deps()

--- a/tests/routers/test_student_documents.py
+++ b/tests/routers/test_student_documents.py
@@ -65,7 +65,7 @@ def test_get_certificat_success() -> None:
                 ),
             ),
             patch(
-                "app.services.student_documents_service._get_school_settings_dict",
+                "app.services._school_settings_helper.load_school_settings_for_pdf",
                 new=AsyncMock(return_value={"school_name": "Ecole Test"}),
             ),
             patch(


### PR DESCRIPTION
Two test fixes following PR #138 + PR #141:
- StaffCreate now requires email + password
- _get_school_settings_dict moved to _school_settings_helper