### PR TITLE
fix(migrations): repair broken 0030 down_revision pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Chaîne de migrations Alembic réparée : la migration de présence enseignant pointait vers un ancêtre nommé `0029_school_pdf_customization` qui n'existe pas (le vrai id étant juste `0029`). Toute installation d'établissement échouait avec une erreur cryptique avant cette correction *(devops)*.
 - Pointage de présence des enseignants désormais accessible : les permissions des 3 nouveaux endpoints (admin saisit, lecture, prof auto-déclare) sont maintenant attribuées aux rôles correspondants (admin, director, staff, teacher). Auparavant tous les appels retournaient 403, ce qui rendait la feature inopérante *(admin, enseignant)* (#148).
 - Reçus de paiement et bordereaux : la méthode et le statut s'affichent désormais en français lisible (« Espèces », « Validé ») au lieu du nom technique brut (« PaymentMethod.CASH », « PaymentStatus.COMPLETED ») *(admin, parent)*.
 - Génération PDF désormais compatible avec les versions récentes de `pydyf` : pin explicite `pydyf<0.12` dans `requirements.txt` car la 0.12 a un breaking change incompatible avec WeasyPrint 62 (Stream.transform retiré → 500 silencieux au render) *(devops)*.

--- a/alembic/versions/20260519_0030_teacher_session_attendance.py
+++ b/alembic/versions/20260519_0030_teacher_session_attendance.py
@@ -6,7 +6,7 @@ Phase 7b (KLASSCI College 2026-05-19) — Marcel a tranché :
 - Retards : compteur minutes (int précis pour calcul salaire DREN)
 
 Revision ID: 0030_teacher_attendance
-Revises: 0029_school_pdf_customization
+Revises: 0029
 Create Date: 2026-05-19
 """
 
@@ -16,7 +16,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "0030_teacher_attendance"
-down_revision = "0029_school_pdf_customization"
+down_revision = "0029"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Pourquoi (P0 — installation cassée)

La PR #146 (Phase 7b BE foundation) a introduit la migration `0030_teacher_session_attendance` avec :

```python
revision = "0030_teacher_attendance"
down_revision = "0029_school_pdf_customization"  # ← erreur
```

Mais le vrai `revision` de la 0029 est juste `"0029"`. Conséquence : tout `alembic upgrade head` à partir d'une version <= 0029 lève :

```
KeyError: '0029_school_pdf_customization'
```

→ **Toute provision d'un nouveau tenant échoue.**
→ **Tout deploy sur EC2 qui exécute `alembic upgrade head` échoue.**

Le bug est resté caché parce que :

1. Le job CI `Lint & Type Check` échouait sur le drift ruff (0.8.4 CI vs 0.15.12 local, fixé dans PR #150)
2. Ce fail cascadait sur `Tests` + `Alembic migrations idempotence` (jobs skipped)
3. PR #146 a été mergée en `--admin` malgré ces skips
4. Localement, j'avais appliqué 0030 via SQL direct (alembic CLI bloquant sur Windows), donc je n'ai pas vu l'erreur

PR #150 (bump ruff 0.15.12) fait passer le lint, ce qui révèle les 2 fails sous-jacents. Donc cette PR doit merger AVANT #150 (ou en même temps).

## Fix (2 lignes)

```diff
-Revises: 0029_school_pdf_customization
+Revises: 0029

-down_revision = "0029_school_pdf_customization"
+down_revision = "0029"
```

Aligne sur la convention du projet (0028, 0029 utilisent juste l'id court).

## CHANGELOG

Entry `Fixed` ajoutée.

## Test plan

- [ ] CI green (Lint + Tests + Alembic migrations idempotence pass)
- [ ] `alembic upgrade head` sur un tenant fresh applique 0028 → 0029 → 0030 → 0031 sans KeyError
- [ ] Aucun side-effect sur les tenants où 0030 est déjà appliqué (le revision id du fichier ne change pas, seul son down_revision change)