### PR TITLE
feat(grades): separate grades:edit permission from grades:write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Added
+
+- Permission `grades:edit` distincte de `grades:write` : la première autorise à saisir une note pour la première fois, la seconde à modifier une note déjà enregistrée. Une école peut désormais autoriser un enseignant à saisir sans pouvoir réviser, ou inversement. Attribuée par défaut à admin, directeur et enseignant ; révocable depuis Rôles & Permissions *(admin)*.
+
 ### Changed
 
 - Noms des matières seedés avec les accents officiels : Mathématiques, Français, Histoire-Géographie, Éducation Civique et Morale, Éducation Physique et Sportive. Affichage cohérent partout (bulletins, EDT, kanban, liste des notes). Un script SQL one-shot met à jour les tenants existants *(admin, enseignant, parent)*.

--- a/app/services/grades_service.py
+++ b/app/services/grades_service.py
@@ -151,6 +151,31 @@ async def batch_update_grades(
 
         raise BusinessValidationError(f"Student IDs not enrolled in this evaluation: {invalid_ids}")
 
+    # Permission fine-grained : grades:write couvre la saisie initiale (slot
+    # vide ou jamais noté), grades:edit couvre la modification d'une note
+    # déjà enregistrée. L'endpoint exige déjà grades:write comme garde
+    # grossière ; ici on vérifie en plus grades:edit pour toute entrée qui
+    # change une valeur existante. Workflow strict possible : une école peut
+    # révoquer grades:edit aux teachers pour empêcher la révision sans aval.
+    existing_by_student: dict[int, Any] = {
+        g.student_id: g.value for g in (evaluation.grades or [])
+    }
+    has_real_edits = any(
+        existing_by_student.get(e["student_id"]) is not None
+        and e["value"] is not None
+        and float(e["value"]) != float(existing_by_student[e["student_id"]])
+        for e in entries
+    )
+    if has_real_edits:
+        from app.core.exceptions import PermissionDeniedError
+        from app.repositories.permission_repository import check_user_permission
+
+        can_edit = await check_user_permission(db, current_user_id, "grades:edit")
+        if not can_edit:
+            raise PermissionDeniedError(
+                "grades:edit requise pour modifier une note déjà enregistrée"
+            )
+
     grades = await repo.batch_update_grades(
         db, eval_id, entries, entered_by_user_id=current_user_id
     )

--- a/app/services/tenants/permissions.py
+++ b/app/services/tenants/permissions.py
@@ -60,6 +60,7 @@ ALL_PERMISSIONS: list[dict[str, str]] = [
     {"slug": "enrollments:promote", "name": "Mass-promote enrollments year over year"},
     {"slug": "grades:read", "name": "View grades"},
     {"slug": "grades:write", "name": "Write grades"},
+    {"slug": "grades:edit", "name": "Modify already-recorded grades"},
     {"slug": "bulletins:generate", "name": "Generate bulletins"},
     # Timetable (3)
     {"slug": "timetable:read", "name": "View timetable"},
@@ -130,6 +131,7 @@ ROLE_DEFINITIONS: dict[str, dict[str, Any]] = {
         "permissions": [
             "grades:read",
             "grades:write",
+            "grades:edit",
             "bulletins:generate",
             "attendance:read",
             "attendance:create",

--- a/scripts/add_grades_edit_permission.sql
+++ b/scripts/add_grades_edit_permission.sql
@@ -1,0 +1,22 @@
+-- Ajoute la permission grades:edit (modify existing notes) sur un tenant
+-- existant et l'attribue par défaut aux rôles admin, director, teacher.
+-- Idempotent grâce à INSERT IGNORE.
+-- Run once locally :
+--   mysql --default-character-set=utf8mb4 -u root local < add_grades_edit_permission.sql
+SET NAMES utf8mb4;
+
+INSERT IGNORE INTO permissions (slug, name)
+VALUES ('grades:edit', 'Modify already-recorded grades');
+
+INSERT IGNORE INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON p.slug = 'grades:edit'
+WHERE r.name IN ('admin', 'director', 'teacher');
+
+SELECT r.name AS role, p.slug AS perm
+FROM role_permissions rp
+JOIN roles r ON r.id = rp.role_id
+JOIN permissions p ON p.id = rp.permission_id
+WHERE p.slug LIKE 'grades:%'
+ORDER BY r.name, p.slug;


### PR DESCRIPTION
## Summary

Distinguer la **saisie initiale** d'une note (`grades:write`) de la **modification d'une note déjà enregistrée** (`grades:edit`). Demandé par Marcel pour qu'une école puisse autoriser un teacher à saisir sans l'autoriser à réviser (workflow DREN strict).

## Architecture

| Permission | Couvre | Endpoint check |
|---|---|---|
| `grades:write` | Saisir une note (slot vide / jamais noté) | Endpoint `require_permission` grossier |
| `grades:edit` | Modifier une note dont la valeur n'est plus null | Check contextuel dans le service |

L'endpoint `PATCH /grades/{eval_id}` exige toujours `grades:write` comme garde grossière. Le service `batch_update_grades` détecte ensuite quelles entrées changent une valeur déjà non-null et exige `grades:edit` dans ce cas.

## Default attribution

| Rôle | grades:read | grades:write | grades:edit |
|---|---|---|---|
| admin | ✓ | ✓ | ✓ |
| director | ✓ | ✓ | ✓ |
| teacher | ✓ | ✓ | ✓ *(permissif, révocable)* |
| staff | — | — | — |
| accountant | — | — | — |
| student | — | — | — |
| parent | — | — | — |

L'admin peut révoquer `grades:edit` au rôle teacher via `/admin/roles` pour passer en workflow strict.

## Fichiers

- `app/services/tenants/permissions.py` : ajout de la permission + attribution au rôle teacher
- `app/services/grades_service.py::batch_update_grades` : check contextuel via `check_user_permission(db, user_id, "grades:edit")`
- `scripts/add_grades_edit_permission.sql` : one-shot pour upgrader les tenants existants

## Test plan

- [x] DB locale : `INSERT IGNORE` ajoute la perm + 3 attributions (admin/director/teacher)
- [x] `SELECT … WHERE p.slug LIKE 'grades:%'` confirme 9 rows (3 rôles × 3 perms)
- [ ] Saisir une note (valeur null → 12) avec teacher → OK
- [ ] Modifier une note (12 → 14) avec teacher → OK si grades:edit, 403 sinon
- [ ] Modifier une note (12 → 12) → pas considéré comme edit (no-op détection)
- [ ] Nouveau tenant via `provision_tenant` reçoit la perm dès l'init