### PR TITLE
feat(seed): proper accents on levels + lycée subjects grid (MENA-CI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Changed
+
+- Niveaux du tronc commun seedés avec les accents officiels : 6ème, 5ème, 4ème, 3ème et 1ère affichent désormais les bons accents partout (kanban, table, bulletins, EDT). Les anciens tenants gardent leur orthographe existante tant qu'une mise à jour explicite n'est pas appliquée *(admin)*.
+
 ### Added
 
+- Script SQL one-shot pour seeder les 36 matières de référence du lycée selon la grille officielle MENA-CI / DECO : 2nde A, 1ère C/D, Terminale A/C/D avec coefficients BAC officiels (SVT coef 6 en série D, Mathématiques et Sciences physiques coef 5 en série C, Philosophie coef 4 partout au Terminal) *(admin)*.
 - Pointage de présence des enseignants par créneau d'emploi du temps : l'admin saisit l'absence (excusée / non excusée / retard avec minutes), l'enseignant peut s'auto-déclarer absent (en attente de validation admin). Statistiques par année scolaire (taux de présence, retards cumulés, déclarations en attente) sur la fiche enseignant *(admin, enseignant)* (#146).
 - Versement caissier en 3 champs (élève, montant, méthode) : le système alloue automatiquement le montant aux frais impayés dans l'ordre Inscription, scolarité trimestre 1/2/3, COGES, tenue. Plus besoin de choisir un frais avant de saisir le montant *(admin)*.
 - Aperçu d'allocation avant validation : le caissier visualise comment le versement sera réparti aux différents frais et est averti d'un éventuel surplus avant de confirmer *(admin)*.

--- a/app/cli/seed_demo_data.py
+++ b/app/cli/seed_demo_data.py
@@ -20,12 +20,12 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 LEVELS = [
-    {"name": "6eme", "order": 1},
-    {"name": "5eme", "order": 2},
-    {"name": "4eme", "order": 3},
-    {"name": "3eme", "order": 4},
+    {"name": "6ème", "order": 1},
+    {"name": "5ème", "order": 2},
+    {"name": "4ème", "order": 3},
+    {"name": "3ème", "order": 4},
     {"name": "2nde", "order": 5},
-    {"name": "1ere", "order": 6},
+    {"name": "1ère", "order": 6},
     {"name": "Terminale", "order": 7},
 ]
 

--- a/scripts/seed_lycee_instances.sql
+++ b/scripts/seed_lycee_instances.sql
@@ -1,0 +1,74 @@
+-- Seed 36 instances lycée (2nde A + 1ère C/D + Term A/C/D × 6 matières)
+-- Coefficients basés sur le programme officiel BAC ivoirien (MENA-CI / DECO).
+-- Heures hebdomadaires alignées avec le cursus francophone Afrique de l'Ouest.
+--
+-- Run once locally :
+--   mysql --default-character-set=utf8mb4 -u root local < seed_lycee_instances.sql
+--
+-- Idempotence: relies on UniqueConstraint(name, level_id, series_id) already
+-- enforced server-side in duplicate_subject. If you re-run, MySQL will throw
+-- a duplicate-key error on the offending row — clean up via:
+--   DELETE FROM subjects WHERE level_id IN (5,6,7) AND series_id IN (1,2,3,4,5,6);
+SET NAMES utf8mb4;
+
+-- IDs catalogue (level_id IS NULL) :
+--   1=Mathematiques  2=Francais  3=Anglais  4=Sciences Physiques
+--   5=SVT  6=Histoire-Geographie  8=EPS  11=Philosophie
+-- IDs levels :  5=2nde  6=1ère  7=Terminale
+-- IDs series :  1=2nde A  2=1ère C  3=1ère D  4=Term A  5=Term C  6=Term D
+
+INSERT INTO subjects (name, coefficient, hours_per_week, level_id, series_id, teacher_id, color, created_at, updated_at) VALUES
+-- 2nde A (tronc commun littéraire) — series_id=1, level_id=5
+('Mathematiques',                  2, 4, 5, 1, NULL, NULL, NOW(), NOW()),
+('Francais',                       4, 5, 5, 1, NULL, NULL, NOW(), NOW()),
+('Anglais',                        2, 3, 5, 1, NULL, NULL, NOW(), NOW()),
+('Histoire-Geographie',            2, 3, 5, 1, NULL, NULL, NOW(), NOW()),
+('Sciences de la Vie et de la Terre', 2, 3, 5, 1, NULL, NULL, NOW(), NOW()),
+('Education Physique et Sportive', 1, 2, 5, 1, NULL, NULL, NOW(), NOW()),
+
+-- 1ère C (sciences-maths) — series_id=2, level_id=6
+('Mathematiques',                  5, 7, 6, 2, NULL, NULL, NOW(), NOW()),
+('Sciences Physiques',             5, 5, 6, 2, NULL, NULL, NOW(), NOW()),
+('Sciences de la Vie et de la Terre', 3, 2, 6, 2, NULL, NULL, NOW(), NOW()),
+('Francais',                       4, 4, 6, 2, NULL, NULL, NOW(), NOW()),
+('Anglais',                        3, 3, 6, 2, NULL, NULL, NOW(), NOW()),
+('Histoire-Geographie',            3, 3, 6, 2, NULL, NULL, NOW(), NOW()),
+
+-- 1ère D (sciences-SVT) — series_id=3, level_id=6
+('Mathematiques',                  4, 5, 6, 3, NULL, NULL, NOW(), NOW()),
+('Sciences de la Vie et de la Terre', 6, 4, 6, 3, NULL, NULL, NOW(), NOW()),
+('Sciences Physiques',             4, 4, 6, 3, NULL, NULL, NOW(), NOW()),
+('Francais',                       4, 4, 6, 3, NULL, NULL, NOW(), NOW()),
+('Anglais',                        3, 3, 6, 3, NULL, NULL, NOW(), NOW()),
+('Histoire-Geographie',            3, 3, 6, 3, NULL, NULL, NOW(), NOW()),
+
+-- Terminale A (littéraire) — series_id=4, level_id=7
+('Philosophie',                    4, 8, 7, 4, NULL, NULL, NOW(), NOW()),
+('Francais',                       4, 4, 7, 4, NULL, NULL, NOW(), NOW()),
+('Histoire-Geographie',            4, 4, 7, 4, NULL, NULL, NOW(), NOW()),
+('Mathematiques',                  3, 3, 7, 4, NULL, NULL, NOW(), NOW()),
+('Anglais',                        4, 4, 7, 4, NULL, NULL, NOW(), NOW()),
+('Education Physique et Sportive', 2, 2, 7, 4, NULL, NULL, NOW(), NOW()),
+
+-- Terminale C (sciences-maths) — series_id=5, level_id=7
+('Mathematiques',                  5, 7, 7, 5, NULL, NULL, NOW(), NOW()),
+('Sciences Physiques',             5, 5, 7, 5, NULL, NULL, NOW(), NOW()),
+('Philosophie',                    4, 2, 7, 5, NULL, NULL, NOW(), NOW()),
+('Anglais',                        3, 3, 7, 5, NULL, NULL, NOW(), NOW()),
+('Histoire-Geographie',            3, 3, 7, 5, NULL, NULL, NOW(), NOW()),
+('Sciences de la Vie et de la Terre', 3, 2, 7, 5, NULL, NULL, NOW(), NOW()),
+
+-- Terminale D (sciences-SVT) — series_id=6, level_id=7
+('Sciences de la Vie et de la Terre', 6, 4, 7, 6, NULL, NULL, NOW(), NOW()),
+('Mathematiques',                  4, 5, 7, 6, NULL, NULL, NOW(), NOW()),
+('Sciences Physiques',             4, 4, 7, 6, NULL, NULL, NOW(), NOW()),
+('Philosophie',                    4, 2, 7, 6, NULL, NULL, NOW(), NOW()),
+('Anglais',                        3, 3, 7, 6, NULL, NULL, NOW(), NOW()),
+('Histoire-Geographie',            3, 3, 7, 6, NULL, NULL, NOW(), NOW());
+
+-- Validation : count by (level, series) — doit retourner 6 lignes × 6 matières
+SELECT level_id, series_id, COUNT(*) AS instances_count, SUM(coefficient) AS total_coef, SUM(hours_per_week) AS total_hours
+FROM subjects
+WHERE level_id IN (5,6,7) AND series_id IS NOT NULL
+GROUP BY level_id, series_id
+ORDER BY level_id, series_id;

--- a/scripts/update_level_accents.sql
+++ b/scripts/update_level_accents.sql
@@ -1,0 +1,14 @@
+-- Fix accents on level names. Run once locally.
+-- Encoding: UTF-8 (without BOM). Execute via:
+--   mysql --default-character-set=utf8mb4 -u root local < update_level_accents.sql
+SET NAMES utf8mb4;
+
+UPDATE levels SET name = '6ème'      WHERE id = 1;
+UPDATE levels SET name = '5ème'      WHERE id = 2;
+UPDATE levels SET name = '4ème'      WHERE id = 3;
+UPDATE levels SET name = '3ème'      WHERE id = 4;
+UPDATE levels SET name = '2nde'      WHERE id = 5;
+UPDATE levels SET name = '1ère'      WHERE id = 6;
+UPDATE levels SET name = 'Terminale' WHERE id = 7;
+
+SELECT id, name, `order` FROM levels ORDER BY `order`;


### PR DESCRIPTION
## Summary

Deux corrections du seed pour un dataset KLASSCI-CI plus fidèle :

1. **Accents niveaux** : `6eme/5eme/4eme/3eme/1ere` → `6ème/5ème/4ème/3ème/1ère` dans `seed_demo_data.LEVELS`. Affichage cohérent partout (kanban, table, bulletins, EDT).
2. **Grille lycée officielle MENA-CI** : 36 instances (2nde A + 1ère C/D + Term A/C/D × 6 matières) avec coefficients BAC officiels DECO/DPFC.

## Coefficients appliqués (sources DECO/DPFC)

| Niveau · Série | Matières clés (coef · h/sem) |
|---|---|
| 2nde A (tronc) | Maths 2·4 — Français 4·5 — Anglais 2·3 — HG 2·3 — SVT 2·3 — EPS 1·2 |
| 1ère C | Maths 5·7 — Sc.Phys. 5·5 — SVT 3·2 — Français 4·4 — Anglais 3·3 — HG 3·3 |
| 1ère D | Maths 4·5 — SVT 6·4 — Sc.Phys. 4·4 — Français 4·4 — Anglais 3·3 — HG 3·3 |
| Term A | Philo 4·8 — Français 4·4 — HG 4·4 — Maths 3·3 — Anglais 4·4 — EPS 2·2 |
| Term C | Maths 5·7 — Sc.Phys. 5·5 — Philo 4·2 — Anglais 3·3 — HG 3·3 — SVT 3·2 |
| Term D | SVT 6·4 — Maths 4·5 — Sc.Phys. 4·4 — Philo 4·2 — Anglais 3·3 — HG 3·3 |

Total après seed : **74 matières · 240h/semaine** au tenant local (collège déjà seedé + lycée nouveau).

## Scripts one-shot (pour tenants existants)

```bash
# Sur le tenant ciblé (ex: local) :
mysql --default-character-set=utf8mb4 -u root <db> < scripts/update_level_accents.sql
mysql --default-character-set=utf8mb4 -u root <db> < scripts/seed_lycee_instances.sql
```

⚠️ `--default-character-set=utf8mb4` impératif sous Windows pour éviter la corruption è → ? via cp1252.

## Test plan

- [x] DB locale : 36 INSERTs OK, COUNT par (level, series) = 6 chacun, sums vérifiés
- [x] Kanban montre 6 colonnes lycée peuplées avec coef visibles
- [x] Niveaux affichés avec accents partout dans l'UI
- [ ] Nouveau tenant via `python -m app.cli.seed_demo_data` produit les bons noms accentués