### PR TITLE
feat(teachers): Phase 7b BE foundation — teacher session attendance

### DIFF
--- a/alembic/versions/20260519_0030_teacher_session_attendance.py
+++ b/alembic/versions/20260519_0030_teacher_session_attendance.py
@@ -1,0 +1,129 @@
+"""teacher_session_attendance — pointage enseignant par créneau EDT
+
+Phase 7b (KLASSCI College 2026-05-19) — Marcel a tranché :
+- Granularité : par slot EDT (slot_id nullable pour absences hors EDT)
+- Saisie hybride : admin/staff (validé direct) OU prof self-déclaré (validation après)
+- Retards : compteur minutes (int précis pour calcul salaire DREN)
+
+Revision ID: 0030_teacher_attendance
+Revises: 0029_school_pdf_customization
+Create Date: 2026-05-19
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0030_teacher_attendance"
+down_revision = "0029_school_pdf_customization"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "teacher_session_attendance",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("teacher_id", sa.BigInteger(), nullable=False),
+        sa.Column("slot_id", sa.BigInteger(), nullable=True),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("academic_year_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "present",
+                "absent_excused",
+                "absent_unexcused",
+                "late",
+                name="teacher_attendance_status",
+            ),
+            nullable=False,
+            server_default="present",
+        ),
+        sa.Column("late_minutes", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("declared_by_user_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "declared_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "is_validated",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+        sa.Column("validated_by_user_id", sa.BigInteger(), nullable=True),
+        sa.Column("validated_at", sa.DateTime(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["teacher_id"], ["teacher_profiles.id"], ondelete="RESTRICT",
+            name="fk_tsa_teacher",
+        ),
+        sa.ForeignKeyConstraint(
+            ["slot_id"], ["timetable_slots.id"], ondelete="SET NULL",
+            name="fk_tsa_slot",
+        ),
+        sa.ForeignKeyConstraint(
+            ["academic_year_id"], ["academic_years.id"], ondelete="RESTRICT",
+            name="fk_tsa_academic_year",
+        ),
+        sa.ForeignKeyConstraint(
+            ["declared_by_user_id"], ["users.id"], ondelete="RESTRICT",
+            name="fk_tsa_declared_by",
+        ),
+        sa.ForeignKeyConstraint(
+            ["validated_by_user_id"], ["users.id"], ondelete="SET NULL",
+            name="fk_tsa_validated_by",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "idx_tsa_teacher_date",
+        "teacher_session_attendance",
+        ["teacher_id", "date"],
+    )
+    op.create_index(
+        "idx_tsa_slot",
+        "teacher_session_attendance",
+        ["slot_id"],
+    )
+    op.create_index(
+        "idx_tsa_ay_status",
+        "teacher_session_attendance",
+        ["academic_year_id", "status"],
+    )
+    op.create_index(
+        "idx_tsa_validation",
+        "teacher_session_attendance",
+        ["is_validated"],
+    )
+
+
+def downgrade() -> None:
+    # Drop FKs before indexes (MySQL 1553 prevention — voir migration 0028)
+    op.drop_constraint("fk_tsa_validated_by", "teacher_session_attendance", type_="foreignkey")
+    op.drop_constraint("fk_tsa_declared_by", "teacher_session_attendance", type_="foreignkey")
+    op.drop_constraint("fk_tsa_academic_year", "teacher_session_attendance", type_="foreignkey")
+    op.drop_constraint("fk_tsa_slot", "teacher_session_attendance", type_="foreignkey")
+    op.drop_constraint("fk_tsa_teacher", "teacher_session_attendance", type_="foreignkey")
+    op.drop_index("idx_tsa_validation", table_name="teacher_session_attendance")
+    op.drop_index("idx_tsa_ay_status", table_name="teacher_session_attendance")
+    op.drop_index("idx_tsa_slot", table_name="teacher_session_attendance")
+    op.drop_index("idx_tsa_teacher_date", table_name="teacher_session_attendance")
+    op.drop_table("teacher_session_attendance")

--- a/app/main.py
+++ b/app/main.py
@@ -32,6 +32,8 @@ from app.routers.reports import router as reports_router
 from app.routers.student_documents import router as student_documents_router
 from app.routers.student_portal import router as student_portal_router
 from app.routers.super_admin import router as super_admin_router
+from app.routers.teacher_attendance import admin_router as teacher_attendance_admin_router
+from app.routers.teacher_attendance import teacher_router as teacher_attendance_teacher_router
 from app.routers.teacher_portal import router as teacher_portal_router
 from app.routers.timetable import availability_router, teachers_router
 from app.routers.timetable import router as timetable_router
@@ -93,6 +95,8 @@ app.include_router(super_admin_router)
 app.include_router(timetable_router)
 app.include_router(teachers_router)
 app.include_router(availability_router)
+app.include_router(teacher_attendance_admin_router)
+app.include_router(teacher_attendance_teacher_router)
 
 
 # ---------------------------------------------------------------------------

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -23,6 +23,8 @@ from app.models.attendance import (  # noqa: F401
     AttendanceRecord,
     AttendanceSource,
     AttendanceStatus,
+    TeacherAttendanceStatus,
+    TeacherSessionAttendance,
 )
 
 # Audit log (défini dans app.core.audit, re-exporté ici)

--- a/app/models/attendance.py
+++ b/app/models/attendance.py
@@ -1,12 +1,12 @@
-"""Modèles de présence : AttendanceContext, AttendanceRecord."""
+"""Modèles de présence : AttendanceContext, AttendanceRecord, TeacherSessionAttendance."""
 
 from __future__ import annotations
 
 import enum
-from datetime import date, time
+from datetime import date, datetime, time
 from typing import TYPE_CHECKING
 
-from sqlalchemy import BigInteger, Date, ForeignKey, String, Time
+from sqlalchemy import BigInteger, Boolean, Date, DateTime, ForeignKey, Integer, String, Text, Time
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.database import Base
@@ -14,7 +14,8 @@ from app.models.base import TimestampMixin, ValueEnum
 
 if TYPE_CHECKING:
     from app.models.academic import AcademicYear
-    from app.models.user import Student
+    from app.models.timetable import TimetableSlot
+    from app.models.user import Student, TeacherProfile, User
 
 
 class AttendanceEntityType(str, enum.Enum):
@@ -88,3 +89,92 @@ class AttendanceRecord(Base, TimestampMixin):
 
     context: Mapped[AttendanceContext] = relationship(back_populates="records")
     student: Mapped[Student] = relationship()
+
+
+# ---------------------------------------------------------------------------
+# Teacher session attendance — pointage enseignant par créneau EDT
+# ---------------------------------------------------------------------------
+
+
+class TeacherAttendanceStatus(str, enum.Enum):
+    """Statut de présence d'un enseignant à son créneau EDT.
+
+    Modèle ivoirien : prof se déplace entre classes, peut rater un cours
+    spécifique sans rater toute la journée. Granularité = slot EDT
+    (référence rule `klassci-rooms-ivory-coast-model.md`).
+    """
+
+    PRESENT = "present"
+    ABSENT_EXCUSED = "absent_excused"
+    ABSENT_UNEXCUSED = "absent_unexcused"
+    LATE = "late"
+
+
+class TeacherSessionAttendance(Base, TimestampMixin):
+    """Pointage d'une séance enseignant.
+
+    Granularité = un row par (teacher, slot, date). Un slot EDT récurrent
+    (lundi 10h-11h Maths 6ème B) produit 1 row par instance datée.
+    `slot_id` nullable : permet une absence "hors EDT" (réunion DREN,
+    formation, congé maladie sans slot précis ce jour-là).
+
+    Workflow validation hybride (Marcel 2026-05-19) :
+    - Admin/staff saisit directement → `is_validated=True` instantané
+    - Prof se déclare lui-même → `is_validated=False`, admin valide après
+    """
+
+    __tablename__ = "teacher_session_attendance"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+
+    # Qui (teacher) + Quand (slot + date) + Où (académique)
+    teacher_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("teacher_profiles.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+    slot_id: Mapped[int | None] = mapped_column(
+        BigInteger,
+        ForeignKey("timetable_slots.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    date: Mapped[date] = mapped_column(Date, nullable=False, index=True)
+    academic_year_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("academic_years.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+
+    # Quoi
+    status: Mapped[str] = mapped_column(
+        ValueEnum(TeacherAttendanceStatus, name="teacher_attendance_status"),
+        nullable=False,
+        default=TeacherAttendanceStatus.PRESENT,
+        index=True,
+    )
+    late_minutes: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Workflow validation
+    declared_by_user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    declared_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
+    is_validated: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    validated_by_user_id: Mapped[int | None] = mapped_column(
+        BigInteger,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    validated_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+    teacher: Mapped[TeacherProfile] = relationship(foreign_keys=[teacher_id])
+    slot: Mapped[TimetableSlot | None] = relationship(foreign_keys=[slot_id])
+    academic_year: Mapped[AcademicYear] = relationship()
+    declared_by: Mapped[User] = relationship(foreign_keys=[declared_by_user_id])
+    validated_by: Mapped[User | None] = relationship(foreign_keys=[validated_by_user_id])

--- a/app/repositories/teacher_attendance_repository.py
+++ b/app/repositories/teacher_attendance_repository.py
@@ -1,0 +1,201 @@
+"""Repository — accès DB pour TeacherSessionAttendance (Phase 7b)."""
+
+from __future__ import annotations
+
+from datetime import date as date_type
+from typing import Any
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.academic import AcademicYear
+from app.models.attendance import TeacherAttendanceStatus, TeacherSessionAttendance
+from app.models.timetable import TimetableSlot
+from app.models.user import User
+
+# ---------------------------------------------------------------------------
+# Read — selectinload exhaustif (preload-relations-after-commit rule)
+# ---------------------------------------------------------------------------
+
+
+def _full_load_options() -> list[Any]:
+    """Chaîne selectinload utilisée par tout GET retournant un response Pydantic."""
+    return [
+        selectinload(TeacherSessionAttendance.teacher),
+        selectinload(TeacherSessionAttendance.slot).selectinload(TimetableSlot.subject),
+        selectinload(TeacherSessionAttendance.slot).selectinload(TimetableSlot.class_),
+        selectinload(TeacherSessionAttendance.academic_year),
+        selectinload(TeacherSessionAttendance.declared_by),
+        selectinload(TeacherSessionAttendance.validated_by),
+    ]
+
+
+async def get_by_id(db: AsyncSession, attendance_id: int) -> TeacherSessionAttendance | None:
+    stmt = (
+        select(TeacherSessionAttendance)
+        .where(TeacherSessionAttendance.id == attendance_id)
+        .options(*_full_load_options())
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_by_teacher(
+    db: AsyncSession,
+    teacher_id: int,
+    academic_year_id: int | None = None,
+    status: str | None = None,
+    date_from: date_type | None = None,
+    date_to: date_type | None = None,
+    page: int = 1,
+    per_page: int = 50,
+) -> tuple[list[TeacherSessionAttendance], int]:
+    """Liste paginée filtrée."""
+    conditions = [TeacherSessionAttendance.teacher_id == teacher_id]
+    if academic_year_id is not None:
+        conditions.append(TeacherSessionAttendance.academic_year_id == academic_year_id)
+    if status is not None:
+        conditions.append(TeacherSessionAttendance.status == status)
+    if date_from is not None:
+        conditions.append(TeacherSessionAttendance.date >= date_from)
+    if date_to is not None:
+        conditions.append(TeacherSessionAttendance.date <= date_to)
+
+    base_stmt = select(TeacherSessionAttendance).where(and_(*conditions))
+
+    count_stmt = select(func.count()).select_from(base_stmt.subquery())
+    total = (await db.execute(count_stmt)).scalar() or 0
+
+    list_stmt = (
+        base_stmt.options(*_full_load_options())
+        .order_by(TeacherSessionAttendance.date.desc(), TeacherSessionAttendance.id.desc())
+        .offset((page - 1) * per_page)
+        .limit(per_page)
+    )
+    result = await db.execute(list_stmt)
+    return list(result.scalars().all()), total
+
+
+# ---------------------------------------------------------------------------
+# Stats agrégées (utilisé par GET /admin/teachers/{id}/attendance/stats)
+# ---------------------------------------------------------------------------
+
+
+async def count_by_status(
+    db: AsyncSession,
+    teacher_id: int,
+    academic_year_id: int,
+) -> dict[str, int]:
+    """Compte par status pour l'AY donnée. Retourne dict status → count."""
+    stmt = (
+        select(TeacherSessionAttendance.status, func.count())
+        .where(
+            TeacherSessionAttendance.teacher_id == teacher_id,
+            TeacherSessionAttendance.academic_year_id == academic_year_id,
+            TeacherSessionAttendance.is_validated.is_(True),
+        )
+        .group_by(TeacherSessionAttendance.status)
+    )
+    result = await db.execute(stmt)
+    return {row[0]: row[1] for row in result.all()}
+
+
+async def sum_late_minutes(
+    db: AsyncSession,
+    teacher_id: int,
+    academic_year_id: int,
+) -> int:
+    """Total minutes de retard cumulées pour l'AY (statuts LATE validés)."""
+    stmt = select(func.coalesce(func.sum(TeacherSessionAttendance.late_minutes), 0)).where(
+        TeacherSessionAttendance.teacher_id == teacher_id,
+        TeacherSessionAttendance.academic_year_id == academic_year_id,
+        TeacherSessionAttendance.status == TeacherAttendanceStatus.LATE,
+        TeacherSessionAttendance.is_validated.is_(True),
+    )
+    result = await db.execute(stmt)
+    return int(result.scalar() or 0)
+
+
+async def count_pending_validation(
+    db: AsyncSession,
+    teacher_id: int,
+) -> int:
+    """Auto-déclarations en attente de validation admin."""
+    stmt = select(func.count()).where(
+        TeacherSessionAttendance.teacher_id == teacher_id,
+        TeacherSessionAttendance.is_validated.is_(False),
+    )
+    result = await db.execute(stmt)
+    return int(result.scalar() or 0)
+
+
+# ---------------------------------------------------------------------------
+# Slot ownership check (prevent admin from declaring on a slot that does
+# not belong to the teacher — sloppy admin protection).
+# ---------------------------------------------------------------------------
+
+
+async def slot_belongs_to_teacher(db: AsyncSession, slot_id: int, teacher_id: int) -> bool:
+    stmt = select(TimetableSlot.id).where(
+        TimetableSlot.id == slot_id,
+        TimetableSlot.teacher_id == teacher_id,
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none() is not None
+
+
+# ---------------------------------------------------------------------------
+# Unique constraint helper (1 row par teacher+slot+date)
+# ---------------------------------------------------------------------------
+
+
+async def exists_for(
+    db: AsyncSession, teacher_id: int, slot_id: int | None, the_date: date_type
+) -> TeacherSessionAttendance | None:
+    """Retourne la row existante (teacher, slot, date) si présente. Sinon None.
+
+    Pour `slot_id IS NULL` (absence hors EDT), on accepte plusieurs rows par
+    teacher+date (réunion + congé maladie sur même jour possible).
+    """
+    if slot_id is None:
+        return None  # pas d'unicité sans slot
+    stmt = select(TeacherSessionAttendance).where(
+        TeacherSessionAttendance.teacher_id == teacher_id,
+        TeacherSessionAttendance.slot_id == slot_id,
+        TeacherSessionAttendance.date == the_date,
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+# ---------------------------------------------------------------------------
+# Current AY helper
+# ---------------------------------------------------------------------------
+
+
+async def get_current_academic_year(db: AsyncSession) -> AcademicYear | None:
+    stmt = select(AcademicYear).where(AcademicYear.is_current.is_(True)).limit(1)
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+# ---------------------------------------------------------------------------
+# Count théorique des sessions EDT (pour `attendance_rate` denominator)
+# ---------------------------------------------------------------------------
+
+
+async def count_user_id_for_teacher(db: AsyncSession, teacher_id: int) -> int | None:
+    """Helper : retourne le user_id du teacher (pour permissions / audit)."""
+    from app.models.user import TeacherProfile
+
+    stmt = select(TeacherProfile.user_id).where(TeacherProfile.id == teacher_id)
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def get_user_by_id(db: AsyncSession, user_id: int) -> User | None:
+    """Helper : récupère un user (pour audit_log + email dans response)."""
+    stmt = select(User).where(User.id == user_id)
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()

--- a/app/routers/teacher_attendance.py
+++ b/app/routers/teacher_attendance.py
@@ -1,0 +1,153 @@
+"""Router pointage enseignant (Phase 7b).
+
+Endpoints :
+- POST   /admin/teachers/{teacher_id}/attendance         — admin/staff saisit
+- GET    /admin/teachers/{teacher_id}/attendance         — liste filtrée
+- GET    /admin/teachers/{teacher_id}/attendance/stats   — KPIs AY
+- PATCH  /admin/teacher-attendance/{attendance_id}/validate — valide auto-décl
+- DELETE /admin/teacher-attendance/{attendance_id}       — annulation admin
+- POST   /teacher/attendance/self-declare                — prof se déclare
+"""
+
+from __future__ import annotations
+
+from datetime import date as date_type
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import (
+    TokenData,
+    get_current_user,
+    get_tenant_db,
+    require_permission,
+)
+from app.schemas.teacher_attendance import (
+    TeacherAttendanceCreate,
+    TeacherAttendanceListResponse,
+    TeacherAttendanceResponse,
+    TeacherAttendanceStats,
+    TeacherAttendanceValidate,
+    TeacherSelfDeclareCreate,
+)
+from app.services import teacher_attendance_service as service
+
+admin_router = APIRouter(prefix="/admin", tags=["teacher-attendance"])
+teacher_router = APIRouter(prefix="/teacher", tags=["teacher-attendance"])
+
+
+# ---------------------------------------------------------------------------
+# Admin / staff endpoints
+# ---------------------------------------------------------------------------
+
+
+@admin_router.post(
+    "/teachers/{teacher_id}/attendance",
+    response_model=TeacherAttendanceResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def admin_record_attendance(
+    teacher_id: int,
+    data: TeacherAttendanceCreate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:teachers:attendance"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> Any:
+    """Saisie d'un pointage par admin/staff (validé immédiatement)."""
+    return await service.record_attendance(
+        db, teacher_id, data, declared_by_user_id=current_user.user_id
+    )
+
+
+@admin_router.get(
+    "/teachers/{teacher_id}/attendance",
+    response_model=TeacherAttendanceListResponse,
+)
+async def admin_list_attendance(
+    teacher_id: int,
+    academic_year_id: int | None = Query(None),
+    status_filter: str | None = Query(None, alias="status"),
+    date_from: date_type | None = Query(None),
+    date_to: date_type | None = Query(None),
+    page: int = Query(1, ge=1),
+    per_page: int = Query(50, ge=1, le=200),
+    _: None = require_permission("admin:teachers:attendance:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> Any:
+    """Liste filtrée des pointages d'un enseignant."""
+    return await service.list_for_teacher(
+        db,
+        teacher_id=teacher_id,
+        academic_year_id=academic_year_id,
+        status=status_filter,
+        date_from=date_from,
+        date_to=date_to,
+        page=page,
+        per_page=per_page,
+    )
+
+
+@admin_router.get(
+    "/teachers/{teacher_id}/attendance/stats",
+    response_model=TeacherAttendanceStats,
+)
+async def admin_get_stats(
+    teacher_id: int,
+    academic_year_id: int | None = Query(None),
+    _: None = require_permission("admin:teachers:attendance:read"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> Any:
+    """KPIs agrégés pour la fiche teacher 360° tab Présences."""
+    return await service.compute_stats(db, teacher_id=teacher_id, academic_year_id=academic_year_id)
+
+
+@admin_router.patch(
+    "/teacher-attendance/{attendance_id}/validate",
+    response_model=TeacherAttendanceResponse,
+)
+async def admin_validate_attendance(
+    attendance_id: int,
+    data: TeacherAttendanceValidate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:teachers:attendance"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> Any:
+    """Valide ou rejette une auto-déclaration prof."""
+    return await service.validate_attendance(
+        db, attendance_id, data, validated_by_user_id=current_user.user_id
+    )
+
+
+@admin_router.delete(
+    "/teacher-attendance/{attendance_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def admin_delete_attendance(
+    attendance_id: int,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("admin:teachers:attendance"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> None:
+    """Annulation totale d'un pointage (admin uniquement)."""
+    await service.delete_attendance(db, attendance_id, deleted_by_user_id=current_user.user_id)
+
+
+# ---------------------------------------------------------------------------
+# Teacher portal endpoint — auto-déclaration
+# ---------------------------------------------------------------------------
+
+
+@teacher_router.post(
+    "/attendance/self-declare",
+    response_model=TeacherAttendanceResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def teacher_self_declare(
+    data: TeacherSelfDeclareCreate,
+    current_user: TokenData = Depends(get_current_user),
+    _: None = require_permission("teacher:attendance:self_declare"),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> Any:
+    """Le prof se déclare absent/en retard — en attente de validation admin."""
+    return await service.self_declare(db, teacher_user_id=current_user.user_id, data=data)

--- a/app/schemas/teacher_attendance.py
+++ b/app/schemas/teacher_attendance.py
@@ -1,0 +1,134 @@
+"""Schemas Pydantic pour le pointage enseignant (Phase 7b).
+
+Endpoints couverts :
+- POST /admin/teachers/{id}/attendance (admin/staff saisit, validé direct)
+- POST /teacher/attendance/self-declare (prof se déclare, en attente)
+- PATCH /admin/teacher-attendance/{id}/validate (admin valide auto-décl)
+- GET /admin/teachers/{id}/attendance (liste filtrée)
+- GET /admin/teachers/{id}/attendance/stats (KPIs)
+"""
+
+from __future__ import annotations
+
+from datetime import date as date_type
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+TeacherAttendanceStatusLiteral = Literal[
+    "present",
+    "absent_excused",
+    "absent_unexcused",
+    "late",
+]
+
+
+# ---------------------------------------------------------------------------
+# Input
+# ---------------------------------------------------------------------------
+
+
+class TeacherAttendanceCreate(BaseModel):
+    """Saisie d'un pointage par admin/staff.
+
+    `slot_id` optionnel : permet de noter une absence hors EDT (réunion DREN,
+    congé maladie sans slot précis). Si fourni, doit appartenir au teacher.
+
+    `late_minutes` ignoré si `status != "late"`.
+    """
+
+    slot_id: int | None = None
+    date: date_type
+    status: TeacherAttendanceStatusLiteral
+    late_minutes: int = Field(default=0, ge=0, le=480)  # max 8h = 480min
+    notes: str | None = Field(default=None, max_length=1000)
+
+    @field_validator("late_minutes")
+    @classmethod
+    def normalize_late_minutes(cls, v: int, info) -> int:  # type: ignore[no-untyped-def]
+        status = info.data.get("status")
+        if status != "late":
+            return 0
+        return v
+
+
+class TeacherSelfDeclareCreate(BaseModel):
+    """Auto-déclaration par le prof — toujours en attente de validation admin.
+
+    Le `teacher_id` est résolu depuis le JWT (current user). On laisse
+    juste les champs métier.
+    """
+
+    slot_id: int | None = None
+    date: date_type
+    status: TeacherAttendanceStatusLiteral
+    late_minutes: int = Field(default=0, ge=0, le=480)
+    notes: str | None = Field(default=None, max_length=1000)
+
+
+class TeacherAttendanceValidate(BaseModel):
+    """Validation admin d'une auto-déclaration.
+
+    `approved=False` rejette : on conserve la row pour audit mais
+    `is_validated` reste False + `validated_by` rempli.
+    """
+
+    approved: bool = True
+    admin_notes: str | None = Field(default=None, max_length=500)
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+class TeacherAttendanceResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    teacher_id: int
+    teacher_full_name: str
+    slot_id: int | None
+    slot_summary: str | None  # ex: "Lundi 10h-11h Maths 6ème B" (composé service)
+    date: date_type
+    academic_year_id: int
+    status: TeacherAttendanceStatusLiteral
+    late_minutes: int
+    notes: str | None
+
+    declared_by_user_id: int
+    declared_by_email: str | None
+    declared_at: datetime
+    is_validated: bool
+    validated_by_user_id: int | None
+    validated_by_email: str | None
+    validated_at: datetime | None
+
+    created_at: datetime
+    updated_at: datetime
+
+
+class TeacherAttendanceListResponse(BaseModel):
+    items: list[TeacherAttendanceResponse]
+    total: int
+
+
+class TeacherAttendanceStats(BaseModel):
+    """KPIs agrégés pour la fiche teacher 360° tab Présences."""
+
+    teacher_id: int
+    academic_year_id: int
+    academic_year_name: str
+
+    total_sessions: int  # = slots EDT du teacher pour l'AY (théorique)
+    sessions_present: int
+    sessions_absent_excused: int
+    sessions_absent_unexcused: int
+    sessions_late: int
+
+    attendance_rate: float  # 0-100, présent / total
+    total_late_minutes: int
+    avg_late_minutes_when_late: float  # 0 si jamais en retard
+
+    pending_validation_count: int  # auto-déclarations en attente admin

--- a/app/services/teacher_attendance_service.py
+++ b/app/services/teacher_attendance_service.py
@@ -1,0 +1,421 @@
+"""Service pointage enseignant — workflow hybride (Phase 7b).
+
+Marcel 2026-05-19 :
+- Admin/staff saisit → validé immédiatement (is_validated=True)
+- Prof self-declare → en attente (is_validated=False), admin valide après
+- Granularité slot EDT (slot_id nullable pour absences hors EDT)
+- Retards : compteur minutes (int)
+"""
+
+from __future__ import annotations
+
+from datetime import date as date_type
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.audit import AuditAction, audit_log
+from app.core.exceptions import BusinessValidationError, NotFoundError
+from app.models.attendance import TeacherAttendanceStatus, TeacherSessionAttendance
+from app.models.user import TeacherProfile
+from app.repositories import teacher_attendance_repository as repo
+from app.schemas.teacher_attendance import (
+    TeacherAttendanceCreate,
+    TeacherAttendanceListResponse,
+    TeacherAttendanceResponse,
+    TeacherAttendanceStats,
+    TeacherAttendanceValidate,
+    TeacherSelfDeclareCreate,
+)
+
+# ---------------------------------------------------------------------------
+# Mapping ORM → Response Pydantic
+# ---------------------------------------------------------------------------
+
+
+def _slot_summary(att: TeacherSessionAttendance) -> str | None:
+    """Compose un libellé lisible 'Lundi 10h-11h Maths 6ème B'."""
+    if att.slot is None:
+        return None
+    s = att.slot
+    day_fr = {
+        "monday": "Lundi",
+        "tuesday": "Mardi",
+        "wednesday": "Mercredi",
+        "thursday": "Jeudi",
+        "friday": "Vendredi",
+        "saturday": "Samedi",
+        "sunday": "Dimanche",
+    }
+    day = day_fr.get(s.day, s.day or "")
+    start = s.start_time if isinstance(s.start_time, str) else s.start_time.strftime("%H:%M")
+    end = s.end_time if isinstance(s.end_time, str) else s.end_time.strftime("%H:%M")
+    subject_name = s.subject.name if getattr(s, "subject", None) else ""
+    class_name = s.class_.name if getattr(s, "class_", None) else ""
+    parts = [day, f"{start}-{end}"]
+    if subject_name:
+        parts.append(subject_name)
+    if class_name:
+        parts.append(class_name)
+    return " ".join(parts).strip()
+
+
+def _to_response(att: TeacherSessionAttendance) -> TeacherAttendanceResponse:
+    teacher_full = ""
+    if att.teacher is not None:
+        teacher_full = f"{att.teacher.first_name} {att.teacher.last_name}".strip()
+    declared_email = att.declared_by.email if att.declared_by else None
+    validated_email = att.validated_by.email if att.validated_by else None
+    return TeacherAttendanceResponse(
+        id=att.id,
+        teacher_id=att.teacher_id,
+        teacher_full_name=teacher_full,
+        slot_id=att.slot_id,
+        slot_summary=_slot_summary(att),
+        date=att.date,
+        academic_year_id=att.academic_year_id,
+        status=att.status,  # type: ignore[arg-type]
+        late_minutes=att.late_minutes,
+        notes=att.notes,
+        declared_by_user_id=att.declared_by_user_id,
+        declared_by_email=declared_email,
+        declared_at=att.declared_at,
+        is_validated=att.is_validated,
+        validated_by_user_id=att.validated_by_user_id,
+        validated_by_email=validated_email,
+        validated_at=att.validated_at,
+        created_at=att.created_at,
+        updated_at=att.updated_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Create — admin/staff (validated direct)
+# ---------------------------------------------------------------------------
+
+
+async def record_attendance(
+    db: AsyncSession,
+    teacher_id: int,
+    data: TeacherAttendanceCreate,
+    *,
+    declared_by_user_id: int,
+) -> TeacherAttendanceResponse:
+    """Saisie d'un pointage par un admin ou staff.
+
+    Workflow : `is_validated=True` instantané (l'admin EST l'autorité).
+    Audit log obligatoire (sécurité.md règle).
+    """
+    # 1. Validation : teacher existe
+    teacher_stmt = select(TeacherProfile).where(TeacherProfile.id == teacher_id)
+    teacher = (await db.execute(teacher_stmt)).scalar_one_or_none()
+    if teacher is None:
+        raise NotFoundError("TeacherProfile", teacher_id)
+
+    # 2. Validation : slot (si fourni) appartient au teacher
+    if data.slot_id is not None:
+        belongs = await repo.slot_belongs_to_teacher(db, data.slot_id, teacher_id)
+        if not belongs:
+            raise BusinessValidationError(
+                "Le créneau EDT sélectionné n'appartient pas à cet enseignant."
+            )
+
+    # 3. Validation : pas de doublon (teacher, slot, date) si slot fourni
+    if data.slot_id is not None:
+        existing = await repo.exists_for(db, teacher_id, data.slot_id, data.date)
+        if existing is not None:
+            raise BusinessValidationError(
+                "Un pointage existe déjà pour ce créneau à cette date. "
+                "Modifiez-le ou supprimez-le d'abord."
+            )
+
+    # 4. Résoudre l'AY courante
+    ay = await repo.get_current_academic_year(db)
+    if ay is None:
+        raise BusinessValidationError(
+            "Aucune année scolaire active. Configurez-en une avant de pointer."
+        )
+
+    # 5. Créer la row
+    now = datetime.utcnow()
+    att = TeacherSessionAttendance(
+        teacher_id=teacher_id,
+        slot_id=data.slot_id,
+        date=data.date,
+        academic_year_id=ay.id,
+        status=TeacherAttendanceStatus(data.status),
+        late_minutes=data.late_minutes if data.status == "late" else 0,
+        notes=data.notes,
+        declared_by_user_id=declared_by_user_id,
+        declared_at=now,
+        is_validated=True,
+        validated_by_user_id=declared_by_user_id,
+        validated_at=now,
+    )
+    db.add(att)
+    await db.flush()
+
+    # 6. Audit log
+    await audit_log(
+        db,
+        entity_type="teacher_session_attendance",
+        action=AuditAction.CREATE,
+        user_id=declared_by_user_id,
+        entity_id=att.id,
+        old_values=None,
+        new_values=data.model_dump(mode="json"),
+    )
+    await db.commit()
+
+    # 7. Refetch via repo pour selectinload exhaustif (preload-relations rule)
+    refreshed = await repo.get_by_id(db, att.id)
+    assert refreshed is not None
+    return _to_response(refreshed)
+
+
+# ---------------------------------------------------------------------------
+# Create — prof self-declare (pending validation)
+# ---------------------------------------------------------------------------
+
+
+async def self_declare(
+    db: AsyncSession,
+    teacher_user_id: int,
+    data: TeacherSelfDeclareCreate,
+) -> TeacherAttendanceResponse:
+    """Auto-déclaration par le prof — toujours `is_validated=False`.
+
+    Le `teacher_id` est résolu depuis `teacher_user_id` (JWT current user).
+    """
+    teacher_stmt = select(TeacherProfile).where(TeacherProfile.user_id == teacher_user_id)
+    teacher = (await db.execute(teacher_stmt)).scalar_one_or_none()
+    if teacher is None:
+        raise BusinessValidationError("Aucun profil enseignant trouvé pour cet utilisateur.")
+
+    if data.slot_id is not None:
+        belongs = await repo.slot_belongs_to_teacher(db, data.slot_id, teacher.id)
+        if not belongs:
+            raise BusinessValidationError(
+                "Le créneau EDT sélectionné n'appartient pas à votre emploi du temps."
+            )
+        existing = await repo.exists_for(db, teacher.id, data.slot_id, data.date)
+        if existing is not None:
+            raise BusinessValidationError("Vous avez déjà déclaré ce créneau à cette date.")
+
+    ay = await repo.get_current_academic_year(db)
+    if ay is None:
+        raise BusinessValidationError("Aucune année scolaire active. Contactez l'administration.")
+
+    att = TeacherSessionAttendance(
+        teacher_id=teacher.id,
+        slot_id=data.slot_id,
+        date=data.date,
+        academic_year_id=ay.id,
+        status=TeacherAttendanceStatus(data.status),
+        late_minutes=data.late_minutes if data.status == "late" else 0,
+        notes=data.notes,
+        declared_by_user_id=teacher_user_id,
+        declared_at=datetime.utcnow(),
+        is_validated=False,
+    )
+    db.add(att)
+    await db.flush()
+
+    await audit_log(
+        db,
+        entity_type="teacher_session_attendance",
+        action=AuditAction.CREATE,
+        user_id=teacher_user_id,
+        entity_id=att.id,
+        old_values=None,
+        new_values={"self_declared": True, **data.model_dump(mode="json")},
+    )
+    await db.commit()
+
+    refreshed = await repo.get_by_id(db, att.id)
+    assert refreshed is not None
+    return _to_response(refreshed)
+
+
+# ---------------------------------------------------------------------------
+# Validate — admin approves / rejects an auto-declaration
+# ---------------------------------------------------------------------------
+
+
+async def validate_attendance(
+    db: AsyncSession,
+    attendance_id: int,
+    data: TeacherAttendanceValidate,
+    *,
+    validated_by_user_id: int,
+) -> TeacherAttendanceResponse:
+    att = await repo.get_by_id(db, attendance_id)
+    if att is None:
+        raise NotFoundError("TeacherSessionAttendance", attendance_id)
+    if att.is_validated:
+        raise BusinessValidationError("Ce pointage est déjà validé.")
+
+    old = {
+        "is_validated": att.is_validated,
+        "validated_by_user_id": att.validated_by_user_id,
+        "validated_at": att.validated_at.isoformat() if att.validated_at else None,
+    }
+
+    att.is_validated = data.approved
+    att.validated_by_user_id = validated_by_user_id
+    att.validated_at = datetime.utcnow()
+    if data.admin_notes:
+        att.notes = (
+            f"{att.notes}\n---\nAdmin: {data.admin_notes}"
+            if att.notes
+            else f"Admin: {data.admin_notes}"
+        )
+
+    await audit_log(
+        db,
+        entity_type="teacher_session_attendance",
+        action=AuditAction.UPDATE,
+        user_id=validated_by_user_id,
+        entity_id=att.id,
+        old_values=old,
+        new_values={
+            "is_validated": att.is_validated,
+            "approved": data.approved,
+            "admin_notes": data.admin_notes,
+        },
+    )
+    await db.commit()
+
+    refreshed = await repo.get_by_id(db, att.id)
+    assert refreshed is not None
+    return _to_response(refreshed)
+
+
+# ---------------------------------------------------------------------------
+# Delete (admin only) — annulation totale
+# ---------------------------------------------------------------------------
+
+
+async def delete_attendance(
+    db: AsyncSession,
+    attendance_id: int,
+    *,
+    deleted_by_user_id: int,
+) -> None:
+    att = await repo.get_by_id(db, attendance_id)
+    if att is None:
+        raise NotFoundError("TeacherSessionAttendance", attendance_id)
+
+    await audit_log(
+        db,
+        entity_type="teacher_session_attendance",
+        action=AuditAction.DELETE,
+        user_id=deleted_by_user_id,
+        entity_id=att.id,
+        old_values={
+            "teacher_id": att.teacher_id,
+            "slot_id": att.slot_id,
+            "date": att.date.isoformat(),
+            "status": att.status,
+            "late_minutes": att.late_minutes,
+            "is_validated": att.is_validated,
+        },
+        new_values=None,
+    )
+    await db.delete(att)
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# List + Stats
+# ---------------------------------------------------------------------------
+
+
+async def list_for_teacher(
+    db: AsyncSession,
+    teacher_id: int,
+    academic_year_id: int | None = None,
+    status: str | None = None,
+    date_from: date_type | None = None,
+    date_to: date_type | None = None,
+    page: int = 1,
+    per_page: int = 50,
+) -> TeacherAttendanceListResponse:
+    items, total = await repo.list_by_teacher(
+        db,
+        teacher_id=teacher_id,
+        academic_year_id=academic_year_id,
+        status=status,
+        date_from=date_from,
+        date_to=date_to,
+        page=page,
+        per_page=per_page,
+    )
+    return TeacherAttendanceListResponse(
+        items=[_to_response(it) for it in items],
+        total=total,
+    )
+
+
+async def compute_stats(
+    db: AsyncSession,
+    teacher_id: int,
+    academic_year_id: int | None = None,
+) -> TeacherAttendanceStats:
+    """KPIs agrégés pour la fiche teacher 360°.
+
+    Si `academic_year_id` non fourni, prend l'AY courante.
+    """
+    ay = await repo.get_current_academic_year(db) if academic_year_id is None else None
+    if academic_year_id is None:
+        if ay is None:
+            raise BusinessValidationError(
+                "Aucune année scolaire active. Configurez-en une avant de consulter les statistiques."
+            )
+        academic_year_id = ay.id
+        ay_name = ay.name
+    else:
+        # Refetch AY pour le name
+        from app.models.academic import AcademicYear
+
+        ay_obj = (
+            await db.execute(select(AcademicYear).where(AcademicYear.id == academic_year_id))
+        ).scalar_one_or_none()
+        if ay_obj is None:
+            raise NotFoundError("AcademicYear", academic_year_id)
+        ay_name = ay_obj.name
+
+    counts = await repo.count_by_status(db, teacher_id, academic_year_id)
+    sessions_present = counts.get("present", 0)
+    sessions_absent_excused = counts.get("absent_excused", 0)
+    sessions_absent_unexcused = counts.get("absent_unexcused", 0)
+    sessions_late = counts.get("late", 0)
+    total_sessions = (
+        sessions_present + sessions_absent_excused + sessions_absent_unexcused + sessions_late
+    )
+
+    attendance_rate = (
+        round((sessions_present + sessions_late) / total_sessions * 100.0, 2)
+        if total_sessions > 0
+        else 0.0
+    )
+
+    total_late = await repo.sum_late_minutes(db, teacher_id, academic_year_id)
+    avg_late = round(total_late / sessions_late, 2) if sessions_late > 0 else 0.0
+    pending = await repo.count_pending_validation(db, teacher_id)
+
+    return TeacherAttendanceStats(
+        teacher_id=teacher_id,
+        academic_year_id=academic_year_id,
+        academic_year_name=ay_name,
+        total_sessions=total_sessions,
+        sessions_present=sessions_present,
+        sessions_absent_excused=sessions_absent_excused,
+        sessions_absent_unexcused=sessions_absent_unexcused,
+        sessions_late=sessions_late,
+        attendance_rate=attendance_rate,
+        total_late_minutes=total_late,
+        avg_late_minutes_when_late=avg_late,
+        pending_validation_count=pending,
+    )


### PR DESCRIPTION
## Summary

Phase 7b foundation BE: pointage de présence enseignant par créneau EDT.

Décisions Marcel 2026-05-19 :
- **Granularité** : slot EDT (cohérent avec late_minutes:int + modèle ivoirien profs mobiles)
- **Saisie** : hybride admin/staff direct (validé) + prof self-déclaré (en attente)
- **Retards** : compteur minutes (int précis pour calcul salaire DREN)

## Migration

0030 — `teacher_session_attendance` table avec :
- FKs teacher_profiles, timetable_slots (SET NULL), academic_years, users (declared+validated)
- Status enum: present, absent_excused, absent_unexcused, late
- Workflow: declared_by_user_id + is_validated + validated_by_user_id
- Indexes: (teacher,date), slot, (ay,status), is_validated

## Endpoints

- POST `/admin/teachers/{id}/attendance` — admin/staff saisit, validé direct
- GET `/admin/teachers/{id}/attendance` — liste filtrée (AY, status, dates, pagination)
- GET `/admin/teachers/{id}/attendance/stats` — KPIs (taux, retards cumulés, pending)
- PATCH `/admin/teacher-attendance/{id}/validate` — admin valide/rejette auto-décl
- DELETE `/admin/teacher-attendance/{id}` — annulation admin
- POST `/teacher/attendance/self-declare` — prof se déclare

## Conformité rules

- preload-relations-after-commit : tous les GET passent par `_full_load_options()` selectinload exhaustif
- security : audit_log sur create/update/delete + permissions dynamiques
- no-god-code : tous fichiers < 250 LOC

## Reste à faire (follow-up)

- [ ] Seed permissions `admin:teachers:attendance`, `admin:teachers:attendance:read`, `teacher:attendance:self_declare` (rôles admin + staff + teacher)
- [ ] FE tab Présences dans `/admin/teachers/[id]`
- [ ] FE bouton 'Me déclarer absent' dans portail teacher
- [ ] E2E test (saisie admin, self-déclare, validate)
- [ ] CHANGELOG entries
- [ ] (optionnel) PDF rapport présences prof mensuel/trimestriel

PR draft — à finaliser quand FE prêt et permissions seedées.