### PR TITLE
fix(portals): resolve 500 errors on student profile, parent timetable, academic-years current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Profil élève (`/student/profile`) accessible sans erreur serveur : Aminata, Bertrand et Fatou voient désormais leur fiche au lieu d'une page blanche *(élève)*.
+- Emploi du temps de l'enfant côté parent (`/parent/children/{id}/timetable`) charge sans erreur serveur : Mariam voit l'EDT d'Aminata au lieu d'une page blanche *(parent)*.
+- Année scolaire courante (`/admin/academic-years/current`) accessible sans erreur de validation : le dashboard admin affiche désormais l'année active sans bug *(admin)*.
+
 ### Added
 
 - Permission `grades:edit` distincte de `grades:write` : la première autorise à saisir une note pour la première fois, la seconde à modifier une note déjà enregistrée. Une école peut désormais autoriser un enseignant à saisir sans pouvoir réviser, ou inversement. Attribuée par défaut à admin, directeur et enseignant ; révocable depuis Rôles & Permissions *(admin)*.

--- a/app/repositories/parent_portal_repository.py
+++ b/app/repositories/parent_portal_repository.py
@@ -74,6 +74,8 @@ async def get_student_active_enrollment(db: AsyncSession, student_id: int) -> En
             Enrollment.status.not_in([EnrollmentStatus.ANNULE, EnrollmentStatus.REJETE]),
         )
         .options(
+            selectinload(Enrollment.class_),
+            selectinload(Enrollment.academic_year),
             selectinload(Enrollment.enrollment_fees)
             .selectinload(EnrollmentFee.fee_variant)
             .selectinload(FeeVariant.category),

--- a/app/repositories/student_portal_repository.py
+++ b/app/repositories/student_portal_repository.py
@@ -12,8 +12,12 @@ from app.models.user import Student
 
 
 async def get_student_by_user_id(db: AsyncSession, user_id: int) -> Student | None:
-    """Retourne le profil eleve lie a un user_id."""
-    stmt = select(Student).where(Student.user_id == user_id)
+    """Retourne le profil eleve lie a un user_id, avec User selectinload pour /student/profile."""
+    stmt = (
+        select(Student)
+        .where(Student.user_id == user_id)
+        .options(selectinload(Student.user))
+    )
     result = await db.execute(stmt)
     return result.scalar_one_or_none()
 

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -716,6 +716,19 @@ async def create_academic_year(
     return await admin_service.create_academic_year(db, data, created_by=current_user.user_id)
 
 
+@router.get("/academic-years/current", response_model=AcademicYearResponse)
+async def get_current_academic_year(
+    current_user: TokenData = Depends(get_current_user),
+    db: AsyncSession = Depends(get_tenant_db),
+) -> AcademicYearResponse:
+    """Retourne l'annee academique courante (is_current=True) ou 404.
+
+    Note: cette route doit etre declaree AVANT /academic-years/{year_id}
+    sinon FastAPI parse "current" comme un int year_id et renvoie 422.
+    """
+    return await admin_service.get_current_academic_year(db)
+
+
 @router.get("/academic-years/{year_id}", response_model=AcademicYearResponse)
 async def get_academic_year(
     year_id: int,
@@ -738,15 +751,6 @@ async def update_academic_year(
     return await admin_service.update_academic_year(
         db, year_id, data, updated_by=current_user.user_id
     )
-
-
-@router.get("/academic-years/current", response_model=AcademicYearResponse)
-async def get_current_academic_year(
-    current_user: TokenData = Depends(get_current_user),
-    db: AsyncSession = Depends(get_tenant_db),
-) -> AcademicYearResponse:
-    """Retourne l'annee academique courante (is_current=True) ou 404."""
-    return await admin_service.get_current_academic_year(db)
 
 
 @router.patch(


### PR DESCRIPTION
## Summary

3 BE endpoints en 500 trouvés via E2E sweep 2026-05-21 :

- `/student/profile` 500 (MissingGreenlet) — Aminata/Bertrand/Fatou voyaient une page blanche
- `/parent/children/{id}/timetable` 500 (MissingGreenlet) — Mariam ne voyait pas l'EDT d'Aminata
- `/admin/academic-years/current` 422 (FastAPI route ordering) — admin dashboard data stale

## Cause

(1)(2) : pattern `preload-relations-after-commit.md`. Le service accède une relation post-fetch qui n'a pas été selectinload → MissingGreenlet → 500.

(3) : la route `/academic-years/current` est déclarée APRÈS `/academic-years/{year_id}`. FastAPI matche {year_id} en premier et tente de parser "current" comme int → 422.

## Fix

- `student_portal_repository.py` : ajout `selectinload(Student.user)` dans `get_student_by_user_id`
- `parent_portal_repository.py` : ajout `selectinload(Enrollment.class_)` + `selectinload(Enrollment.academic_year)` dans `get_student_active_enrollment`
- `admin.py` : déplace `/academic-years/current` AVANT `/academic-years/{year_id}` + docstring explicative

## Test plan

- [x] Login admin/aminata/bertrand/fatou/parent : 6/6 200
- [x] /student/profile : 3/3 200 (Aminata + Bertrand + Fatou)
- [x] /parent/children/1/timetable : 200 avec 7 slots EDT
- [x] /admin/academic-years/current : 200 retourne année 2025-2026
- [x] Régression : aucun autre endpoint cassé via sweep complet

Closes #161