### PR TITLE
feat(reports): student trimester breakdowns + premium bulletin + PDF error contract

### DIFF
--- a/.claude/rules/no-pep563-with-204.md
+++ b/.claude/rules/no-pep563-with-204.md
@@ -1,0 +1,190 @@
+# Rule : Pas de `from __future__ import annotations` dans un router avec endpoints 204
+
+## Quand s'active
+
+Cette rule s'active automatiquement quand :
+- Tu crées ou modifies un fichier dans `app/routers/` qui contient un endpoint avec `status_code=204` ou `status_code=status.HTTP_204_NO_CONTENT`
+- Tu ajoutes `from __future__ import annotations` au début d'un router existant
+- Tu ajoutes un endpoint 204 (typiquement DELETE) dans un router qui a déjà `from __future__ import annotations`
+
+## La règle
+
+**Un router FastAPI ne doit JAMAIS combiner :**
+
+```python
+from __future__ import annotations  # PEP 563 — stringifie toutes les annotations
+```
+
+**ET un endpoint :**
+
+```python
+@router.delete("/x", status_code=status.HTTP_204_NO_CONTENT)
+async def del_x(...) -> None: ...   # ← le `-> None` est le piège
+```
+
+Le router crash **à l'import du module** avec :
+
+```
+AssertionError: Status code 204 must not have a response body
+```
+
+## Pourquoi cette rule existe
+
+**Incident fondateur 2026-05-20** (PR #150) — `teacher_attendance.py` ajouté en
+Phase 7b BE foundation (PR #146) combinait `from __future__ import annotations`
+et un DELETE 204 avec `-> None`. Le router ne se chargeait pas, mais le bug
+était masqué par une cascade CI :
+
+1. `Lint & Type Check` failait (drift ruff 0.8.4 CI vs 0.15.12 local)
+2. `Tests` était `skipped` à cause du fail lint
+3. `Alembic migrations idempotence` était `skipped` à cause du fail lint
+4. Bug d'import jamais déclenché en CI
+5. Bug 0030 chain `down_revision = "0029_school_pdf_customization"` (au lieu de
+   `"0029"`) jamais déclenché non plus
+
+Coût : **toute provision d'un nouveau tenant échouait**, tout deploy EC2 qui
+exécute `alembic upgrade head` échouait. Découvert seulement quand la PR #150
+a bumpé ruff et que les tests ont enfin tourné.
+
+## Pourquoi techniquement
+
+Sous PEP 563 (`from __future__ import annotations`), toutes les annotations
+sont stringifiées au parse. FastAPI 0.115.6 inspecte ensuite l'annotation de
+retour pour déterminer le `response_model`. Sur un endpoint avec
+`status_code=204` :
+
+- Sans PEP 563 : `-> None` est résolu en `NoneType`, FastAPI sait qu'il n'y a
+  pas de body → OK
+- Avec PEP 563 : `-> None` est la string `"None"`, FastAPI ne résout pas
+  correctement et infère un response_model truthy → assertion violée
+
+Python 3.12 (la version du projet) supporte déjà nativement PEP 604
+(`int | None`, `str | None`) et le `from __future__ import annotations` n'est
+**plus nécessaire** pour les unions modernes. Donc on peut juste le retirer.
+
+## Pattern correct
+
+### Option A — Retirer le future import (recommandé)
+
+```python
+# app/routers/teacher_attendance.py
+"""Router pointage enseignant."""
+
+# PAS d'import `from __future__ import annotations`
+from datetime import date as date_type
+from fastapi import APIRouter, Depends, Query, status
+# ...
+
+@router.delete(
+    "/teacher-attendance/{attendance_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def admin_delete_attendance(
+    attendance_id: int,
+    # ...
+) -> None:
+    """OK — le -> None est résolu en NoneType, pas en string."""
+    await service.delete_attendance(...)
+```
+
+Si le router contient des unions ou generics modernes, Python 3.12 les supporte
+nativement :
+
+```python
+# Pas besoin de PEP 563 pour ça :
+async def list_x(
+    page: int = 1,
+    status_filter: str | None = None,
+    date_from: date | None = None,
+) -> dict[str, Any]: ...
+```
+
+### Option B — Garder PEP 563 mais retirer `-> None`
+
+Si pour une raison X le router doit garder `from __future__ import annotations`
+(typiquement parce qu'il y a beaucoup de forward references) :
+
+```python
+# Ne PAS annoter le retour des endpoints 204
+@router.delete("/x", status_code=status.HTTP_204_NO_CONTENT)
+async def del_x(...):  # pas de `-> None`
+    await service.delete(...)
+```
+
+Moins clean (l'annotation de retour disparaît du contrat), donc préférer
+l'Option A.
+
+## Reproducer minimal
+
+```python
+# repro.py
+from __future__ import annotations
+from fastapi import APIRouter, Depends, status
+
+def fake_dep(): pass
+router = APIRouter()
+
+@router.delete("/x", status_code=status.HTTP_204_NO_CONTENT)
+async def del_x(_: None = Depends(fake_dep)) -> None: pass
+# AssertionError: Status code 204 must not have a response body
+```
+
+```bash
+py -c "import repro"
+# Traceback (most recent call last):
+#   ...
+# AssertionError: Status code 204 must not have a response body
+```
+
+## Détection programmatique (avant commit)
+
+Script de check rapide à exécuter ponctuellement :
+
+```bash
+# Lister les routers qui ont les 2 patterns
+for f in app/routers/**/*.py; do
+  if grep -l "from __future__ import annotations" "$f" > /dev/null && \
+     grep -lE "status_code=(status\.)?HTTP_204_NO_CONTENT|status_code=204" "$f" > /dev/null; then
+    echo "SUSPECT: $f"
+  fi
+done
+```
+
+Si le script remonte un fichier, vérifier manuellement que l'endpoint 204 n'a
+pas `-> None`. Si oui → corriger.
+
+## Anti-patterns à bloquer en review
+
+1. ❌ Ajouter `from __future__ import annotations` en haut d'un router qui a
+   déjà des endpoints 204 avec `-> None`
+2. ❌ Ajouter un endpoint 204 `-> None` dans un router qui a déjà
+   `from __future__ import annotations`
+3. ❌ Pinner ruff/lint pour masquer la cascade qui cache ce bug. Si le lint
+   échoue, **fix le lint** au lieu de skip les tests
+4. ❌ Documenter le pattern bogué dans un docstring comme "feature" plutôt que
+   le corriger
+
+## Audit complet au 2026-05-20
+
+Croisement des deux listes après PR #150 :
+
+| Router | PEP 563 ? | 204 endpoint ? | Verdict |
+|---|---|---|---|
+| `teacher_attendance.py` | non (retiré #150) | oui | ✅ Safe |
+| `reports.py` | oui | non | Safe |
+| `student_documents.py` | oui | non | Safe |
+| `grades.py` | oui | non | Safe |
+| `council.py` | oui | non | Safe |
+| `dren_stats.py` | oui | non | Safe |
+| `auth.py`, `fees.py`, `timetable.py`, `enrollments.py`, `admin.py`, `super_admin/pats.py` | non | oui | Safe |
+
+**Plus aucune intersection PEP 563 ∩ 204 dans le codebase.**
+
+## Voir aussi
+
+- Memory `project_session_2026_05_20_phase7b_ship_and_ci_cleanup.md` —
+  incident fondateur + 3 bugs uncovered ensemble
+- PR #150 — bump ruff 0.15.12 + fix migration 0030 chain + fix PEP 563/204
+- Rule projet `preload-relations-after-commit.md` — autre classe de bugs
+  latents masqués par CI cascade
+- Rule projet `changelog.md` — un fix de cette classe va dans `### Fixed`

--- a/.claude/rules/pdf-response-wrap.md
+++ b/.claude/rules/pdf-response-wrap.md
@@ -1,0 +1,116 @@
+# Rule : tout endpoint PDF doit passer par `pdf_response`
+
+## Quand s'active
+
+Cette rule s'active automatiquement quand :
+- Tu crées un nouvel endpoint qui renvoie `media_type="application/pdf"`
+- Tu modifies un endpoint existant qui retourne un `Response(content=pdf_bytes, ...)`
+- Tu ajoutes un service `generate_*_pdf()` qui appelle WeasyPrint
+
+## La règle
+
+**Tout endpoint qui renvoie un PDF doit utiliser le helper
+`app.routers._pdf_helpers.pdf_response`**. Pas de `Response(content=...,
+media_type="application/pdf", ...)` direct dans un router.
+
+```python
+from app.routers._pdf_helpers import pdf_response
+
+@router.get("/{resource_id}/pdf")
+async def get_resource_pdf(
+    resource_id: int,
+    _: None = require_permission("..."),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> Response:
+    return await pdf_response(
+        lambda: service.get_pdf(db, resource_id),
+        filename=f"resource-{resource_id}.pdf",
+        error_context=f"resource {resource_id}",
+    )
+```
+
+Pour les services PDF synchrones (sans `await`), encapsuler dans une closure async :
+
+```python
+data = await service.fetch_data(db, ...)
+settings = await load_school_settings_for_pdf(db)
+
+async def _generate() -> bytes:
+    return generate_resource_pdf(data, settings)
+
+return await pdf_response(
+    _generate,
+    filename=...,
+    error_context=...,
+)
+```
+
+Param `disposition="attachment"` pour forcer le download au lieu d'un preview
+navigateur (utile pour les exports Excel-like : EDT, bordereau journalier).
+
+## Pourquoi cette rule existe
+
+**Incident fondateur 2026-05-20** (visual-check E2E /admin/reports) : le
+téléchargement d'un bulletin PDF en local Windows déclenchait un
+`OSError: cannot load library 'gobject-2.0-0'` côté WeasyPrint (GTK runtime
+absent). L'exception non gérée remontait jusqu'à Starlette qui renvoyait
+un **`500 Internal Server Error` plain-text** (21 bytes).
+
+Conséquences cascadées :
+1. Le `text/plain` BYPASS le `CORSMiddleware` Starlette → aucun header
+   `Access-Control-Allow-Origin` ajouté
+2. Le browser bloque la réponse côté FE (CORS policy)
+3. L'admin clique « Télécharger », ne voit rien — **silent failure UX**
+4. Le FE tombait dans un `catch` générique « Erreur 500 » sans info exploitable
+
+Le pattern correct : lever une `HTTPException` dans le router → FastAPI/Starlette
+applique le pipeline normal → CORS s'applique → réponse JSON
+`{detail: "..."}` exploitable par le FE pour un toast utilisateur.
+
+## Pattern correct (helper canonique)
+
+`app/routers/_pdf_helpers.py::pdf_response(factory, *, filename, error_context, disposition="inline")` :
+
+- `factory` : coroutine sans args produisant `bytes`
+- Catch `OSError` → message explicite GTK/Cairo missing
+- Catch `Exception` → message générique avec contexte
+- `disposition="inline"` (preview) ou `"attachment"` (download forcé)
+- Réponse 500 = JSON `{detail}` avec headers CORS appliqués
+
+## Couverture actuelle (2026-05-20)
+
+10 endpoints PDF — 100% via `pdf_response` :
+
+| Router | Endpoint | Disposition |
+|---|---|---|
+| `reports.py` | `/bulletins/{id}/pdf` | inline |
+| `council.py` | `/{class_id}/{trimester}/pdf` | inline |
+| `class_documents.py` | `/{class_id}/roster` | inline |
+| `enrollment_payments.py` | `/{id}/statement` | inline |
+| `enrollment_payments.py` | `/{id}/form` | inline |
+| `payments.py` | `/daily-cash-book` | inline |
+| `payments.py` | `/{id}/receipt` | inline |
+| `student_documents.py` | `/{id}/documents/certificat-scolarite.pdf` | inline |
+| `student_documents.py` | `/{id}/documents/attestation-frequentation.pdf` | inline |
+| `timetable.py` | `/export-pdf` | attachment |
+
+## Anti-patterns à bloquer en review
+
+1. ❌ `Response(content=pdf_bytes, media_type="application/pdf", headers=...)`
+   dans un router → wrap obligatoire dans `pdf_response`
+2. ❌ `try/except` ad-hoc dans le router qui re-raise un `HTTPException`
+   custom → utiliser le helper centralisé
+3. ❌ Service `get_*_pdf` qui catch `OSError` lui-même et retourne `None` ou
+   bytes vides → la responsabilité du wrap est dans le router, pas le service
+4. ❌ Endpoint qui appelle WeasyPrint sans wrap → silent failure garanti
+5. ❌ Helper local `_make_pdf_response()` dans un router → utiliser le
+   `_pdf_helpers.py` partagé
+
+## Voir aussi
+
+- Memory `project_session_2026_05_20_visual_check_e2e.md` — incident fondateur
+- `app/routers/_pdf_helpers.py` — implémentation canonique
+- FE `lib/api/client.ts::apiFetchBlob` — propage le `{detail}` BE comme
+  `error.message` côté FE pour permettre un toast utilisateur exploitable
+- Rule projet `audit-school-settings-compositors.md` — autre rule sur la
+  cohérence cross-PDF des compositors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Téléchargement d'un PDF en erreur : le serveur renvoie maintenant un message JSON explicite (« Génération PDF impossible pour … ») au lieu d'une réponse vide générique. Bulletin, reçu, EDT, certificat, fiche d'inscription, PV de conseil, bordereau, état des frais et liste de classe sont protégés *(admin, parent, enseignant)*.
+- Fiche élève : les graphes « Moyennes par trimestre » et « Absences par trimestre » du tab Parcours affichent désormais les vraies données (trimestre 1 : moyenne générale, meilleure et plus faible matière) au lieu d'un message « Pas encore de notes » trompeur *(admin)*.
+- Bulletin scolaire : la liste des élèves affiche le nom complet, le matricule et un avatar à initiales au lieu d'un identifiant technique `#3`. La fenêtre de détail montre le détail par matière avec coefficient et moyenne *(admin)*.
 - Chaîne de migrations Alembic réparée : la migration de présence enseignant pointait vers un ancêtre nommé `0029_school_pdf_customization` qui n'existe pas (le vrai id étant juste `0029`). Toute installation d'établissement échouait avec une erreur cryptique avant cette correction *(devops)*.
 - Pointage de présence des enseignants désormais accessible : les permissions des 3 nouveaux endpoints (admin saisit, lecture, prof auto-déclare) sont maintenant attribuées aux rôles correspondants (admin, director, staff, teacher). Auparavant tous les appels retournaient 403, ce qui rendait la feature inopérante *(admin, enseignant)* (#148).
 - Reçus de paiement et bordereaux : la méthode et le statut s'affichent désormais en français lisible (« Espèces », « Validé ») au lieu du nom technique brut (« PaymentMethod.CASH », « PaymentStatus.COMPLETED ») *(admin, parent)*.

--- a/app/routers/_pdf_helpers.py
+++ b/app/routers/_pdf_helpers.py
@@ -1,0 +1,64 @@
+"""Helper pour wrapper la génération PDF de manière sûre côté router.
+
+Sans ce wrapper, une exception non gérée (typiquement `OSError` quand
+WeasyPrint ne trouve pas la GTK runtime, ou `TypeError` lors de la
+sérialisation Pydantic→Jinja) remonte en 500 plain-text qui **bypass
+le CORSMiddleware Starlette** — le browser bloque alors la réponse
+sans header `Access-Control-Allow-Origin` et le FE affiche un toast
+générique muet. Voir incident `project_session_2026_05_20_visual_check_e2e.md`.
+
+En levant explicitement `HTTPException`, FastAPI/Starlette wrappe la
+réponse dans le pipeline normal → CORS s'applique → le FE reçoit un
+JSON `{detail: ...}` exploitable pour un toast utilisateur.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+
+from fastapi import HTTPException, status
+from fastapi.responses import Response
+
+logger = logging.getLogger(__name__)
+
+
+async def pdf_response(
+    factory: Callable[[], Awaitable[bytes]],
+    *,
+    filename: str,
+    error_context: str,
+    disposition: str = "inline",
+) -> Response:
+    """Génère un PDF et le retourne comme `application/pdf`.
+
+    `factory` est une coroutine sans args qui produit les bytes PDF.
+    `error_context` est inclus dans le `detail` 500 pour faciliter le debug
+    sans exposer la stack trace au client (ex: "bulletin 42").
+    `disposition` : `inline` pour preview navigateur (défaut), `attachment`
+    pour forcer le téléchargement direct (ex: export EDT, bordereau).
+    """
+    try:
+        pdf_bytes = await factory()
+    except OSError as exc:
+        logger.exception("PDF generation failed (%s): library load error", error_context)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=(
+                f"Génération PDF impossible pour {error_context}. "
+                "Le serveur n'a pas pu charger la bibliothèque PDF (GTK/Cairo). "
+                "Contactez l'administrateur système."
+            ),
+        ) from exc
+    except Exception as exc:
+        logger.exception("PDF generation failed (%s)", error_context)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Génération PDF impossible pour {error_context}.",
+        ) from exc
+
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'{disposition}; filename="{filename}"'},
+    )

--- a/app/routers/class_documents.py
+++ b/app/routers/class_documents.py
@@ -9,6 +9,7 @@ from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.dependencies import get_tenant_db, require_permission
+from app.routers._pdf_helpers import pdf_response
 from app.services import class_roster_service
 
 router = APIRouter(prefix="/admin/classes", tags=["admin", "class-documents"])
@@ -28,9 +29,8 @@ async def get_class_roster_pdf(
     Usage : conseil de classe, sortie scolaire, appel papier secrétariat.
     Tri par nom de famille puis prénom. Photo miniature ou initiales.
     """
-    pdf_bytes = await class_roster_service.get_class_roster_pdf(db, class_id)
-    return Response(
-        content=pdf_bytes,
-        media_type="application/pdf",
-        headers={"Content-Disposition": (f'inline; filename="liste-classe-{class_id}.pdf"')},
+    return await pdf_response(
+        lambda: class_roster_service.get_class_roster_pdf(db, class_id),
+        filename=f"liste-classe-{class_id}.pdf",
+        error_context=f"liste de classe {class_id}",
     )

--- a/app/routers/council.py
+++ b/app/routers/council.py
@@ -9,6 +9,7 @@ from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.dependencies import TokenData, get_current_user, get_tenant_db, require_permission
+from app.routers._pdf_helpers import pdf_response
 from app.schemas.council import (
     CouncilMinutesGenerateRequest,
     CouncilMinutesResponse,
@@ -52,13 +53,10 @@ async def get_council_minutes_pdf(
     db: AsyncSession = Depends(get_tenant_db),
 ) -> Response:
     """Genere et retourne le PDF du PV du conseil de classe."""
-    pdf_bytes = await service.get_council_minutes_pdf(db, class_id, trimester, academic_year_id)
-    return Response(
-        content=pdf_bytes,
-        media_type="application/pdf",
-        headers={
-            "Content-Disposition": (f'inline; filename="pv_conseil_{class_id}_T{trimester}.pdf"')
-        },
+    return await pdf_response(
+        lambda: service.get_council_minutes_pdf(db, class_id, trimester, academic_year_id),
+        filename=f"pv_conseil_{class_id}_T{trimester}.pdf",
+        error_context=f"PV conseil classe {class_id} T{trimester}",
     )
 
 

--- a/app/routers/enrollment_payments.py
+++ b/app/routers/enrollment_payments.py
@@ -12,6 +12,7 @@ from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.dependencies import TokenData, get_current_user, get_tenant_db, require_permission
+from app.routers._pdf_helpers import pdf_response
 from app.schemas.payment import (
     AllocationPreviewResponse,
     EnrollmentPaymentCreate,
@@ -94,11 +95,10 @@ async def get_fee_statement_pdf(
     l'année scolaire de son enfant (total dû, total versé, reste à payer,
     breakdown par catégorie + historique des versements).
     """
-    pdf_bytes = await fee_statement_service.get_fee_statement_pdf(db, enrollment_id)
-    return Response(
-        content=pdf_bytes,
-        media_type="application/pdf",
-        headers={"Content-Disposition": (f'inline; filename="etat-frais-{enrollment_id}.pdf"')},
+    return await pdf_response(
+        lambda: fee_statement_service.get_fee_statement_pdf(db, enrollment_id),
+        filename=f"etat-frais-{enrollment_id}.pdf",
+        error_context=f"état des frais (inscription {enrollment_id})",
     )
 
 
@@ -117,11 +117,8 @@ async def get_enrollment_form_pdf(
     responsables (père/mère/tuteur) + tableau frais avec total + signatures
     Parent + Chef d'établissement.
     """
-    pdf_bytes = await enrollment_form_service.get_enrollment_form_pdf(db, enrollment_id)
-    return Response(
-        content=pdf_bytes,
-        media_type="application/pdf",
-        headers={
-            "Content-Disposition": (f'inline; filename="fiche-inscription-{enrollment_id}.pdf"')
-        },
+    return await pdf_response(
+        lambda: enrollment_form_service.get_enrollment_form_pdf(db, enrollment_id),
+        filename=f"fiche-inscription-{enrollment_id}.pdf",
+        error_context=f"fiche d'inscription {enrollment_id}",
     )

--- a/app/routers/payments.py
+++ b/app/routers/payments.py
@@ -7,6 +7,7 @@ from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.dependencies import TokenData, get_current_user, get_tenant_db, require_permission
+from app.routers._pdf_helpers import pdf_response
 from app.schemas.payment import (
     PaymentCreate,
     PaymentListResponse,
@@ -89,13 +90,12 @@ async def get_daily_cash_book(
     document fin de journée pour clôture.
     """
     target = target_date or date.today()
-    pdf_bytes = await daily_cash_book_service.get_daily_cash_book_pdf(
-        db, target, cashier_user_id=current_user.user_id
-    )
-    return Response(
-        content=pdf_bytes,
-        media_type="application/pdf",
-        headers={"Content-Disposition": (f'inline; filename="bordereau-{target.isoformat()}.pdf"')},
+    return await pdf_response(
+        lambda: daily_cash_book_service.get_daily_cash_book_pdf(
+            db, target, cashier_user_id=current_user.user_id
+        ),
+        filename=f"bordereau-{target.isoformat()}.pdf",
+        error_context=f"bordereau journalier {target.isoformat()}",
     )
 
 
@@ -123,11 +123,10 @@ async def get_payment_receipt(
     db: AsyncSession = Depends(get_tenant_db),
 ) -> Response:
     """Genere et retourne le recu de paiement en PDF."""
-    pdf_bytes = await payment_service.get_payment_receipt_pdf(db, payment_id)
-    return Response(
-        content=pdf_bytes,
-        media_type="application/pdf",
-        headers={"Content-Disposition": f'inline; filename="recu_{payment_id}.pdf"'},
+    return await pdf_response(
+        lambda: payment_service.get_payment_receipt_pdf(db, payment_id),
+        filename=f"recu_{payment_id}.pdf",
+        error_context=f"reçu paiement {payment_id}",
     )
 
 

--- a/app/routers/reports.py
+++ b/app/routers/reports.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.dependencies import TokenData, get_current_user, get_tenant_db, require_permission
 from app.core.exceptions import NotFoundError
+from app.routers._pdf_helpers import pdf_response
 from app.schemas.reports import (
     BulletinGenerateRequest,
     BulletinGenerateResponse,
@@ -84,11 +85,10 @@ async def get_bulletin_pdf(
     db: AsyncSession = Depends(get_tenant_db),
 ) -> Response:
     """Genere et retourne le PDF d'un bulletin."""
-    pdf_bytes = await service.get_bulletin_pdf(db, bulletin_id)
-    return Response(
-        content=pdf_bytes,
-        media_type="application/pdf",
-        headers={"Content-Disposition": f'inline; filename="bulletin_{bulletin_id}.pdf"'},
+    return await pdf_response(
+        lambda: service.get_bulletin_pdf(db, bulletin_id),
+        filename=f"bulletin_{bulletin_id}.pdf",
+        error_context=f"bulletin {bulletin_id}",
     )
 
 

--- a/app/routers/student_documents.py
+++ b/app/routers/student_documents.py
@@ -7,6 +7,7 @@ from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.dependencies import TokenData, get_current_user, get_tenant_db
+from app.routers._pdf_helpers import pdf_response
 from app.services import student_documents_service
 from app.services._school_settings_helper import load_school_settings_for_pdf
 from app.services.pdf_service import (
@@ -41,16 +42,18 @@ async def get_certificat_scolarite(
 
     data = await student_documents_service.compose_certificate_data(db, student_id)
     settings = await load_school_settings_for_pdf(db)
-    pdf_bytes = generate_certificate_scolarite_pdf(data, settings)
 
     last_name = data["student"]["last_name"]
     safe_year = data["academic_year_name"].replace(" ", "_").replace("/", "-")
     filename = f"certificat_scolarite_{last_name}_{safe_year}.pdf"
 
-    return Response(
-        content=pdf_bytes,
-        media_type="application/pdf",
-        headers={"Content-Disposition": f'inline; filename="{filename}"'},
+    async def _generate() -> bytes:
+        return generate_certificate_scolarite_pdf(data, settings)
+
+    return await pdf_response(
+        _generate,
+        filename=filename,
+        error_context=f"certificat de scolarité élève {student_id}",
     )
 
 
@@ -78,14 +81,16 @@ async def get_attestation_frequentation(
 
     data = await student_documents_service.compose_attendance_certificate_data(db, student_id)
     settings = await load_school_settings_for_pdf(db)
-    pdf_bytes = generate_attendance_certificate_pdf(data, settings)
 
     last_name = data["student"]["last_name"]
     safe_year = data["academic_year_name"].replace(" ", "_").replace("/", "-")
     filename = f"attestation_frequentation_{last_name}_{safe_year}.pdf"
 
-    return Response(
-        content=pdf_bytes,
-        media_type="application/pdf",
-        headers={"Content-Disposition": f'inline; filename="{filename}"'},
+    async def _generate() -> bytes:
+        return generate_attendance_certificate_pdf(data, settings)
+
+    return await pdf_response(
+        _generate,
+        filename=filename,
+        error_context=f"attestation fréquentation élève {student_id}",
     )

--- a/app/routers/timetable.py
+++ b/app/routers/timetable.py
@@ -5,6 +5,7 @@ from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.dependencies import TokenData, get_current_user, get_tenant_db, require_permission
+from app.routers._pdf_helpers import pdf_response
 from app.schemas.timetable import (
     GenerateTimetableRequest,
     GenerateTimetableResponse,
@@ -101,13 +102,11 @@ async def export_timetable_pdf(
     db: AsyncSession = Depends(get_tenant_db),
 ) -> Response:
     """Export emploi du temps en PDF (A4 paysage)."""
-    pdf_bytes = await timetable_service.export_timetable_pdf(db, class_id)
-    return Response(
-        content=pdf_bytes,
-        media_type="application/pdf",
-        headers={
-            "Content-Disposition": f"attachment; filename=emploi-du-temps-classe-{class_id}.pdf"
-        },
+    return await pdf_response(
+        lambda: timetable_service.export_timetable_pdf(db, class_id),
+        filename=f"emploi-du-temps-classe-{class_id}.pdf",
+        error_context=f"emploi du temps classe {class_id}",
+        disposition="attachment",
     )
 
 

--- a/app/schemas/admin.py
+++ b/app/schemas/admin.py
@@ -104,6 +104,19 @@ class StudentFiltersResponse(BaseModel):
     current_academic_year_id: int | None = None
 
 
+class StudentTrimesterGrades(BaseModel):
+    trimester: int
+    general: float | None = None
+    best: float | None = None
+    worst: float | None = None
+
+
+class StudentTrimesterAbsences(BaseModel):
+    trimester: int
+    justifiees: int = 0
+    non_justifiees: int = 0
+
+
 class StudentFullResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -145,6 +158,11 @@ class StudentFullResponse(BaseModel):
     fees_paid: float = 0.0
     fees_remaining: float = 0.0
     fees_rate: float = 0.0
+
+    # Trimester breakdowns (current academic year)
+    # Toujours 3 entrées (T1/T2/T3) padded avec null/0 si pas de données.
+    trimester_grades: list[StudentTrimesterGrades] = []
+    trimester_absences: list[StudentTrimesterAbsences] = []
 
 
 class StudentListResponse(BaseModel):

--- a/app/schemas/reports.py
+++ b/app/schemas/reports.py
@@ -41,6 +41,8 @@ class BulletinResponse(BaseModel):
     id: int
     student_id: int
     student_name: str
+    student_photo_url: str | None = None
+    student_enrollment_number: str | None = None
     class_id: int
     class_name: str
     academic_year_id: int

--- a/app/services/admin_service.py
+++ b/app/services/admin_service.py
@@ -1,7 +1,8 @@
 """Service admin — logique métier CRUD pour les entités de base."""
 
+import asyncio
 import logging
-from typing import Any
+from typing import Any, Final
 
 from fastapi import HTTPException
 from sqlalchemy import case, func, select, text, update
@@ -337,7 +338,112 @@ async def get_student_full(db: AsyncSession, student_id: int) -> dict:
     result["fees_remaining"] = expected - paid
     result["fees_rate"] = round(paid / expected * 100, 1) if expected > 0 else 0.0
 
+    # Trimester breakdowns — alimentent les charts du tab Parcours.
+    current_ay_id = enrollment.academic_year_id if enrollment else None
+    grades, absences = await asyncio.gather(
+        _student_trimester_grades(db, student_id=student_id, academic_year_id=current_ay_id),
+        _student_trimester_absences(db, student_id=student_id, academic_year_id=current_ay_id),
+    )
+    result["trimester_grades"] = grades
+    result["trimester_absences"] = absences
+
     return result
+
+
+TRIMESTERS: Final[tuple[int, int, int]] = (1, 2, 3)
+
+
+async def _student_trimester_grades(
+    db: AsyncSession, *, student_id: int, academic_year_id: int | None
+) -> list[dict]:
+    """Moyenne générale + min/max matière par trimestre pour l'année courante."""
+    if academic_year_id is None:
+        return [{"trimester": t, "general": None, "best": None, "worst": None} for t in TRIMESTERS]
+
+    from app.models.grade import Bulletin, SubjectAverage
+
+    bulletin_stmt = select(Bulletin.trimester, Bulletin.average).where(
+        Bulletin.student_id == student_id, Bulletin.academic_year_id == academic_year_id
+    )
+    sa_stmt = (
+        select(
+            SubjectAverage.trimester,
+            func.min(SubjectAverage.average).label("worst"),
+            func.max(SubjectAverage.average).label("best"),
+        )
+        .join(Bulletin, SubjectAverage.bulletin_id == Bulletin.id)
+        .where(
+            SubjectAverage.student_id == student_id,
+            Bulletin.academic_year_id == academic_year_id,
+        )
+        .group_by(SubjectAverage.trimester)
+    )
+    bulletin_res, sa_res = await asyncio.gather(db.execute(bulletin_stmt), db.execute(sa_stmt))
+
+    by_trim: dict[int, dict[str, float | None]] = {
+        t: {"general": None, "best": None, "worst": None} for t in TRIMESTERS
+    }
+    for row in bulletin_res.all():
+        if row.trimester in by_trim:
+            by_trim[row.trimester]["general"] = (
+                float(row.average) if row.average is not None else None
+            )
+    for row in sa_res.all():
+        if row.trimester in by_trim:
+            by_trim[row.trimester]["best"] = float(row.best) if row.best is not None else None
+            by_trim[row.trimester]["worst"] = float(row.worst) if row.worst is not None else None
+
+    return [{"trimester": t, **by_trim[t]} for t in TRIMESTERS]
+
+
+async def _student_trimester_absences(
+    db: AsyncSession, *, student_id: int, academic_year_id: int | None
+) -> list[dict]:
+    """Absences justifiées (EXCUSED) vs non justifiées (ABSENT) par trimestre.
+
+    LATE n'est pas compté ici (ni absence ni justifié).
+    """
+    if academic_year_id is None:
+        return [{"trimester": t, "justifiees": 0, "non_justifiees": 0} for t in TRIMESTERS]
+
+    from app.models.academic import Trimester as TrimesterModel
+    from app.models.attendance import AttendanceContext, AttendanceRecord, AttendanceStatus
+
+    abs_stmt = (
+        select(
+            TrimesterModel.order_no.label("trimester"),
+            func.sum(
+                case((AttendanceRecord.status == AttendanceStatus.EXCUSED, 1), else_=0)
+            ).label("justifiees"),
+            func.sum(
+                case((AttendanceRecord.status == AttendanceStatus.ABSENT, 1), else_=0)
+            ).label("non_justifiees"),
+        )
+        .select_from(AttendanceRecord)
+        .join(AttendanceContext, AttendanceRecord.context_id == AttendanceContext.id)
+        .join(
+            TrimesterModel,
+            (TrimesterModel.academic_year_id == AttendanceContext.academic_year_id)
+            & (AttendanceContext.date >= TrimesterModel.start_date)
+            & (AttendanceContext.date <= TrimesterModel.end_date),
+        )
+        .where(
+            AttendanceRecord.student_id == student_id,
+            AttendanceContext.academic_year_id == academic_year_id,
+            AttendanceRecord.status.in_([AttendanceStatus.ABSENT, AttendanceStatus.EXCUSED]),
+        )
+        .group_by(TrimesterModel.order_no)
+    )
+
+    by_trim: dict[int, dict[str, int]] = {
+        t: {"justifiees": 0, "non_justifiees": 0} for t in TRIMESTERS
+    }
+    for row in (await db.execute(abs_stmt)).all():
+        if row.trimester in by_trim:
+            by_trim[row.trimester]["justifiees"] = int(row.justifiees or 0)
+            by_trim[row.trimester]["non_justifiees"] = int(row.non_justifiees or 0)
+
+    return [{"trimester": t, **by_trim[t]} for t in TRIMESTERS]
 
 
 async def create_student_user_account(

--- a/app/services/reports_service.py
+++ b/app/services/reports_service.py
@@ -81,6 +81,10 @@ def _bulletin_to_response(bulletin: Bulletin, total_students: int) -> BulletinRe
         id=bulletin.id,
         student_id=bulletin.student_id,
         student_name=_student_full_name(bulletin.student) if bulletin.student else "",
+        student_photo_url=bulletin.student.photo_url if bulletin.student else None,
+        student_enrollment_number=(
+            bulletin.student.enrollment_number if bulletin.student else None
+        ),
         class_id=bulletin.class_id,
         class_name=bulletin.class_.name if bulletin.class_ else "",
         academic_year_id=bulletin.academic_year_id,


### PR DESCRIPTION
## Summary

- BE `StudentFullResponse` enriched with `trimester_grades` + `trimester_absences` (alimente le tab Parcours côté FE)
- BE `BulletinResponse` enriched with `student_name`, `student_photo_url`, `student_enrollment_number` (alimente le redesign premium /admin/reports)
- New `app/routers/_pdf_helpers.py::pdf_response` wraps all 10 PDF endpoints in try/except so OSError becomes a CORS-safe JSON 500 with actionable `detail` instead of a silent 500 plain-text
- 2 new project rules : `no-pep563-with-204.md` (le piège FastAPI 0.115.6) + `pdf-response-wrap.md` (pattern PDF obligatoire)

## Test plan

- [x] `curl /reports/bulletins/3/pdf` → 500 JSON + `Access-Control-Allow-Origin` + detail exploitable
- [x] `curl /timetable/export-pdf?class_id=2` → 500 JSON + CORS + detail
- [x] `curl /admin/students/1/full` → `trimester_grades[0] = {trimester:1, general:13.59, best:14.17, worst:13}`
- [x] `curl /reports/bulletins?class_id=2&trimester=1` → `student_name`, `student_photo_url`, `student_enrollment_number` présents