### PR TITLE
feat(permissions): seed teacher attendance permissions (Phase 7b finition)

### DIFF
--- a/alembic/versions/20260519_0031_seed_teacher_attendance_permissions.py
+++ b/alembic/versions/20260519_0031_seed_teacher_attendance_permissions.py
@@ -1,0 +1,79 @@
+"""Seed teacher attendance permissions (Phase 7b finition).
+
+Phase 7b a livré le BE foundation (model + service + endpoints) en migration
+0030 mais les permissions n'avaient pas encore été seedées. Sans ces 3 slugs,
+les endpoints retournent 403 même pour admin/staff/teacher légitimes.
+
+- admin:teachers:attendance        → admin, director, staff
+- admin:teachers:attendance:read   → admin, director, staff
+- teacher:attendance:self_declare  → admin, director, teacher
+
+Revision ID: 0031_teacher_attendance_perms
+Revises: 0030_teacher_attendance
+Create Date: 2026-05-19
+"""
+
+from alembic import op
+
+revision = "0031_teacher_attendance_perms"
+down_revision = "0030_teacher_attendance"
+branch_labels = None
+depends_on = None
+
+
+_NEW_PERMISSIONS = [
+    ("admin:teachers:attendance", "Manage teacher attendance"),
+    ("admin:teachers:attendance:read", "View teacher attendance"),
+    ("teacher:attendance:self_declare", "Teacher self-declare absence"),
+]
+
+
+_ROLE_PERMISSION_MATRIX = {
+    "admin": [
+        "admin:teachers:attendance",
+        "admin:teachers:attendance:read",
+        "teacher:attendance:self_declare",
+    ],
+    "director": [
+        "admin:teachers:attendance",
+        "admin:teachers:attendance:read",
+        "teacher:attendance:self_declare",
+    ],
+    "staff": [
+        "admin:teachers:attendance",
+        "admin:teachers:attendance:read",
+    ],
+    "teacher": [
+        "teacher:attendance:self_declare",
+    ],
+}
+
+
+def upgrade() -> None:
+    values_sql = ", ".join(f"('{slug}', '{name}')" for slug, name in _NEW_PERMISSIONS)
+    op.execute(f"INSERT IGNORE INTO permissions (slug, name) VALUES {values_sql}")
+
+    for role_name, slugs in _ROLE_PERMISSION_MATRIX.items():
+        slugs_sql = ", ".join(f"'{slug}'" for slug in slugs)
+        op.execute(
+            f"""
+            INSERT IGNORE INTO role_permissions (role_id, permission_id)
+            SELECT r.id, p.id
+            FROM roles r
+            CROSS JOIN permissions p
+            WHERE r.name = '{role_name}'
+            AND p.slug IN ({slugs_sql})
+            """
+        )
+
+
+def downgrade() -> None:
+    slugs_sql = ", ".join(f"'{slug}'" for slug, _ in _NEW_PERMISSIONS)
+    op.execute(
+        f"""
+        DELETE rp FROM role_permissions rp
+        JOIN permissions p ON rp.permission_id = p.id
+        WHERE p.slug IN ({slugs_sql})
+        """
+    )
+    op.execute(f"DELETE FROM permissions WHERE slug IN ({slugs_sql})")

--- a/app/services/tenants/permissions.py
+++ b/app/services/tenants/permissions.py
@@ -75,6 +75,10 @@ ALL_PERMISSIONS: list[dict[str, str]] = [
     {"slug": "reports:read", "name": "View reports"},
     {"slug": "reports:generate", "name": "Generate reports"},
     {"slug": "reports:override", "name": "Override council decisions"},
+    # Teacher attendance (Phase 7b) (3)
+    {"slug": "admin:teachers:attendance", "name": "Manage teacher attendance"},
+    {"slug": "admin:teachers:attendance:read", "name": "View teacher attendance"},
+    {"slug": "teacher:attendance:self_declare", "name": "Teacher self-declare absence"},
     # Official documents (2)
     {"slug": "documents:certificate", "name": "Generate certificat de scolarite"},
     {"slug": "documents:attendance", "name": "Generate attestation de frequentation"},
@@ -132,6 +136,7 @@ ROLE_DEFINITIONS: dict[str, dict[str, Any]] = {
             "attendance:update",
             "timetable:read",
             "reports:read",
+            "teacher:attendance:self_declare",
         ],
     },
     "staff": {
@@ -148,6 +153,8 @@ ROLE_DEFINITIONS: dict[str, dict[str, Any]] = {
             "admin:classes:read",
             "attendance:read",
             "reports:read",
+            "admin:teachers:attendance",
+            "admin:teachers:attendance:read",
         ],
     },
     "accountant": {


### PR DESCRIPTION
## Pourquoi

Phase 7b BE foundation (PR #146) a livré le model + service + 6 endpoints `teacher_session_attendance` mais a oublié de seeder les 3 permission slugs. Conséquence : tous les endpoints retournent 403 même pour admin / staff / teacher légitimes. **Bloque la finition FE** (#79).

## Changements

### Permissions seedées (3 nouvelles)

| Slug | Roles cibles |
|---|---|
| `admin:teachers:attendance` | admin, director, staff |
| `admin:teachers:attendance:read` | admin, director, staff |
| `teacher:attendance:self_declare` | admin, director, teacher |

### Pour nouveaux tenants

`app/services/tenants/permissions.py` :
- Append des 3 slugs à `ALL_PERMISSIONS` (auto-grant admin + director via le comprehension `not super-admin`)
- Ajout explicite des slugs aux rôles `teacher` et `staff` dans `ROLE_DEFINITIONS`

### Pour tenants existants

Migration `20260519_0031_seed_teacher_attendance_permissions.py` (Revises 0030) :
- INSERT IGNORE des 3 permissions
- INSERT IGNORE des role_permissions pour admin, director, staff, teacher (matrice ci-dessus)
- Downgrade nettoie les role_permissions puis les permissions

## Test plan

- [ ] CI green (ruff + format + tests)
- [ ] Sur tenant local : `alembic upgrade head` applique 0031 sans erreur
- [ ] `SELECT * FROM permissions WHERE slug LIKE 'admin:teachers:attendance%' OR slug = 'teacher:attendance:self_declare'` → 3 rows
- [ ] `SELECT r.name, p.slug FROM role_permissions ...` → 9 rows attendues
- [ ] Avec admin@klassci.com : `POST /admin/teachers/1/attendance` ne retourne plus 403
- [ ] Avec prof@klassci.com : `POST /teacher/attendance/self-declare` ne retourne plus 403

## Liens

- BE foundation Phase 7b : PR #146
- FE consumer : feat/79-teacher-attendance-fe (klassci-college-frontend)
- Task #79