### PR TITLE
fix(admin): use EmailStr in UserAccountCreate/Update for login consistency

### DIFF
--- a/app/schemas/admin.py
+++ b/app/schemas/admin.py
@@ -2,7 +2,7 @@
 
 from datetime import date, datetime
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, EmailStr, field_validator
 
 # ---------------------------------------------------------------------------
 # Student
@@ -696,20 +696,23 @@ class SchoolSettingsResponse(BaseModel):
 
 
 class UserAccountCreate(BaseModel):
-    email: str
+    """Create a user account for an existing profile (student/parent/teacher/staff).
+
+    Uses Pydantic ``EmailStr`` so validation is consistent with ``/auth/login``
+    (both rely on ``email-validator`` and reject special-use TLDs like
+    ``.local`` or ``.test``). Previously this used plain ``str`` and accepted
+    e-mails that could never log in — caught during the e2e regression on
+    2026-05-20 when ``foo@bar.local`` was accepted at creation but rejected at
+    login with HTTP 422.
+    """
+
+    email: EmailStr
     password: str
 
 
 class UserAccountUpdate(BaseModel):
-    email: str | None = None
+    email: EmailStr | None = None
     password: str | None = None
-
-    @field_validator("email")
-    @classmethod
-    def validate_email(cls, v: str | None) -> str | None:
-        if v is not None and "@" not in v:
-            raise ValueError("Email invalide")
-        return v
 
     @field_validator("password")
     @classmethod


### PR DESCRIPTION
Closes #159

## Summary

`UserAccountCreate` and `UserAccountUpdate` used `email: str` instead of `EmailStr`, allowing special-use TLDs (`.local`, `.test`) that `/auth/login` then rejected with HTTP 422. Result: an admin could create a student account that immediately couldn't log in.

## Fix

- `email: str` → `email: EmailStr` in both schemas
- Drop the now-redundant `field_validator('email')` (EmailStr covers it)
- Docstring on `UserAccountCreate` documenting why and the 2026-05-20 incident

## Test plan

- [x] Local BE restart + `POST /admin/students/{id}/account` with `foo@bar.local` → returns HTTP 422 (consistent with `/auth/login`)
- [x] Same payload with `foo@bar.com` → still works (HTTP 200) + subsequent login succeeds
- [x] No call sites broken (only schema-level change)

## skip-changelog rationale

Pure bug fix on internal validation drift, no user-visible behaviour change for the happy path. The two students that were affected (Bertrand, Fatou) were back-filled with `@klassci.com` emails in DB during the regression session.