### PR TITLE
fix(seed): proper accents on subject names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Noms des matières seedés avec les accents officiels : Mathématiques, Français, Histoire-Géographie, Éducation Civique et Morale, Éducation Physique et Sportive. Affichage cohérent partout (bulletins, EDT, kanban, liste des notes). Un script SQL one-shot met à jour les tenants existants *(admin, enseignant, parent)*.
 - Niveaux du tronc commun seedés avec les accents officiels : 6ème, 5ème, 4ème, 3ème et 1ère affichent désormais les bons accents partout (kanban, table, bulletins, EDT). Les anciens tenants gardent leur orthographe existante tant qu'une mise à jour explicite n'est pas appliquée *(admin)*.
 
 ### Added

--- a/app/cli/seed_demo_data.py
+++ b/app/cli/seed_demo_data.py
@@ -40,14 +40,14 @@ SERIES = [
 ]
 
 SUBJECTS = [
-    {"name": "Mathematiques", "coefficient": 4, "hours_per_week": 5},
-    {"name": "Francais", "coefficient": 4, "hours_per_week": 5},
+    {"name": "Mathématiques", "coefficient": 4, "hours_per_week": 5},
+    {"name": "Français", "coefficient": 4, "hours_per_week": 5},
     {"name": "Anglais", "coefficient": 2, "hours_per_week": 3},
     {"name": "Sciences Physiques", "coefficient": 3, "hours_per_week": 4},
     {"name": "Sciences de la Vie et de la Terre", "coefficient": 2, "hours_per_week": 3},
-    {"name": "Histoire-Geographie", "coefficient": 2, "hours_per_week": 3},
-    {"name": "Education Civique et Morale", "coefficient": 1, "hours_per_week": 1},
-    {"name": "Education Physique et Sportive", "coefficient": 1, "hours_per_week": 2},
+    {"name": "Histoire-Géographie", "coefficient": 2, "hours_per_week": 3},
+    {"name": "Éducation Civique et Morale", "coefficient": 1, "hours_per_week": 1},
+    {"name": "Éducation Physique et Sportive", "coefficient": 1, "hours_per_week": 2},
     {"name": "Dessin / Arts Plastiques", "coefficient": 1, "hours_per_week": 1},
     {"name": "Musique", "coefficient": 1, "hours_per_week": 1},
     {"name": "Philosophie", "coefficient": 3, "hours_per_week": 4},

--- a/scripts/seed_lycee_instances.sql
+++ b/scripts/seed_lycee_instances.sql
@@ -19,52 +19,52 @@ SET NAMES utf8mb4;
 
 INSERT INTO subjects (name, coefficient, hours_per_week, level_id, series_id, teacher_id, color, created_at, updated_at) VALUES
 -- 2nde A (tronc commun littéraire) — series_id=1, level_id=5
-('Mathematiques',                  2, 4, 5, 1, NULL, NULL, NOW(), NOW()),
-('Francais',                       4, 5, 5, 1, NULL, NULL, NOW(), NOW()),
+('Mathématiques',                  2, 4, 5, 1, NULL, NULL, NOW(), NOW()),
+('Français',                       4, 5, 5, 1, NULL, NULL, NOW(), NOW()),
 ('Anglais',                        2, 3, 5, 1, NULL, NULL, NOW(), NOW()),
-('Histoire-Geographie',            2, 3, 5, 1, NULL, NULL, NOW(), NOW()),
+('Histoire-Géographie',            2, 3, 5, 1, NULL, NULL, NOW(), NOW()),
 ('Sciences de la Vie et de la Terre', 2, 3, 5, 1, NULL, NULL, NOW(), NOW()),
-('Education Physique et Sportive', 1, 2, 5, 1, NULL, NULL, NOW(), NOW()),
+('Éducation Physique et Sportive', 1, 2, 5, 1, NULL, NULL, NOW(), NOW()),
 
 -- 1ère C (sciences-maths) — series_id=2, level_id=6
-('Mathematiques',                  5, 7, 6, 2, NULL, NULL, NOW(), NOW()),
+('Mathématiques',                  5, 7, 6, 2, NULL, NULL, NOW(), NOW()),
 ('Sciences Physiques',             5, 5, 6, 2, NULL, NULL, NOW(), NOW()),
 ('Sciences de la Vie et de la Terre', 3, 2, 6, 2, NULL, NULL, NOW(), NOW()),
-('Francais',                       4, 4, 6, 2, NULL, NULL, NOW(), NOW()),
+('Français',                       4, 4, 6, 2, NULL, NULL, NOW(), NOW()),
 ('Anglais',                        3, 3, 6, 2, NULL, NULL, NOW(), NOW()),
-('Histoire-Geographie',            3, 3, 6, 2, NULL, NULL, NOW(), NOW()),
+('Histoire-Géographie',            3, 3, 6, 2, NULL, NULL, NOW(), NOW()),
 
 -- 1ère D (sciences-SVT) — series_id=3, level_id=6
-('Mathematiques',                  4, 5, 6, 3, NULL, NULL, NOW(), NOW()),
+('Mathématiques',                  4, 5, 6, 3, NULL, NULL, NOW(), NOW()),
 ('Sciences de la Vie et de la Terre', 6, 4, 6, 3, NULL, NULL, NOW(), NOW()),
 ('Sciences Physiques',             4, 4, 6, 3, NULL, NULL, NOW(), NOW()),
-('Francais',                       4, 4, 6, 3, NULL, NULL, NOW(), NOW()),
+('Français',                       4, 4, 6, 3, NULL, NULL, NOW(), NOW()),
 ('Anglais',                        3, 3, 6, 3, NULL, NULL, NOW(), NOW()),
-('Histoire-Geographie',            3, 3, 6, 3, NULL, NULL, NOW(), NOW()),
+('Histoire-Géographie',            3, 3, 6, 3, NULL, NULL, NOW(), NOW()),
 
 -- Terminale A (littéraire) — series_id=4, level_id=7
 ('Philosophie',                    4, 8, 7, 4, NULL, NULL, NOW(), NOW()),
-('Francais',                       4, 4, 7, 4, NULL, NULL, NOW(), NOW()),
-('Histoire-Geographie',            4, 4, 7, 4, NULL, NULL, NOW(), NOW()),
-('Mathematiques',                  3, 3, 7, 4, NULL, NULL, NOW(), NOW()),
+('Français',                       4, 4, 7, 4, NULL, NULL, NOW(), NOW()),
+('Histoire-Géographie',            4, 4, 7, 4, NULL, NULL, NOW(), NOW()),
+('Mathématiques',                  3, 3, 7, 4, NULL, NULL, NOW(), NOW()),
 ('Anglais',                        4, 4, 7, 4, NULL, NULL, NOW(), NOW()),
-('Education Physique et Sportive', 2, 2, 7, 4, NULL, NULL, NOW(), NOW()),
+('Éducation Physique et Sportive', 2, 2, 7, 4, NULL, NULL, NOW(), NOW()),
 
 -- Terminale C (sciences-maths) — series_id=5, level_id=7
-('Mathematiques',                  5, 7, 7, 5, NULL, NULL, NOW(), NOW()),
+('Mathématiques',                  5, 7, 7, 5, NULL, NULL, NOW(), NOW()),
 ('Sciences Physiques',             5, 5, 7, 5, NULL, NULL, NOW(), NOW()),
 ('Philosophie',                    4, 2, 7, 5, NULL, NULL, NOW(), NOW()),
 ('Anglais',                        3, 3, 7, 5, NULL, NULL, NOW(), NOW()),
-('Histoire-Geographie',            3, 3, 7, 5, NULL, NULL, NOW(), NOW()),
+('Histoire-Géographie',            3, 3, 7, 5, NULL, NULL, NOW(), NOW()),
 ('Sciences de la Vie et de la Terre', 3, 2, 7, 5, NULL, NULL, NOW(), NOW()),
 
 -- Terminale D (sciences-SVT) — series_id=6, level_id=7
 ('Sciences de la Vie et de la Terre', 6, 4, 7, 6, NULL, NULL, NOW(), NOW()),
-('Mathematiques',                  4, 5, 7, 6, NULL, NULL, NOW(), NOW()),
+('Mathématiques',                  4, 5, 7, 6, NULL, NULL, NOW(), NOW()),
 ('Sciences Physiques',             4, 4, 7, 6, NULL, NULL, NOW(), NOW()),
 ('Philosophie',                    4, 2, 7, 6, NULL, NULL, NOW(), NOW()),
 ('Anglais',                        3, 3, 7, 6, NULL, NULL, NOW(), NOW()),
-('Histoire-Geographie',            3, 3, 7, 6, NULL, NULL, NOW(), NOW());
+('Histoire-Géographie',            3, 3, 7, 6, NULL, NULL, NOW(), NOW());
 
 -- Validation : count by (level, series) — doit retourner 6 lignes × 6 matières
 SELECT level_id, series_id, COUNT(*) AS instances_count, SUM(coefficient) AS total_coef, SUM(hours_per_week) AS total_hours

--- a/scripts/update_subject_accents.sql
+++ b/scripts/update_subject_accents.sql
@@ -1,0 +1,12 @@
+-- Fix accents on subject names. Run once locally.
+-- Encoding: UTF-8 (without BOM). Execute via:
+--   mysql --default-character-set=utf8mb4 -u root local < update_subject_accents.sql
+SET NAMES utf8mb4;
+
+UPDATE subjects SET name = 'Mathématiques'                  WHERE name = 'Mathematiques';
+UPDATE subjects SET name = 'Français'                       WHERE name = 'Francais';
+UPDATE subjects SET name = 'Histoire-Géographie'            WHERE name = 'Histoire-Geographie';
+UPDATE subjects SET name = 'Éducation Civique et Morale'    WHERE name = 'Education Civique et Morale';
+UPDATE subjects SET name = 'Éducation Physique et Sportive' WHERE name = 'Education Physique et Sportive';
+
+SELECT name, COUNT(*) AS n FROM subjects GROUP BY name ORDER BY name;


### PR DESCRIPTION
## Summary

Suite logique de #154 (accents niveaux) : 5 noms de matières du seed `seed_demo_data.SUBJECTS` étaient sans accent et apparaissaient verbatim dans toute l'UI (timetable, grades, bulletins) :

- `Mathematiques` → **Mathématiques**
- `Francais` → **Français**
- `Histoire-Geographie` → **Histoire-Géographie**
- `Education Civique et Morale` → **Éducation Civique et Morale**
- `Education Physique et Sportive` → **Éducation Physique et Sportive**

## Découvert via visual-check

`/admin/grades` (6ème B, T1) affichait :
- Devoir 1 - Calcul mental · **Mathematiques** (sans accent)
- Devoir 1 - Dictee · **Francais** (sans accent)
- Controle - Geometrie · **Mathematiques** (sans accent)

Marcel l'a flaggé après le fix niveaux (#154).

## Fichiers

- `app/cli/seed_demo_data.py` : 5 entrées SUBJECTS corrigées
- `scripts/update_subject_accents.sql` (nouveau) : one-shot UPDATE pour tenants existants
- `scripts/seed_lycee_instances.sql` : mis à jour aussi pour cohérence si le script est re-run plus tard (sinon il créerait des doublons `Mathematiques` + `Mathématiques`)

## DB safety

Pas de UNIQUE constraint sur `subjects.name` (vérifié `SHOW CREATE TABLE subjects`). L'UPDATE rename les 14 catalogue + toutes les instances en une transaction. Les FKs (`grades.evaluation_id → evaluations.subject_id → subjects.id`) sont safe : on touche au `name` pas à l'`id`.

## Test plan

- [x] DB locale : 14 noms après UPDATE, tous accentués
- [x] `GET /admin/subjects?level_id=1` retourne « Mathématiques », « Français », etc.
- [ ] Nouveau tenant via `python -m app.cli.seed_demo_data` produit les noms accentués
- [ ] Bulletin PDF affiche correctement « Mathématiques » dans le tableau de moyennes